### PR TITLE
src/runner.py: pass templates_paths argument to .generate()

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -66,7 +66,7 @@ class Runner:
         params.update(device_config.params)
         templates = ['config/runtime', '/etc/kernelci/runtime']
         job = self._runtime.generate(
-            params, device_config, plan_config, templates_path=templates
+            params, device_config, plan_config, templates_paths=templates
         )
         output_file = self._runtime.save_file(job, tmp, params)
         self._logger.log_message(logging.INFO, f"output_file: {output_file}")


### PR DESCRIPTION
The keywoard argument templates_path has been renamed to templates_paths as it can now be either a string with a single path or a list of paths.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>