### PR TITLE
docker-compose.yaml: set default plans for runner services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
       - '--lab-config=shell'
+      - '--plan=kver'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
@@ -47,6 +48,7 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
       - '--lab-config=k8s-gke-eu-west4'
+      - '--plan=kunit'
 
   tarball:
     <<: *base-service


### PR DESCRIPTION
Depends on #83, #84, #88

Set default plan names with kver for runner and kunit for runner-k8s.
This is now required as the --plan argument is being added to the
runner.py loop command.
