### PR TITLE
Update template paths to use runtime directory

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -71,12 +71,10 @@ labs:
 
   k8s-gke-eu-west4:
     lab_type: kubernetes
-    config_path: 'kubernetes'
     context: 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
 
   shell:
     lab_type: shell
-    config_path: 'scripts'
 
 
 test_plans:

--- a/src/runner.py
+++ b/src/runner.py
@@ -61,14 +61,9 @@ class Runner:
         }
         params.update(plan_config.params)
         params.update(device_config.params)
-        config_path = self._runtime.config.config_path
-        templates_path = [
-            os.path.join(path, config_path)
-            for path in ['config', '/etc/kernelci']
-        ]
+        templates = ['config/runtime', '/etc/kernelci/runtime']
         job = self._runtime.generate(
-            params, device_config, plan_config,
-            templates_path=templates_path
+            params, device_config, plan_config, templates_path=templates
         )
         output_file = self._runtime.save_file(job, tmp, params)
         self._logger.log_message(logging.INFO, f"output_file: {output_file}")


### PR DESCRIPTION
Stop using the `config_path` attribute which is now deprecated and update the templates path to use the `runtime` directory.

Depends on https://github.com/kernelci/kernelci-core/pull/1317 and https://github.com/kernelci/kernelci-core/pull/1301