### PR TITLE
src/test_report: send email reports about a kernel revision

### DIFF
--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -1,16 +1,21 @@
 {# -*- mode: Python -*- -#}
 {# SPDX-License-Identifier: LGPL-2.1-or-later -#}
 
-{{ root.revision.tree }}/{{ root.revision.branch }} {{ '(Unknown)' if root.revision.describe is none else root.revision.describe}}: {{ total_runs }} runs, {{ total_failures}} failures
+{{ subject_str }}
+
+Tests Summary
+-------------
+
+Build details:
+
+Tree:     {{ root.revision.tree }}
+Branch:   {{ root.revision.branch }}
+Describe: {{ root.revision.describe }}
+URL:      {{ root.revision.url }}
+SHA1:     {{ root.revision.commit }}
 
 {{'%-15s %s %s'|format("test", "|", "result")}}
 {{'%s%s%s'|format("-"*16, "+", "-"*7)}}
 {%- for test in tests %}
 {{'%-15s %s %s'|format(test.name, "|", test.status)}}
 {%- endfor %}
-
-  Tree:     {{ root.revision.tree }}
-  Branch:   {{ root.revision.branch }}
-  Describe: {{ '(Unknown)' if root.revision.describe is none else root.revision.describe}}
-  URL:      {{ root.revision.url }}
-  SHA1:     {{ root.revision.commit }}


### PR DESCRIPTION
It updates the test_report module in pipeline to listen for a completed event and then creates a summary with test revisions to be sent in the report. Additionally, updates the jinja template accordingly.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>