### PR TITLE
config/kernelci.conf: add staging db config

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -27,3 +27,6 @@ plan: check-describe
 
 [db:docker-host]
 api: http://172.17.0.1:8001
+
+[db:staging.kernelci.org]
+api: https://staging.kernelci.org:9000


### PR DESCRIPTION
Add entry in kernelci.conf for the staging.kernelci.org db config.
This can be used by anyone with an API token.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>