### PR TITLE
runner.py: add runtime_image template parameter

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -85,6 +85,7 @@ test_plans:
 
   kver:
     pattern: 'kver.jinja2'
+    image: 'kernelci/-staging-kernelci'
 
 
 device_types:

--- a/src/runner.py
+++ b/src/runner.py
@@ -55,6 +55,7 @@ class Runner:
             'node_id': node['_id'],
             'revision': revision,
             'runtime': self._runtime.config.lab_type,
+            'runtime_image': plan_config.image,
             'tarball_url': node['artifacts']['tarball'],
             'workspace': tmp,
         }


### PR DESCRIPTION
Add the runtime_image template parameter currently only used by
base/kubernetes.jinja2 to specify the Docker image to use when running
the test plan.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>