### PR TITLE
src/test_report.py: drop redundant report log message

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -53,7 +53,6 @@ class TestReport:
             email_msg['To'] = send_to
         email_msg['From'] = send_from
         email_msg['Subject'] = email_subject
-        self._logger.log_message(logging.INFO, email_content)
         return email_msg
 
     def _smtp_connect(self):


### PR DESCRIPTION
Drop a redundant log message showing the email contents in _create_email() as it's already done in the main loop.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>