### PR TITLE
T35078 src: use `get_nodes` to get nodes from commit

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -154,7 +154,9 @@ class RunnerSingleJob(Runner):
             return True
 
     def _get_node_from_commit(self, git_commit):
-        nodes = self._db.get_nodes_by_commit_hash(git_commit)
+        nodes = self._db.get_nodes({
+            "revision.commit": git_commit,
+        })
         return nodes[0] if nodes else None
 
     def run(self, args):

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -25,7 +25,9 @@ from logger import Logger
 
 def _run_trigger(args, build_config, db, logger):
     head_commit = kernelci.build.get_branch_head(build_config)
-    node_list = db.get_nodes_by_commit_hash(head_commit)
+    node_list = db.get_nodes({
+        "revision.commit": head_commit,
+    })
     if node_list:
         logger.log_message(logging.INFO, f"Node exists with \
 the latest git commit {head_commit}")


### PR DESCRIPTION
As `get_nodes` API can now be used with required
node attributes (in this case commit HASH) , used it instead
of `get_nodes_by_commit_hash`.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>