### PR TITLE
T35745 Fix permission issues with linux repository creation

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -8,7 +8,7 @@ build_config: mainline
 poll_period: 0
 
 [tarball]
-kdir: /home/kernelci/data/linux
+kdir: /home/kernelci/data/src/linux
 output: /home/kernelci/data/output
 ssh_key: /home/kernelci/data/ssh/id_rsa_tarball
 ssh_port: 8022

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
       - './data/ssh:/home/kernelci/data/ssh'
-      - './data/linux:/home/kernelci/data/linux'
+      - './data/src:/home/kernelci/data/src'
       - './data/output:/home/kernelci/data/output'
 
   trigger:


### PR DESCRIPTION
Need to mount empty directory for linux source to have `kernelci` permission instead of `root` within tarball container.
Modify `kernelci.conf` for the same.