### PR TITLE
Reflect Node.status field schema in client scripts

### DIFF
--- a/config/scripts/base-python.jinja2
+++ b/config/scripts/base-python.jinja2
@@ -60,7 +60,7 @@ if __name__ == '__main__':
         db = _get_db()
         if db:
             node = db.get_node(NODE_ID)
-            node['status'] = res
+            node['status'] = "pass" if res else "fail"
             db.submit({'node': node})
 
     sys.exit(0 if res is True else 1)

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -24,9 +24,9 @@ class cmd_run(Command):
         log_fmt = "{time:26s}  {commit:12s}  {status:8s}  {name}"
 
         status_map = {
-            None: "Pending",
-            True: "Pass",
-            False: "Fail",
+            "pending": "Pending",
+            "pass": "Pass",
+            "fail": "Fail",
         }
 
         db_config = configs['db_configs'][args.db_config]

--- a/src/runner.py
+++ b/src/runner.py
@@ -96,7 +96,7 @@ class Runner:
                 if checkout_node['name'] != 'checkout':
                     continue
 
-                if checkout_node['status'] is not True:
+                if checkout_node['status'] != "pass":
                     continue
 
                 self._info("Tarball: {}".format(

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -55,7 +55,7 @@ class cmd_run(Command):
             while True:
                 event = db.get_event(sub_id)
                 node = db.get_node_from_event(event)
-                if node['name'] != 'checkout' or node['status'] is not True:
+                if node['name'] != 'checkout' or node['status'] != 'pass':
                     continue
 
                 print(f"Submitting node to KCIDB: {node['_id']}")

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -115,7 +115,7 @@ scp \
                 if node['name'] != 'checkout':
                     continue
 
-                if node['status'] is not None:
+                if node['status'] != "pending":
                     continue
 
                 build_config = self._find_build_config(node)
@@ -128,7 +128,7 @@ scp \
                     build_config.tree.name, self._kdir
                 )
                 tarball = self._push_tarball(build_config, describe)
-                self._update_node(node, describe, tarball, True)
+                self._update_node(node, describe, tarball, "pass")
         except KeyboardInterrupt as e:
             self._print("Stopping.")
         finally:

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -32,7 +32,7 @@ class TestReport:
                 event = self._db.get_event(sub_id)
 
                 node = self._db.get_node_from_event(event)
-                if node['status'] is None:
+                if node['status'] == 'pending':
                     continue
 
                 root_node = self._db.get_root_node(node['_id'])


### PR DESCRIPTION
Node.status is now defined as Enum type, with 'pending'
as its default value. Hence, modified condition to
check status in client scripts.

Signed-off-by: Jeny Sadadia <jeny.sadadia@gmail.com>