### PR TITLE
config/runtime: set result string in kver.jinja2

### DIFF
--- a/config/runtime/kver.jinja2
+++ b/config/runtime/kver.jinja2
@@ -64,7 +64,8 @@ class Job(BaseJob):
         with open(os.path.join(src_path, 'Makefile')) as makefile:
             kver = REVISION['version']
             res = self._check_kver(makefile, kver)
-            print("Result: {}".format("PASS" if res is True else "FAIL"))
+            result = 'pass' if res is True else 'fail'
+            print(f"Result: {result}")
 
-        return res
+        return result
 {% endblock %}


### PR DESCRIPTION
Rather than passing True or False, pass the actual result string to
set in the node in the kver test template.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>