### PR TITLE
src: dump call stack when catching unexpected exception

### DIFF
--- a/src/complete_hack.py
+++ b/src/complete_hack.py
@@ -56,7 +56,7 @@ class CompleteHack:
                 else:
                     time.sleep(5)
                     self._check_pending_node()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
         except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import traceback
 
 import kernelci
 import kernelci.config
@@ -74,6 +75,8 @@ class cmd_run(Command):
                 sys.stdout.flush()
         except KeyboardInterrupt as e:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             db.unsubscribe(sub_id)
 

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -73,9 +73,9 @@ class cmd_run(Command):
                     name=obj['name'],
                 ))
                 sys.stdout.flush()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             db.unsubscribe(sub_id)

--- a/src/runner.py
+++ b/src/runner.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import tempfile
+import traceback
 
 import kernelci
 import kernelci.config
@@ -132,6 +133,8 @@ class RunnerLoop(Runner):
                 self._cleanup_paths()
         except KeyboardInterrupt as e:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)
             self._cleanup_paths()

--- a/src/runner.py
+++ b/src/runner.py
@@ -131,9 +131,9 @@ class RunnerLoop(Runner):
                 if self._runtime.config.lab_type == 'shell':
                     self._job_tmp_dirs[job] = tmp
                 self._cleanup_paths()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)
@@ -151,7 +151,7 @@ class RunnerSingleJob(Runner):
                 self._logger.log_message(logging.INFO, "Waiting...")
                 job.wait()
                 self._logger.log_message(logging.INFO, "...done")
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.ERROR, "Aborting.")
         finally:
             return True

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -108,7 +108,7 @@ connection to KCIDB")
 
         except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             db.unsubscribe(sub_id)

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -12,6 +12,7 @@ import datetime
 import logging
 import os
 import sys
+import traceback
 
 import kernelci
 import kernelci.db
@@ -107,6 +108,8 @@ connection to KCIDB")
 
         except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             db.unsubscribe(sub_id)
 

--- a/src/set_timeout.py
+++ b/src/set_timeout.py
@@ -10,6 +10,7 @@ import os
 import sys
 from datetime import datetime, timedelta
 from time import sleep
+import traceback
 
 import kernelci
 import kernelci.config
@@ -60,6 +61,8 @@ class SetTimeout:
                 sleep(self._poll_period)
         except KeyboardInterrupt as err:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
 
 
 class cmd_run(Command):

--- a/src/set_timeout.py
+++ b/src/set_timeout.py
@@ -59,9 +59,9 @@ class SetTimeout:
                 for node in nodes:
                     self._set_timeout_status(node)
                 sleep(self._poll_period)
-        except KeyboardInterrupt as err:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
 
 

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -155,9 +155,9 @@ scp \
                 version = self._get_version_from_describe()
                 self._update_checkout_node(node, describe, version, tarball)
                 self._create_tarball_node(node, "pending", None)
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import sys
+import traceback
 import urllib.parse
 
 import kernelci
@@ -156,6 +157,8 @@ scp \
                 self._create_tarball_node(node, "pending", None)
         except KeyboardInterrupt as e:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)
 

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -16,6 +16,7 @@ import email.mime.text
 import os
 import smtplib
 import sys
+import traceback
 
 import kernelci.config
 import kernelci.db
@@ -145,6 +146,8 @@ class TestReport:
                     email_server.quit()
         except KeyboardInterrupt as e:
             self._logger.log_message(logging.INFO, "Stopping.")
+        except Exception as e:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)
 

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -144,9 +144,9 @@ class TestReport:
                 if email_server:
                     self.send_mail(email_msg, email_server)
                     email_server.quit()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
-        except Exception as e:
+        except Exception:
             self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             self._db.unsubscribe(sub_id)

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -95,9 +95,9 @@ class cmd_run(Command):
                     time.sleep(poll_period)
                 else:
                     break
-            except KeyboardInterrupt as e:
+            except KeyboardInterrupt:
                 self._logger.log_message(logging.INFO, "Stopping.")
-            except Exception as e:
+            except Exception:
                 self._logger.log_message(logging.ERROR, traceback.format_exc())
 
         return True

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 import time
+import traceback
 
 import kernelci
 import kernelci.build
@@ -88,11 +89,16 @@ class cmd_run(Command):
         poll_period = int(args.poll_period)
 
         while True:
-            _run_trigger(args, build_config, db, self._logger)
-            if poll_period:
-                time.sleep(poll_period)
-            else:
-                break
+            try:
+                _run_trigger(args, build_config, db, self._logger)
+                if poll_period:
+                    time.sleep(poll_period)
+                else:
+                    break
+            except KeyboardInterrupt as e:
+                self._logger.log_message(logging.INFO, "Stopping.")
+            except Exception as e:
+                self._logger.log_message(logging.ERROR, traceback.format_exc())
 
         return True
 


### PR DESCRIPTION
When an unexpected exception occurs during a loop, catch it and log
the call stack as when it's not handled rather than silencing it with
the `finally` clause.  This helps with debugging to find where errors
are coming from.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>