### PR TITLE
Generate test report

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -19,5 +19,8 @@ db_config: docker-host
 [kcidb]
 db_config: docker-host
 
+[test_report]
+db_config: docker-host
+
 [db:docker-host]
 api: http://172.17.0.1:8001

--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -1,0 +1,16 @@
+{# -*- mode: Python -*- -#}
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
+{{ root.revision.tree }}/{{ root.revision.branch }} {{ '(Unknown)' if root.revision.describe is none else root.revision.describe}}: {{ total_runs }} runs, {{ total_failures}} failures
+
+{{'%-15s %s %s'|format("test", "|", "result")}}
+{{'%s%s%s'|format("-"*16, "+", "-"*7)}}
+{%- for test in tests %}
+{{'%-15s %s %s'|format(test.name, "|", test.status)}}
+{%- endfor %}
+
+  Tree:     {{ root.revision.tree }}
+  Branch:   {{ root.revision.branch }}
+  Describe: {{ '(Unknown)' if root.revision.describe is none else root.revision.describe}}
+  URL:      {{ root.revision.url }}
+  SHA1:     {{ root.revision.commit }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,3 +56,13 @@ services:
       - '/home/kernelci/pipeline/kcidb.py'
       - '--settings=/home/kernelci/config/kernelci.conf'
       - 'run'
+
+  test_report:
+    <<: *base-service
+    container_name: 'test_report'
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/test_report.py'
+      - '--settings=/home/kernelci/config/kernelci.conf'
+      - 'run'

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Jeny Sadadia
+# Author: Jeny Sadadia <jeny.sadadia@gmail.com>
+
+import os
+import sys
+
+import kernelci.config
+import kernelci.data
+from kernelci.cli import Args, Command, parse_opts
+import jinja2
+
+
+class TestReport:
+
+    def __init__(self, configs, args):
+        self._db_config = configs['db_configs'][args.db_config]
+        api_token = os.getenv('API_TOKEN')
+        self._db = kernelci.data.get_db(self._db_config, api_token)
+
+    def run(self):
+        sub_id = self._db.subscribe('node')
+        self._print("Listening for test completion events")
+        self._print("Press Ctrl-C to stop.")
+
+        try:
+            while True:
+                sys.stdout.flush()
+                event = self._db.get_event(sub_id)
+
+                node = self._db.get_node_from_event(event)
+                if node['status'] is None:
+                    continue
+
+                root_node = node
+                templateEnv = jinja2.Environment(
+                            loader=jinja2.FileSystemLoader("./config/reports/")
+                        )
+                template = templateEnv.get_template("test-report.jinja2")
+                self._print(template.render(total_runs=1, total_failures=0,
+                                            root=root_node, tests=[node]))
+
+        except KeyboardInterrupt as e:
+            self._print("Stopping.")
+        finally:
+            self._db.unsubscribe(sub_id)
+
+    def _print(self, msg):
+        print(msg)
+        sys.stdout.flush()
+
+
+class cmd_run(Command):
+    help = "Generate test report"
+    args = [Args.db_config]
+
+    def __call__(self, configs, args):
+        generate_test_report = TestReport(configs, args)
+        generate_test_report.run()
+
+
+if __name__ == '__main__':
+    opts = parse_opts('test_report', globals())
+    configs = kernelci.config.load('config/pipeline.yaml')
+    status = opts.command(configs, opts)
+    sys.exit(0 if status is True else 1)


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/11

Add client and template to generate test report 
docker-compose.yaml: add 'test_report' service 
config/kernelci.conf: add configuration for 'test_report' 