### PR TITLE
docker/Dockerfile: move kcidb before kernelci-core

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,10 +16,10 @@ USER kernelci
 ENV PATH=$PATH:/home/kernelci/.local/bin
 WORKDIR /home/kernelci
 
+# Install kcidb
+RUN pip install git+https://github.com/kernelci/kcidb.git
+
 # Install kernelci-core from pinned revision:
 # kernelci/data/kernelci_api: add KernelCI_API.get_nodes_by_commit_hash
 RUN pip install git+https://github.com/kernelci/kernelci-core.git@\
 6c277bec689d060e599532873631b47192a4314f
-
-# Install kcidb
-RUN pip install git+https://github.com/kernelci/kcidb.git


### PR DESCRIPTION
The kernelci-core revision is likely to be changing often until things
settle down.  Move the kcidb line before it so that the kcidb layer
doesn't need to be rebuilt every time the kernelci-core revision
changes in the file.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>