### PR TITLE
src/fstests: parse fstests results

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -18,9 +18,6 @@ ssh_host: 172.17.0.1
 [runner]
 output: /home/kernelci/output
 
-[fstests_runner]
-output: /home/kernelci/alex/fstests-poc/output
-
 [notifier]
 
 [kcidb]

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -126,7 +126,11 @@ class Job(BaseJob):
             return 'fail'
         if not self._get_xml_from_vm(src_path):
             return 'fail'
-        with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
-            result_file.write(json.dumps(self._parse_results(src_path)))
+        try:
+            with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
+                result_file.write(json.dumps(self._parse_results(src_path)))
+        except Exception as e:
+            print(f"Exception raised while parsing results: {e}")
+            return 'fail'
         return 'pass'
 {% endblock %}

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -41,6 +41,16 @@ class Job(BaseJob):
         except Exception as e:
             print('Kernel build error:', e)
 
+    def _get_xml_from_vm(self, kdir):
+        try:
+            result = subprocess.run([f"debugfs -R \"dump ext4/results-4k/results.xml {kdir}/results.xml\" {xfstests_bld_path}/run-fstests/disks/vdg"], check=True, shell=True)
+            if result.returncode == 0:
+                print(f"XML file in the output directory.")
+                return 'pass'
+        except Exception as e:
+            print('XML not found.', e)
+            return 'fail'
+
     def _run_smoke_tests(self):
         try:
             result = subprocess.run(["kvm-xfstests", "smoke"], check=True)
@@ -68,7 +78,7 @@ class Job(BaseJob):
         if self._check_kvm_xfstest_env():
             if self._kernel_config(src_path) == 'pass':
                 if self._kernel_build(src_path) == 'pass':
-                    return self._run_smoke_tests()
-        else:
-            return 'fail'
+                    if self._run_smoke_tests() == 'pass':
+                        return self._get_xml_from_vm(src_path)
+        return 'fail'
 {% endblock %}

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -10,7 +10,9 @@ xfstests_bld_path = '{{ xfstests_bld_path }}'
 
 {%- block python_imports %}
 {{ super() }}
+import json
 import subprocess
+import xml.etree.ElementTree as ET
 {%- endblock %}
 
 {% block python_job -%}
@@ -51,6 +53,40 @@ class Job(BaseJob):
             print('XML not found.', e)
             return 'fail'
 
+    def _parse_to_json(self, node, tree, name=None):
+        if 'result' in tree:
+            node['name'] = name
+            node['result'] = tree['result']
+        else:
+            if (not name == None): node['name'] = name
+            child_nodes = []
+            for name in tree:
+                child_nodes.append(self._parse_to_json({}, tree[name], name))
+            node['child_nodes'] = child_nodes
+        return node
+
+    def _parse_results(self, kdir):
+        xml_file = ET.parse(f"{kdir}/results.xml")
+        root = xml_file.getroot()
+        tree = {}
+        for test_case in root.iter('testcase'):
+            if test_case.find('skipped') is not None:
+                result = None
+            elif test_case.find('failure') is not None:
+                result = 'fail'
+            else:
+                result = 'pass'
+            name = test_case.attrib['name'].split('/')
+            if not name[0] == 'ext4':
+                name.insert(0, 'ext4')
+            current = tree
+            for item in name:
+                if not item in current:
+                    current[item] = {}
+                current = current[item]
+            current['result'] = result
+        return self._parse_to_json({}, tree, 'fstests')
+
     def _run_smoke_tests(self):
         try:
             result = subprocess.run(["kvm-xfstests", "smoke"], check=True)
@@ -79,6 +115,8 @@ class Job(BaseJob):
             if self._kernel_config(src_path) == 'pass':
                 if self._kernel_build(src_path) == 'pass':
                     if self._run_smoke_tests() == 'pass':
-                        return self._get_xml_from_vm(src_path)
+                        if self._get_xml_from_vm(src_path) == 'pass':
+                            with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
+                                result_file.write(json.dumps(self._parse_results(src_path)))
         return 'fail'
 {% endblock %}

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -53,20 +53,8 @@ class Job(BaseJob):
             print('XML not found.', e)
             return False
 
-    def _parse_to_json(self, node, tree, name=None):
-        if 'result' in tree:
-            node['name'] = name
-            node['result'] = tree['result']
-        else:
-            if (not name == None): node['name'] = name
-            child_nodes = []
-            for name in tree:
-                child_nodes.append(self._parse_to_json({}, tree[name], name))
-            node['child_nodes'] = child_nodes
-        return node
-
-    def _parse_results(self, kdir):
-        xml_file = ET.parse(f"{kdir}/results.xml")
+    def _parse_xml_results(self, kdir):
+        xml_file = ET.parse(kdir)
         root = xml_file.getroot()
         tree = {}
         for test_case in root.iter('testcase'):
@@ -85,7 +73,7 @@ class Job(BaseJob):
                     current[item] = {}
                 current = current[item]
             current['result'] = result
-        return self._parse_to_json({}, tree, 'fstests')
+        return tree
 
     def _run_smoke_tests(self):
         try:
@@ -96,6 +84,26 @@ class Job(BaseJob):
         except Exception as e:
             print('Problem found during tests:', e)
             return False
