### PR TITLE
Use event filters in clients

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,4 +22,4 @@ RUN pip install git+https://github.com/kernelci/kcidb.git
 # Install kernelci-core from pinned revision:
 # kernelci/data/kernelci_api: add KernelCI_API.get_nodes_by_commit_hash
 RUN pip install git+https://github.com/kernelci/kernelci-core.git@\
-ac52362f4e58946900ed819d4c69c4a2fc9c74fb
+8b9d23b5ad7bfdea9077091e1eb52985b30c68e6

--- a/src/runner.py
+++ b/src/runner.py
@@ -81,23 +81,17 @@ class Runner:
         # ToDo: if stat != 0 then report error to API?
 
     def run(self):
-        sub_id = self._db.subscribe('node')
-        self._print("Listening for new checkout events")
+        sub_id = self._db.subscribe_node_channel(filters={
+            'op': 'updated',
+            'name': 'checkout',
+            'status': 'pass',
+        })
+        self._print("Listening for completed checkout events")
         self._print("Press Ctrl-C to stop.")
 
         try:
             while True:
-                sys.stdout.flush()
-                event = self._db.get_event(sub_id)
-                if event.data['op'] != 'updated':
-                    continue
-
-                checkout_node = self._db.get_node_from_event(event)
-                if checkout_node['name'] != 'checkout':
-                    continue
-
-                if checkout_node['status'] != "pass":
-                    continue
+                checkout_node = self._db.receive_node(sub_id)
 
                 self._info("Tarball: {}".format(
                     checkout_node['artifacts']['tarball']

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -100,23 +100,17 @@ scp \
         self._db.submit({'node': node})
 
     def run(self):
-        sub_id = self._db.subscribe('node')
+        sub_id = self._db.subscribe_node_channel(filters={
+            'op': 'created',
+            'name': 'checkout',
+            'status': 'pending',
+        })
         self._print("Listening for new checkout events")
         self._print("Press Ctrl-C to stop.")
 
         try:
             while True:
-                sys.stdout.flush()
-                event = self._db.get_event(sub_id)
-                if event.data['op'] != 'created':
-                    continue
-
-                node = self._db.get_node_from_event(event)
-                if node['name'] != 'checkout':
-                    continue
-
-                if node['status'] != "pending":
-                    continue
+                node = self._db.receive_node(sub_id)
 
                 build_config = self._find_build_config(node)
                 if build_config is None:


### PR DESCRIPTION
Use the new method from kernelci-core subscribe_node_channel() with filters to only receive nodes objects that match a particular set of criteria and simplify the logic in the client code accordingly.