### PR TITLE
config/kubernetes: add check-describe.jinja2

### DIFF
--- a/config/kubernetes/check-describe.jinja2
+++ b/config/kubernetes/check-describe.jinja2
@@ -1,0 +1,63 @@
+{%- extends 'base-k8s-python.jinja2' %}
+
+{%- block python_imports %}
+{{ super() }}
+import requests
+{%- endblock %}
+
+{%- block python_globals %}
+{{ super() }}
+GIT_URL = '{{ git_url }}'
+GIT_COMMIT = '{{ git_commit }}'
+GIT_DESCRIBE = '{{ git_describe }}'
+{% endblock %}
+
+{%- block python_body %}
+def _get_makefile_rev(makefile):
+    makefile_rev = {
+        'VERSION': None,
+        'PATCHLEVEL': None,
+        'SUBLEVEL': None,
+    }
+    for line_n, line in enumerate(makefile):
+        value = list(val.strip() for val in line.split('='))
+        for key in makefile_rev.keys():
+            if value[0] == key:
+                makefile_rev[key] = int(value[1])
+                res = [val is not None for val in makefile_rev.values()]
+                if all(res):
+                    return makefile_rev
+        if line_n == 10:
+            return None
+    return None
+
+
+def _check_describe(makefile, describe):
+    try:
+        makefile_rev = _get_makefile_rev(makefile)
+    except Exception as e:
+        print(e)
+        makefile_rev = None
+    finally:
+        if makefile_rev is None:
+            return False
+
+    makefile_version = "v{version}.{patch}{dot}{sub}".format(
+        version=makefile_rev['VERSION'],
+        patch=makefile_rev['PATCHLEVEL'],
+        dot='.' if makefile_rev['SUBLEVEL'] else '',
+        sub=makefile_rev['SUBLEVEL'] if makefile_rev['SUBLEVEL'] else '',
+    )
+    return describe.startswith(makefile_version)
+
+
+def main(argv):
+    src_path = argv[1]
+
+    print("Checking git describe")
+    with open(os.path.join(src_path, 'Makefile')) as makefile:
+        res = _check_describe(makefile, GIT_DESCRIBE)
+        print("Result: {}".format("PASS" if res is True else "FAIL"))
+
+    return res
+{% endblock %}


### PR DESCRIPTION
Add config/kubernetes/check-describe.jinja2 template which inherits
from the base-k8s-python.jinja2 template from kernelci-core.  This is
an intermediate step towards merging it with the
scripts/check-describe.jinja2 template which would inherit a different
base depending on the runtime environment (local shell or Kubernetes
etc.).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>