### PR TITLE
Update email configs

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 db_config: docker-host
+email_config: staging
 storage_url: http://172.17.0.1:8002/
 verbose: true
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Alexandra Pereira <alexandra.pereira@collabora.com>
 
 trees:
 
@@ -96,3 +97,11 @@ device_types:
     class: shell
     params:
       shebang: '/usr/bin/env python3'
+
+
+email_configs:
+
+  staging:
+    email_send_to: 'kernelci-results-staging@groups.io'
+    email_send_from: 'bot@kernelci.org'
+    email_subject: 'Kernel CI Test Reports'

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -103,5 +103,3 @@ email_configs:
 
   staging:
     email_send_to: 'kernelci-results-staging@groups.io'
-    email_send_from: 'bot@kernelci.org'
-    email_subject: 'Kernel CI Test Reports'

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -31,12 +31,13 @@ class TestReport:
         self._db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
         self._db = kernelci.db.get_db(self._db_config, api_token)
+        self._email_config = configs['email_configs'][args.email_config]
         self._logger = Logger("config/logger.conf", "test_report")
         self._email_host = args.email_host
         self._email_port = int(args.email_port)
         self._email_send_from = 'bot@kernelci.org'
         self._email_subject = 'Kernel CI Test Reports'
-        self._email_send_to = 'kernelci-results-staging@groups.io'
+        self._email_send_to = self._email_config.email_send_to
         self._email_user = os.getenv('EMAIL_USER')
         self._email_pass = os.getenv('EMAIL_PASSWORD')
 


### PR DESCRIPTION
Now that kernelci-core can load email configs we can update the pipeline code to use email configs coming from pipeline.yaml file. 

Depends on [#1231](https://github.com/kernelci/kernelci-core/pull/1231)