### PR TITLE
HACK extend complete-hack timeout to 30min

### DIFF
--- a/src/complete_hack.py
+++ b/src/complete_hack.py
@@ -33,7 +33,9 @@ class CompleteHack:
         now = datetime.utcnow()
         created = datetime.fromisoformat(self._pending_node['created'])
         expires = created + timedelta(minutes=10)
+        print(f"Expires: {expires.strftime('%Y-%M-%d %H:%M:%S')}")
         if now > expires:
+            print(f"Done: {self._pending_node['_id']}")
             self._pending_node['state'] = "done"
             self._db.submit({'node': self._pending_node})
             self._pending_node = None
@@ -50,6 +52,9 @@ class CompleteHack:
             while True:
                 if not self._pending_node:
                     self._pending_node = self._db.receive_node(sub_id)
+                    self._logger.log_message(
+                        logging.INFO, f"Pending: {self._pending_node['_id']}"
+                    )
                 else:
                     time.sleep(5)
                     self._check_pending_node()

--- a/src/complete_hack.py
+++ b/src/complete_hack.py
@@ -32,7 +32,7 @@ class CompleteHack:
     def _check_pending_node(self):
         now = datetime.utcnow()
         created = datetime.fromisoformat(self._pending_node['created'])
-        expires = created + timedelta(minutes=10)
+        expires = created + timedelta(minutes=30)
         print(f"Expires: {expires.strftime('%Y-%M-%d %H:%M:%S')}")
         if now > expires:
             print(f"Done: {self._pending_node['_id']}")

--- a/src/complete_hack.py
+++ b/src/complete_hack.py
@@ -36,17 +36,14 @@ class CompleteHack:
         if now > expires:
             self._pending_node['state'] = "done"
             self._db.submit({'node': self._pending_node})
-            checkout_node = self._db.get_node(self._pending_node['parent'])
-            checkout_node['state'] = "done"
-            self._db.submit({'node': checkout_node})
             self._pending_node = None
 
     def run(self):
         sub_id = self._db.subscribe_node_channel({
-            'op': 'created',
-            'name': 'tarball',
+            'name': 'checkout',
+            'state': 'available',
         })
-        self._logger.log_message(logging.INFO, "Listening for new tarballs")
+        self._logger.log_message(logging.INFO, "Listening for new checkouts")
         self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
 
         try:
@@ -66,7 +63,7 @@ class CompleteHack:
 
 
 class cmd_run(Command):
-    help = "Hack to set tarball nodes to done state"
+    help = "Hack to set checkout nodes to done state"
     args = [Args.db_config]
     opt_args = [Args.verbose]
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -37,14 +37,14 @@ class Runner:
             os.makedirs(self._output)
         self._verbose = args.verbose
 
-    def _create_node(self, tarball_node, plan_config):
+    def _create_node(self, checkout_node, plan_config):
         node = {
-            'parent': tarball_node['_id'],
+            'parent': checkout_node['_id'],
             'name': plan_config.name,
-            'path': tarball_node['path'] + [plan_config.name],
+            'path': checkout_node['path'] + [plan_config.name],
             'group': plan_config.name,
-            'artifacts': tarball_node['artifacts'],
-            'revision': tarball_node['revision'],
+            'artifacts': checkout_node['artifacts'],
+            'revision': checkout_node['revision'],
         }
         return self._db.submit({'node': node})[0]
 
@@ -72,13 +72,13 @@ class Runner:
         self._logger.log_message(logging.INFO, f"output_file: {output_file}")
         return output_file
 
-    def _schedule_test(self, tarball_node, plan, device):
+    def _schedule_test(self, checkout_node, plan, device):
         self._logger.log_message(logging.INFO, "Tarball: {}".format(
-            tarball_node['artifacts']['tarball']
+            checkout_node['artifacts']['tarball']
         ))
 
         self._logger.log_message(logging.INFO, "Creating test node")
-        node = self._create_node(tarball_node, plan)
+        node = self._create_node(checkout_node, plan)
 
         tmp = tempfile.TemporaryDirectory(dir=self._output)
         output_file = self._generate_job(node, plan, device, tmp.name)
@@ -107,8 +107,8 @@ class RunnerLoop(Runner):
 
     def loop(self):
         sub_id = self._db.subscribe_node_channel(filters={
-            'op': 'created',
-            'name': 'tarball',
+            'name': 'checkout',
+            'state': 'available',
         })
         self._logger.log_message(logging.INFO,
                                  "Listening for complete checkout events")
@@ -126,9 +126,9 @@ class RunnerLoop(Runner):
 
         try:
             while True:
-                tarball_node = self._db.receive_node(sub_id)
+                checkout_node = self._db.receive_node(sub_id)
                 job, tmp = self._schedule_test(
-                    tarball_node, self._plan, device
+                    checkout_node, self._plan, device
                 )
                 if self._runtime.config.lab_type == 'shell':
                     self._job_tmp_dirs[job] = tmp
@@ -146,9 +146,9 @@ class RunnerLoop(Runner):
 class RunnerSingleJob(Runner):
     """Runner subclass to execute a single job"""
 
-    def _run_single_job(self, tarball_node, plan, device):
+    def _run_single_job(self, checkout_node, plan, device):
         try:
