### PR TITLE
runner.py: add runtime param

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -57,6 +57,7 @@ class Runner:
             'runtime': self._runtime.config.lab_type,
             'tarball_url': node['artifacts']['tarball'],
             'workspace': tmp,
+            'runtime': self._runtime.config.lab_type,
         }
         params.update(plan_config.params)
         params.update(device_config.params)


### PR DESCRIPTION
Add the 'runtime' parameter which is required when generating job
definitions with the new runtime templates.  Its value is the type of
runtime e.g. 'shell', 'kubernetes' etc.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>