### PR TITLE
src/runner.py: make --verbose an optional argument

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -117,9 +117,9 @@ class Runner:
 
 class cmd_run(Command):
     help = "Run some arbitrary test"
-    args = [Args.db_config, Args.verbose]
+    args = [Args.db_config]
     opt_args = [
-        Args.plan, Args.output,
+        Args.plan, Args.output, Args.verbose,
     ]
 
     def __call__(self, configs, args):


### PR DESCRIPTION
Fix the --verbose argument to be optional rather than required.

Fixes: c712aedfe8f8 ("src/runner.py: add --verbose argument")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>