### PR TITLE
docker-compose.yaml: add STORAGE_URL environment variable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       - './pipeline/tarball.py'
       - '--settings=/home/kernelci/config/kernelci.conf'
       - 'run'
+      - '--storage-url=${STORAGE_URL:-http://172.17.0.1:8002/}'
 
   trigger:
     <<: *base-service


### PR DESCRIPTION
Add STORAGE_URL environment variable to be able to configure the
--storage-url parameter used by the tarball.py script.  This is to
match the API configuration which might be serving files with an
alternative host or port number.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>