### PR TITLE
src/*.py: use kernelci.db

### DIFF
--- a/src/notifier.py
+++ b/src/notifier.py
@@ -12,7 +12,7 @@ import sys
 
 import kernelci
 import kernelci.config
-import kernelci.data
+import kernelci.db
 from kernelci.cli import Args, Command, parse_opts
 
 
@@ -31,7 +31,7 @@ class cmd_run(Command):
 
         db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        db = kernelci.data.get_db(db_config, api_token)
+        db = kernelci.db.get_db(db_config, api_token)
 
         sub_id = db.subscribe('node')
         print("Listening for events... ")

--- a/src/runner.py
+++ b/src/runner.py
@@ -12,7 +12,7 @@ import tempfile
 
 import kernelci
 import kernelci.config
-import kernelci.data
+import kernelci.db
 import kernelci.lab
 from kernelci.cli import Args, Command, parse_opts
 
@@ -22,7 +22,7 @@ class Runner:
     def __init__(self, configs, args):
         self._db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        self._db = kernelci.data.get_db(self._db_config, api_token)
+        self._db = kernelci.db.get_db(self._db_config, api_token)
         self._plan_config = configs['test_plans'][args.plan]
         self._device_config = configs['device_types']['python']
         runtime_config = configs['labs']['shell']

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 import kernelci
-import kernelci.data
+import kernelci.db
 from kernelci.config import load
 from kernelci.cli import Args, Command, parse_opts
 from kcidb import Client
@@ -23,7 +23,7 @@ class cmd_run(Command):
     def __call__(self, configs, args):
         db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        db = kernelci.data.get_db(db_config, api_token)
+        db = kernelci.db.get_db(db_config, api_token)
 
         if not os.getenv('GOOGLE_APPLICATION_CREDENTIALS'):
             print("No GOOGLE_APPLICATION_CREDENTIALS environment variable")

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -12,7 +12,7 @@ import urllib.parse
 import kernelci
 import kernelci.build
 import kernelci.config
-import kernelci.data
+import kernelci.db
 from kernelci.cli import Args, Command, parse_opts
 
 
@@ -22,7 +22,7 @@ class Tarball:
         self._build_configs = configs['build_configs']
         self._db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        self._db = kernelci.data.get_db(self._db_config, api_token)
+        self._db = kernelci.db.get_db(self._db_config, api_token)
         self._kdir = args.kdir
         self._output = args.output
         if not os.path.exists(self._output):

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 import kernelci.config
-import kernelci.data
+import kernelci.db
 from kernelci.cli import Args, Command, parse_opts
 import jinja2
 
@@ -19,7 +19,7 @@ class TestReport:
     def __init__(self, configs, args):
         self._db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        self._db = kernelci.data.get_db(self._db_config, api_token)
+        self._db = kernelci.db.get_db(self._db_config, api_token)
 
     def run(self):
         sub_id = self._db.subscribe('node')

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -13,7 +13,7 @@ import time
 import kernelci
 import kernelci.build
 import kernelci.config
-import kernelci.data
+import kernelci.db
 from kernelci.cli import Args, Command, parse_opts
 import urllib
 import requests
@@ -71,7 +71,7 @@ class cmd_run(Command):
         build_config = configs['build_configs'][args.build_config]
         db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        db = kernelci.data.get_db(db_config, api_token)
+        db = kernelci.db.get_db(db_config, api_token)
         poll_period = int(args.poll_period)
 
         while True:


### PR DESCRIPTION
Update all the client scripts to use kernleci.db as it is being renamed from kernelci.data in kernelci-core.