### PR TITLE
Drop python suffix in device types

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -87,12 +87,10 @@ test_plans:
 
 device_types:
 
-  kubernetes_python:
+  kubernetes:
     base_name: kubernetes
     class: kubernetes
 
-  shell_python:
+  shell:
     base_name: shell
     class: shell
-    params:
-      shebang: '/usr/bin/env python3'

--- a/src/runner.py
+++ b/src/runner.py
@@ -121,10 +121,13 @@ class RunnerLoop(Runner):
         plan = self._plan_configs['check-describe']
 
         # ToDo: iterate over device types for the current runtime
-        if self._runtime.config.lab_type == 'shell':
-            device = self._device_configs['shell_python']
-        else:
-            device = self._device_configs['kubernetes_python']
+        device_type = self._runtime.config.lab_type
+        device = self._device_configs.get(device_type)
+        if device is None:
+            self._logger.log_message(
+                logging.ERROR, "Device type not found: {device_type}"
+            )
+            return False
 
         try:
             while True:


### PR DESCRIPTION
Drop the `_python` suffix in the device type names as the language being used is now defined in the test templates.