### PR TITLE
T35140 runner exceptions

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -198,8 +198,11 @@ class cmd_run(Command):
         if not args.node_id and not args.git_commit:
             print("Either --node-id or --git-commit is required",
                   file=sys.stderr)
+        try:
+            return Runner(configs, args).run(args)
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
             return False
-        return Runner(configs, args).run(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As the "run" command is meant to be used interactively on the command
line rather than as a standalone service, print an error message and
exit cleanly when an exception is raised.

Depends on #59