### PR TITLE
config/pipeline.yaml: fix typo in kver Docker image name

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -85,7 +85,7 @@ test_plans:
 
   kver:
     pattern: 'kver.jinja2'
-    image: 'kernelci/-staging-kernelci'
+    image: 'kernelci/staging-kernelci'
 
 
 device_types:


### PR DESCRIPTION
Fix a typo in the kver image name used for Docker.

Fixes: 3c139d4544d2 ("config/pipeline.yaml: add image attribute for kver")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>