### PR TITLE
src/runner.py: also print stack in run command

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -153,6 +153,8 @@ class RunnerSingleJob(Runner):
                 self._logger.log_message(logging.INFO, "...done")
         except KeyboardInterrupt:
             self._logger.log_message(logging.ERROR, "Aborting.")
+        except Exception:
+            self._logger.log_message(logging.ERROR, traceback.format_exc())
         finally:
             return True
 


### PR DESCRIPTION
Also print the stack trace when catching an expected exception with
the 'run' command, not just 'loop'.  The 'run' command is mostly used
for debugging and development so having details about exceptions is
very useful.

Fixes: 75b9c16b8f26 ("src: dump call stack when catching unexpected exception")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>