### PR TITLE
kver.jinja2: drop duplicate requests import

### DIFF
--- a/config/runtime/kver.jinja2
+++ b/config/runtime/kver.jinja2
@@ -3,11 +3,6 @@
 
 {%- extends 'base/python.jinja2' %}
 
-{%- block python_imports %}
-{{ super() }}
-import requests
-{%- endblock %}
-
 {%- block python_globals %}
 {{ super() }}
 REVISION = {{ revision }}


### PR DESCRIPTION
Drop unused import as the requests package is imported in the
python.jinja2 base template already.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>