### PR TITLE
T35078 src/test_report: use `get_nodes` to get child nodes from parent

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -129,9 +129,8 @@ class TestReport:
         try:
             while True:
                 root_node = self._db.receive_node(sub_id)
-                child_nodes = self._db.get_child_nodes_from_parent(
-                    root_node['_id']
-                )
+                child_nodes = self._db.get_nodes({"parent": root_node['_id']})
+
                 email_content, email_sub = self.create_test_report(
                     root_node, child_nodes
                 )


### PR DESCRIPTION
As `get_nodes` can be used to get all child nodes
by providing parent id using attributes, need
to replace `get_child_nodes_from_parent` with it.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>