### PR TITLE
Add kvm xfstest conf and template

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -18,6 +18,9 @@ ssh_host: 172.17.0.1
 [runner]
 output: /home/kernelci/output
 
+[fstests_runner]
+output: /home/kernelci/alex/fstests-poc/output
+
 [notifier]
 
 [kcidb]

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -79,6 +79,9 @@ labs:
 
 test_plans:
 
+  fstests:
+    pattern: 'fstests.jinja2'
+
   kunit:
     pattern: 'kunit.jinja2'
     image: 'kernelci/staging-gcc-10:x86-kunit-kernelci'

--- a/config/runtime/fstests.jinja2
+++ b/config/runtime/fstests.jinja2
@@ -1,0 +1,32 @@
+{# -*- mode: Python -*- -#}
+{# SPDX-License-Identifier: LGPL-2.1-or-later -#}
+ 
+{%- extends 'base/python.jinja2' %}
+ 
+{%- block python_imports %}
+{{ super() }}
+import subprocess
+{%- endblock %}
+ 
+{%- block python_globals %}
+{{ super() }}
+REVISION = {{ revision }}
+{% endblock %}
+ 
+{%- block python_body %}
+def check_kvm_xfstest_env():
+   try:
+       result = subprocess.run("kvm-xfstests --help", check=True, shell=True)
+       if result.returncode == 0:
+           print(f"KVM-xftests found.")
+           return True
+       else:
+           return False
+   except Exception as e:
+       print(f"Raised exception: {e}")
+       return False
+ 
+def main(argv):
+   print("Checking if KVM-xfstests is available...")
+   check_kvm_xfstest_env()
+{% endblock %}


### PR DESCRIPTION
- Add a jinja2 template for fstests.
- Add a fstests test plan.
- Update the run function to run to generate a job and run it using shell lab.
- Drop the code used to run `kvm-xfstests` as a subprocess. 