### PR TITLE
src/trigger.py: fix --poll-period

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -9,6 +9,7 @@ import json
 import os
 import requests
 import sys
+import time
 
 import kernelci
 import kernelci.build
@@ -66,7 +67,7 @@ class cmd_run(Command):
         {
             'name': '--poll-period',
             'type': int,
-            'help': "Polling period in minutes, disabled by default",
+            'help': "Polling period in seconds, disabled by default",
             'default': 0,
         },
     ]


### PR DESCRIPTION
Fix the --poll-period help in trigger.py and add missing import time.

Fixes: 1f49cd92b848 ("src/trigger.py: add script to detect new revisions")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>