+
+    def _convert_results_for_api(self, tree, name):
+        if 'result' in tree:
+            return {
+                'name': name,
+                'result': tree['result'],
+            }
+        else:
+            child_nodes = []
+            for child_name in tree:
+                child_nodes.append(self._convert_results_for_api(tree[child_name], child_name))
+            return {
+                'name': name,
+                'child_nodes': child_nodes,
+            }
+
+    def _parse_results(self, kdir):
+        tree_data = self._parse_xml_results(os.path.join(kdir, 'results.xml'))
+        api_data = self._convert_results_for_api(tree_data, 'fstests')
+        return api_data
 
     def _check_kvm_xfstest_env(self):
         try:

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -23,13 +23,13 @@ class Job(BaseJob):
             result = subprocess.run("kvm-xfstests install-kconfig", check=True, shell=True)
             if result.returncode == 0:
                 print(f"Kernel config done.")
-                return 'pass'
+                return True
             else:
                 print((f"Missing kernel .config file."))
-                return 'fail'
+                return False
         except Exception as e:
             print('Kernel config error:', e)
-            return 'fail'
+            return False
 
     def _kernel_build(self, kdir):
         try:
@@ -37,9 +37,9 @@ class Job(BaseJob):
             result = subprocess.run("make -j$(nproc)", check=True, shell=True)
             if result.returncode == 0:
                 print(f"Kernel Build DONE.")
-                return 'pass'
+                return True
             else:
-                return 'fail'
+                return False
         except Exception as e:
             print('Kernel build error:', e)
 
@@ -48,10 +48,10 @@ class Job(BaseJob):
             result = subprocess.run([f"debugfs -R \"dump ext4/results-4k/results.xml {kdir}/results.xml\" {xfstests_bld_path}/run-fstests/disks/vdg"], check=True, shell=True)
             if result.returncode == 0:
                 print(f"XML file in the output directory.")
-                return 'pass'
+                return True
         except Exception as e:
             print('XML not found.', e)
-            return 'fail'
+            return False
 
     def _parse_to_json(self, node, tree, name=None):
         if 'result' in tree:
@@ -92,10 +92,10 @@ class Job(BaseJob):
             result = subprocess.run(["kvm-xfstests", "smoke"], check=True)
             if result.returncode == 0:
                 print(f"Test run success.")
-                return 'pass'
+                return True
         except Exception as e:
             print('Problem found during tests:', e)
-            return 'fail'
+            return False
 
     def _check_kvm_xfstest_env(self):
         try:
@@ -110,13 +110,15 @@ class Job(BaseJob):
             return False
 
     def _run(self, src_path):
-        print("Checking if KVM-xfstests is available...")
-        if self._check_kvm_xfstest_env():
-            if self._kernel_config(src_path) == 'pass':
-                if self._kernel_build(src_path) == 'pass':
-                    if self._run_smoke_tests() == 'pass':
-                        if self._get_xml_from_vm(src_path) == 'pass':
-                            with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
-                                result_file.write(json.dumps(self._parse_results(src_path)))
-        return 'fail'
+        if not self._kernel_config(src_path):
+            return 'fail'
+        if not self._kernel_build(src_path):
+            return 'fail'
+        if not self._run_smoke_tests():
+            return 'fail'
+        if not self._get_xml_from_vm(src_path):
+            return 'fail'
+        with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
+            result_file.write(json.dumps(self._parse_results(src_path)))
+        return 'pass'
 {% endblock %}

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -3,6 +3,11 @@
 
 {%- extends 'base/python.jinja2' %}
 
+{%- block python_globals %}
+{{ super() }}
+xfstests_bld_path = '{{ xfstests_bld_path }}'
+{% endblock %}
+
 {%- block python_imports %}
 {{ super() }}
 import subprocess

--- a/src/fstests/fstests.kernelci.conf
+++ b/src/fstests/fstests.kernelci.conf
@@ -1,0 +1,4 @@
+[fstests_runner]
+output: /home/kernelci/alex/fstests-poc/output
+xfstests_bld_path: /home/kernelci/alex/fstests-poc/fstests
+db_config: staging.kernelci.org

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -24,6 +24,7 @@ class FstestsRunner:
         self._device_configs = configs['device_types']
         self._plan = configs['test_plans']['fstests']
         self._output = args.output
+        self._xfstests_bld_path = args.xfstests_bld_path
         if not os.path.exists(self._output):
             os.makedirs(self._output)
         runtime_config = configs['labs']['shell']
@@ -51,6 +52,7 @@ class FstestsRunner:
                 'runtime': self._runtime.config.lab_type,
                 'tarball_url': node['artifacts']['tarball'],
                 'workspace': tmp,
+                'xfstests_bld_path' : self._xfstests_bld_path
             }
             params.update(self._plan.params)
             params.update(device_config.params)
@@ -113,6 +115,10 @@ class cmd_run(Command):
     help = 'KVM fstests runner'
     args = [
         Args.db_config, Args.output,
+        {
+            'name': '--xfstests-bld-path',
+            'help': "xfstests build directory"
+        },
     ]
     opt_args = [
         Args.verbose,


### PR DESCRIPTION
- add a step to get fstests results.xml file and copy it to the kernel source directory.
- parse fstests XML result file into a JSON containing the node structure to be submitted.
- small design improviments