### PR TITLE
config/pipeline.yaml: add config_path to shell

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -71,6 +71,7 @@ labs:
 
   shell:
     lab_type: shell
+    config_path: 'scripts'
 
 
 test_plans:


### PR DESCRIPTION
Add the config_path attribute to the shell "lab" so that the scripts
templates installed from the kernelci Pyhon package can be found by
runner.py.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

Depends on https://github.com/kernelci/kernelci-core/pull/1142