### PR TITLE
docker/Dockerfile: bump kernelci-core with get_root_node()

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,4 +22,4 @@ RUN pip install git+https://github.com/kernelci/kcidb.git
 # Install kernelci-core from pinned revision:
 # kernelci/data/kernelci_api: add KernelCI_API.get_nodes_by_commit_hash
 RUN pip install git+https://github.com/kernelci/kernelci-core.git@\
-763cde9e66f10516e34953b9008e446d85d8376d
+39214cdfc1937d516dab951aa40a9e2d9847c703


### PR DESCRIPTION
Bump the version of kernelci-core to use get_root_node() with the
KernelCI API.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>