### PR TITLE
Push git commit with trigger.py

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -57,12 +57,8 @@ def _run_trigger(args, build_config, db):
     print(f"Sending revision node to API: {revision['commit']}")
     sys.stdout.flush()
     node = {
-        'name': "checkout",
-        'status': True,
-        'revision': {
-            k: revision[k] for k in [
-                'tree', 'url', 'branch', 'commit', 'describe',
-            ]},
+        'name': 'checkout',
+        'revision': revision,
     }
     resp_obj = db.submit({'node': node})[0]
     node_id = resp_obj['_id']

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -34,6 +34,11 @@ def _run_trigger(args, build_config, db):
     if args.skip_pull:
         print("Not updating repo")
     else:
+        head_commit = kernelci.build.get_branch_head(build_config)
+        node_list = get_node_by_commit_id(head_commit)
+        if node_list:
+            print(f"Node exists with the latest git commit: {head_commit}")
+            return
         print(f"Updating repo: {args.kdir}")
         sys.stdout.flush()
         kernelci.build.update_repo(build_config, args.kdir)

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -7,7 +7,6 @@
 
 import json
 import os
-import requests
 import sys
 import time
 
@@ -16,6 +15,19 @@ import kernelci.build
 import kernelci.config
 import kernelci.data
 from kernelci.cli import Args, Command, parse_opts
+import urllib
+import requests
+
+DEFAULT_URL = 'http://172.17.0.1:8001'
+
+
+def get_node_by_commit_id(commit_id):
+    """
+    Get node object by sending commit ID to 'nodes' endpoint
+    """
+    get_node_path = '?'.join(['nodes', 'revision.commit='+commit_id])
+    url = urllib.parse.urljoin(DEFAULT_URL, get_node_path)
+    return requests.get(url).json()
 
 
 def _run_trigger(args, build_config, db):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/3

src/trigger.py: add get_node_by_commit_id
src/trigger.py: get latest git commit and use it to get node
src/trigger.py: send revision node with empty describe
src/trigger.py: define revision dict and remove unnecessary code

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>