### PR TITLE
Add group and path attributes

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -67,10 +67,12 @@ cd {src_path} && \
             'parent': parent['_id'],
             'status': 'complete',
             'revision': parent['revision'],
+            'group': parent['group'],
         }
         for node in child_nodes:
             base_node.update({
                 'name': node['name'],
+                'path': parent['path'] + [node['name']],
                 'result': node.get('result'),
             })
             sent_node = db.submit({'node': base_node})[0]

--- a/src/runner.py
+++ b/src/runner.py
@@ -41,6 +41,8 @@ class Runner:
         node = {
             'parent': tarball_node['_id'],
             'name': plan_config.name,
+            'path': tarball_node['path'] + [plan_config.name],
+            'group': plan_config.name,
             'artifacts': tarball_node['artifacts'],
             'revision': tarball_node['revision'],
         }

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -102,6 +102,7 @@ scp \
         node = {
             'parent': checkout_node['_id'],
             'name': 'tarball',
+            'path': checkout_node['path'] + ['tarball'],
             'artifacts': checkout_node['artifacts'],
             'revision': checkout_node['revision'],
             'status': status,

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -51,6 +51,7 @@ anyway")
     sys.stdout.flush()
     node = {
         'name': 'checkout',
+        'path': ['checkout'],
         'revision': revision,
     }
     resp_obj = db.submit({'node': node})[0]


### PR DESCRIPTION
Add the `Node.group` and `Node.path` attributes when submitting nodes where applicable.

Depends on https://github.com/kernelci/kernelci-api/pull/167 and https://github.com/kernelci/kernelci-api/pull/168