### PR TITLE
src/*.py: get nodes from 'items' key

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -159,9 +159,9 @@ class RunnerSingleJob(Runner):
             return True
 
     def _get_node_from_commit(self, git_commit):
-        nodes = self._db.get_nodes({
+        nodes = (self._db.get_nodes({
             "revision.commit": git_commit,
-        })
+        })).get('items')
         return nodes[0] if nodes else None
 
     def run(self, args):

--- a/src/set_timeout.py
+++ b/src/set_timeout.py
@@ -31,8 +31,8 @@ class SetTimeout:
 
     def _update_pending_child(self, parent_id):
         """Set child node status to timeout when parent is timed out"""
-        child_nodes = self._db.get_nodes({"status": "pending",
-                                          "parent": parent_id})
+        child_nodes = (self._db.get_nodes({"status": "pending",
+                                          "parent": parent_id})).get('items')
         for child in child_nodes:
             child['status'] = "timeout"
             self._db.submit({'node': child})
@@ -55,7 +55,9 @@ class SetTimeout:
 
         try:
             while True:
-                nodes = self._db.get_nodes({"status": "pending"})
+                nodes = (self._db.get_nodes({
+                    "status": "pending"
+                })).get('items')
                 for node in nodes:
                     self._set_timeout_status(node)
                 sleep(self._poll_period)

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -104,7 +104,9 @@ class TestReport:
         try:
             while True:
                 root_node = self._db.receive_node(sub_id)
-                child_nodes = self._db.get_nodes({"parent": root_node['_id']})
+                child_nodes = (self._db.get_nodes({
+                    "parent": root_node['_id']
+                })).get('items')
                 content, subject = self._create_test_report(
                     root_node, child_nodes
                 )

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -26,9 +26,9 @@ from logger import Logger
 
 def _run_trigger(args, build_config, db, logger):
     head_commit = kernelci.build.get_branch_head(build_config)
-    node_list = db.get_nodes({
+    node_list = (db.get_nodes({
         "revision.commit": head_commit,
-    })
+    })).get('items')
     if node_list:
         logger.log_message(logging.INFO, f"Node exists with \
 the latest git commit {head_commit}")


### PR DESCRIPTION
The `/nodes` endpoint response has now been changed
due to pagination implementation.
Need to fetch value of 'items' from json response
dictionary to get nodes.

Depends on API Pagination PR: https://github.com/kernelci/kernelci-api/pull/164

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>