### PR TITLE
config/scripts: align check-describe template with kubernetes

### DIFF
--- a/config/kubernetes/check-describe.jinja2
+++ b/config/kubernetes/check-describe.jinja2
@@ -1,3 +1,6 @@
+{# -*- mode: Python -*- -#}
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+
 {%- extends 'base-k8s-python.jinja2' %}
 
 {%- block python_imports %}

--- a/config/scripts/check-describe.jinja2
+++ b/config/scripts/check-describe.jinja2
@@ -3,17 +3,19 @@
 
 {%- extends 'base-python.jinja2' %}
 
-{% block script_init -%}
+{%- block python_imports %}
 {{ super() }}
 import requests
+{%- endblock %}
+
+{%- block python_globals %}
+{{ super() }}
+GIT_URL = '{{ git_url }}'
+GIT_COMMIT = '{{ git_commit }}'
+GIT_DESCRIBE = '{{ git_describe }}'
 {% endblock %}
 
-{% block commands %}
-GIT_URL = '{{ git_url }}'
-GIT_COMMIT = '{{ git_commit}}'
-GIT_DESCRIBE = '{{ git_describe }}'
-
-
+{%- block python_body %}
 def _get_makefile_rev(makefile):
     makefile_rev = {
         'VERSION': None,


### PR DESCRIPTION
Align the scripts/check-describe.jinja2 template with the one in
kubernetes as an intermediate step to merge them together.  The only
difference left is the name of the base template.

Depends on https://github.com/kernelci/kernelci-core/pull/1201