### PR TITLE
src/trigger.py: drop --output and --kdir

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -1,8 +1,5 @@
 [trigger]
-verbose: true
-kdir: /home/kernelci/data/linux
 build_config: mainline
-output: data
 db_config: docker-host
 
 [runner]

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -49,7 +49,7 @@ def _run_trigger(args, build_config, db):
 class cmd_run(Command):
     help = "Submit a new revision to the API based on local git repo"
     args = [
-        Args.kdir, Args.build_config, Args.output, Args.db_config,
+        Args.build_config, Args.db_config,
     ]
     opt_args = [
         {


### PR DESCRIPTION
Drop the now unused `--output` and `--kdir` command line arguments since there is no local git checkout any more. Update `kernelci.conf` accordingly.