### PR TITLE
config/pipeline.yaml: add staging.kernelci.org

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -62,6 +62,10 @@ db_configs:
     db_type: kernelci_api
     url: http://172.17.0.1:8001
 
+  staging.kernelci.org:
+    db_type: kernelci_api
+    url: https://staging.kernelci.org:9000
+
 
 labs:
 


### PR DESCRIPTION
Add an entry in pipeline.yaml for the staging.kernelci.org API
instance now that it's available.

Signed-off-by: kernelci.org bot <bot@kernelci.org>