### PR TITLE
T35078 test_report.py: Generate test report for completed node

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -27,6 +27,8 @@ target: shell_python
 
 [test_report]
 
+[set_complete]
+
 [db:docker-host]
 api: http://172.17.0.1:8001
 

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -4,7 +4,7 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 [loggers]
-keys=root, notifier, runner, send_kcidb, tarball, test_report, trigger
+keys=root, notifier, runner, send_kcidb, set_complete, tarball, test_report, trigger
 
 [handlers]
 keys=consoleHandler
@@ -32,6 +32,12 @@ propagate=0
 level=DEBUG
 handlers=consoleHandler
 qualname=send_kcidb
+propagate=0
+
+[logger_set_complete]
+level=DEBUG
+handlers=consoleHandler
+qualname=set_complete
 propagate=0
 
 [logger_tarball]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,3 +81,13 @@ services:
       - '/home/kernelci/pipeline/test_report.py'
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
+
+  set_complete:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-set_complete'
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/set_complete.py'
+      - '--settings=/home/kernelci/config/kernelci.conf'
+      - 'run'

--- a/src/set_complete.py
+++ b/src/set_complete.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+import logging
+import os
+import sys
+
+import kernelci
+import kernelci.config
+import kernelci.db
+from kernelci.cli import Args, Command, parse_opts
+
+from logger import Logger
+
+
+class SetComplete:
+
+    def __init__(self, configs, args):
+        self._db_config = configs['db_configs'][args.db_config]
+        api_token = os.getenv('API_TOKEN')
+        self._db = kernelci.db.get_db(self._db_config, api_token)
+        self._logger = Logger("config/logger.conf", "set_complete")
+
+    def run(self):
+        sub_id = self._db.subscribe_node_channel(filters={
+            'status': ('complete', 'timeout'),
+        })
+        self._logger.log_message(logging.INFO, "Listening for node events... ")
+        self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
+
+        try:
+            while True:
+                node = self._db.receive_node(sub_id)
+                if node['parent'] is None:
+                    continue
+                nodes = self._db.get_child_nodes_from_parent(node['parent'])
+                ret = False
+                for node in nodes:
+                    if node['status'] == "pending":
+                        ret = True
+                        break
+                if ret:
+                    continue
+                root_node = self._db.get_root_node(node['_id'])
+                root_node['status'] = "complete"
+                resp = self._db.submit({'node': root_node})[0]
+                self._logger.log_message(logging.INFO, f"Set status to \
+complete of node: {resp['_id']}")
+        except KeyboardInterrupt as e:
+            self._logger.log_message(logging.INFO, "Stopping.")
+        finally:
+            self._db.unsubscribe(sub_id)
+
+
+class cmd_run(Command):
+    help = "Set root node status to 'complete' when all child nodes are \
+completed"
+    args = [Args.db_config]
+
+    def __call__(self, configs, args):
+        set_complete = SetComplete(configs, args)
+        set_complete.run()
+
+
+if __name__ == '__main__':
+    opts = parse_opts('set_complete', globals())
+    configs = kernelci.config.load('config/pipeline.yaml')
+    status = opts.command(configs, opts)
+    sys.exit(0 if status is True else 1)

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -96,6 +96,11 @@ class TestReport:
         else:
             self._logger.log_message(logging.INFO, "Email Sent.")
 
+    def get_test_analysis(self, nodes):
+        total_runs = len(nodes)
+        total_failures = sum(node['status'] == "fail" for node in nodes)
+        return total_runs, total_failures
+
     def run(self):
         sub_id = self._db.subscribe_node_channel(filters={
             'op': 'updated',
@@ -114,11 +119,15 @@ class TestReport:
                 child_nodes = self._db.get_child_nodes_from_parent(
                                     root_node['_id'])
 
+                total_runs, total_failures = \
+                    self.get_test_analysis(child_nodes)
+
                 template_env = jinja2.Environment(
                             loader=jinja2.FileSystemLoader("./config/reports/")
                         )
                 template = template_env.get_template("test-report.jinja2")
-                email_content = template.render(total_runs=1, total_failures=0,
+                email_content = template.render(total_runs=total_runs,
+                                                total_failures=total_failures,
                                                 root=root_node,
                                                 tests=child_nodes)
                 email_msg = self.create_email(email_content,


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-api/issues/130

Depends on https://github.com/kernelci/kernelci-pipeline/pull/66 and https://github.com/kernelci/kernelci-core/pull/1242/

Instead of listening to all node events, listen to the "completed" event.
Display total timeouts to test report.