### PR TITLE
docker/Dockerfile: use kernelci-core revision from main branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,5 +16,7 @@ USER kernelci
 ENV PATH=$PATH:/home/kernelci/.local/bin
 WORKDIR /home/kernelci
 
-# Install kernelci-core from api-pipeline topic branch
-RUN pip install git+https://github.com/kernelci/kernelci-core.git@api-pipeline
+# Install kernelci-core from pinned revision:
+# kernelci/data/kernelci_api: add KernelCI_API.get_nodes_by_commit_hash
+RUN pip install git+https://github.com/kernelci/kernelci-core.git@\
+6c277bec689d060e599532873631b47192a4314f


### PR DESCRIPTION
Pick a fixed revision from the kernelci-core main branch as there is
no released version tag yet with all the changes required for
kernelci-api.  This will ensure the Docker image gets rebuilt whenever
the revision is changed in the file.

The new kernelci-core revision being picked is:

  6c277bec689d kernelci/data/kernelci_api: add KernelCI_API.get_nodes_by_commit_hash

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>