### PR TITLE
src/complete_hack.py: extend timeout to 10 minutes

### DIFF
--- a/src/complete_hack.py
+++ b/src/complete_hack.py
@@ -32,7 +32,7 @@ class CompleteHack:
     def _check_pending_node(self):
         now = datetime.utcnow()
         created = datetime.fromisoformat(self._pending_node['created'])
-        expires = created + timedelta(minutes=3)
+        expires = created + timedelta(minutes=10)
         if now > expires:
             self._pending_node['status'] = "complete"
             self._db.submit({'node': self._pending_node})


### PR DESCRIPTION
Extend the arbitrary timeout in complete_hack.py to 10 minutes to
avoid marking the parent node "complete" too early.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>