### PR TITLE
Add test group data in email reports

### DIFF
--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -1,9 +1,9 @@
 {# SPDX-License-Identifier: LGPL-2.1-or-later -#}
 
-{{ subject_str }}
+{{ subject }}
 
-Tests Summary
--------------
+Summary
+=======
 
 Tree:     {{ root.revision.tree }}
 Branch:   {{ root.revision.branch }}
@@ -11,8 +11,29 @@ Describe: {{ root.revision.describe }}
 URL:      {{ root.revision.url }}
 SHA1:     {{ root.revision.commit }}
 
-{{'%-15s %s %s'|format("test", "|", "result")}}
-{{'%s%s%s'|format("-"*16, "+", "-"*7)}}
-{%- for test in tests %}
-{{'%-15s %s %s'|format(test.name, "|", test.result)}}
+{{ '%-15s %s %-8s %s %-8s %s %-8s'|format(
+"Name", "|", "Result", "|", "Total", "|", "Failures") }}
+{{ '%s%s%s%s%s%s%s'|format(
+"-"*16, "+", "-"*10, "+", "-"*10, "+", "-"*9) }}
+{%- for group_name, group in groups.items() %}
+{{ '%-15s %s %-8s %s %8d %s %8d'|format(
+group_name, "|",
+group.root.result, "|",
+group.nodes|count, "|",
+group.failures|count) }}
+{%- endfor %}
+
+
+Failing tests
+=============
+
+{%- for group_name, group in groups.items() %}
+{%- if group.failures|count %}
+
+{{ group_name }}
+{{ '-'*group_name|length }}
+
+{% for failure in group.failures %}* {{ failure.path }}
+{% endfor %}
+{%- endif %}
 {%- endfor %}


### PR DESCRIPTION
Add data from test group results to email reports.

Depends on #117 

Sample email report:
```
mainline/master v5.19-14184-g69dac8e431af: 2 runs 1 failures

Summary
=======

Tree:     mainline
Branch:   master
Describe: v5.19-14184-g69dac8e431af
URL:      https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
SHA1:     69dac8e431af26173ca0a1ebc87054e01c585bcc

Name            | Result   | Total    | Failures
----------------+----------+----------+---------
kver            | pass     |        0 |        0
kunit           | fail     |      234 |        1


Failing tests
=============

kunit
-----

* property-entry.pe_test_uints
```