-            job, tmp = self._schedule_test(tarball_node, plan, device)
+            job, tmp = self._schedule_test(checkout_node, plan, device)
             if self._runtime.config.lab_type == 'shell':
                 self._logger.log_message(logging.INFO, "Waiting...")
                 job.wait()
@@ -168,19 +168,19 @@ class RunnerSingleJob(Runner):
 
     def run(self, args):
         if args.node_id:
-            tarball_node = self._db.get_node(args.node_id)
+            checkout_node = self._db.get_node(args.node_id)
         elif args.git_commit:
-            tarball_node = self._get_node_from_commit(args.git_commit)
+            checkout_node = self._get_node_from_commit(args.git_commit)
         else:
-            tarball_node = None
+            checkout_node = None
 
-        if tarball_node is None:
+        if checkout_node is None:
             self._logger.log_message(logging.ERROR, "Node not found")
             return False
 
         plan_config = self._plan_configs[args.plan]
         device_config = self._device_configs[args.target]
-        return self._run_single_job(tarball_node, plan_config,
+        return self._run_single_job(checkout_node, plan_config,
                                     device_config)
 
 

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -98,23 +98,14 @@ scp \
         os.unlink(tarball_path)
         return tarball
 
-    def _create_tarball_node(self, checkout_node):
-        tarball_node = {
-            'parent': checkout_node['_id'],
-            'name': 'tarball',
-            'path': checkout_node['path'] + ['tarball'],
-            'revision': checkout_node['revision'],
-        }
-        return self._db.submit({'node': tarball_node})[0]
-
-    def _make_tarball_node_available(self, tarball_node, tarball):
-        tarball_node.update({
+    def _make_checkout_node_available(self, checkout_node, tarball):
+        checkout_node.update({
             'state': 'available',
             'artifacts': {
                 'tarball': urllib.parse.urljoin(self._storage_url, tarball),
             },
         })
-        return self._db.submit({'node': tarball_node})
+        return self._db.submit({'node': checkout_node})
 
     def _add_checkout_version(self, node, describe, version):
         node['revision'].update({
@@ -136,10 +127,10 @@ scp \
         sub_id = self._db.subscribe_node_channel(filters={
             'op': 'created',
             'name': 'checkout',
-            'state': 'available',
+            'state': 'running',
         })
         self._logger.log_message(logging.INFO,
-                                 "Listening for new checkout events")
+                                 "Listening for new trigger events")
         self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
 
         try:
@@ -150,7 +141,6 @@ scp \
                 if build_config is None:
                     continue
 
-                tarball_node = self._create_tarball_node(checkout_node)
                 self._update_repo(build_config)
                 describe = kernelci.build.git_describe(
                     build_config.tree.name, self._kdir
@@ -158,7 +148,7 @@ scp \
                 version = self._get_version_from_describe()
                 self._add_checkout_version(checkout_node, describe, version)
                 tarball = self._push_tarball(build_config, describe)
-                self._make_tarball_node_available(tarball_node, tarball)
+                self._make_checkout_node_available(checkout_node, tarball)
         except KeyboardInterrupt:
             self._logger.log_message(logging.INFO, "Stopping.")
         except Exception:

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -128,12 +128,11 @@ class TestReport:
 
     def run(self):
         sub_id = self._db.subscribe_node_channel(filters={
-            'name': 'tarball',
-            'status': 'complete',
+            'name': 'checkout',
+            'state': 'done',
         })
 
-        self._logger.log_message(logging.INFO,
-                                 "Listening for complete tarballs")
+        self._logger.log_message(logging.INFO, "Listening for complete jobs")
         self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
 
         try:

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -30,34 +30,35 @@ def _run_trigger(args, build_config, db, logger):
         "revision.commit": head_commit,
     })
     if node_list:
-        logger.log_message(logging.INFO, f"Node exists with \
-the latest git commit {head_commit}")
         if args.force:
-            logger.log_message(logging.INFO, "Creating new checkout node \
-anyway")
+            logger.log_message(
+                logging.INFO,
+                f"Creating new node with existing commit {head_commit}"
+            )
         else:
+            logger.log_message(
+                logging.INFO,
+                f"Node alread exists with commit {head_commit}"
+            )
             return
-    sys.stdout.flush()
+    else:
+        logger.log_message(
+            logging.INFO,
+            f"Found new revision for {build_config.name}: {head_commit}"
+        )
 
     revision = {
         'tree': build_config.tree.name,
         'url': build_config.tree.url,
         'branch': build_config.branch,
-        'commit': head_commit
+        'commit': head_commit,
     }
-
-    logger.log_message(logging.INFO, f"Sending revision node to API: \
-{revision['commit']}")
-    sys.stdout.flush()
     node = {
         'name': 'checkout',
         'path': ['checkout'],
         'revision': revision,
     }
-    resp_obj = db.submit({'node': node})[0]
-    node_id = resp_obj['_id']
-    logger.log_message(logging.INFO, f"Node id: {node_id}")
-    sys.stdout.flush()
+    db.submit({'node': node})[0]
 
 
 class cmd_run(Command):


### PR DESCRIPTION
As fstests "smoke" tests take about 20min to run, extend the complete-hack timeout to 30min.  That's only until we have proper handling of node timeouts.