### PR TITLE
Trigger all build configs

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -4,7 +4,6 @@ storage_url: http://172.17.0.1:8002/
 verbose: true
 
 [trigger]
-build_config: mainline
 poll_period: 0
 
 [tarball]

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -24,47 +24,10 @@ import requests
 from logger import Logger
 
 
-def _run_trigger(args, build_config, db, logger):
-    head_commit = kernelci.build.get_branch_head(build_config)
-    node_list = db.get_nodes({
-        "revision.commit": head_commit,
-    })
-    if node_list:
-        if args.force:
-            logger.log_message(
-                logging.INFO,
-                f"Creating new node with existing commit {head_commit}"
-            )
-        else:
-            logger.log_message(
-                logging.INFO,
-                f"Node alread exists with commit {head_commit}"
-            )
-            return
-    else:
-        logger.log_message(
-            logging.INFO,
-            f"Found new revision for {build_config.name}: {head_commit}"
-        )
-
-    revision = {
-        'tree': build_config.tree.name,
-        'url': build_config.tree.url,
-        'branch': build_config.branch,
-        'commit': head_commit,
-    }
-    node = {
-        'name': 'checkout',
-        'path': ['checkout'],
-        'revision': revision,
-    }
-    db.submit({'node': node})[0]
-
-
 class cmd_run(Command):
     help = "Submit a new revision to the API based on local git repo"
     args = [
-        Args.build_config, Args.db_config,
+        Args.db_config,
     ]
     opt_args = [
         {
@@ -82,20 +45,71 @@ class cmd_run(Command):
     def __init__(self, sub_parser, name):
         super().__init__(sub_parser, name)
         self._logger = Logger("config/logger.conf", "trigger")
+        self._build_configs = None
+        self._db = None
+
+    def _log_revision(self, message, build_config, head_commit):
+        self._logger.log_message(
+            logging.INFO,
+            f"{message:32s} {build_config.name:32s} {head_commit}"
+        )
+
+    def _run_trigger(self, build_config, force):
+        head_commit = kernelci.build.get_branch_head(build_config)
+        node_list = self._db.get_nodes({
+            "revision.commit": head_commit,
+        })
+
+        if node_list:
+            if force:
+                self._log_revision(
+                    "Resubmitting existing revision", build_config, head_commit
+                )
+            else:
+                self._log_revision(
+                    "Existing revision", build_config, head_commit
+                )
+                return
+        else:
+            self._log_revision(
+                "New revision", build_config, head_commit
+            )
+
+        revision = {
+            'tree': build_config.tree.name,
+            'url': build_config.tree.url,
+            'branch': build_config.branch,
+            'commit': head_commit,
+        }
+        node = {
+            'name': 'checkout',
+            'path': ['checkout'],
+            'revision': revision,
+        }
+        self._db.submit({'node': node})[0]
+
+    def _iterate_build_configs(self, force):
+        for name, config in self._build_configs.items():
+            self._run_trigger(config, force)
 
     def __call__(self, configs, args):
-        build_config = configs['build_configs'][args.build_config]
+        self._build_configs = configs['build_configs']
         db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
-        db = kernelci.db.get_db(db_config, api_token)
+        self._db = kernelci.db.get_db(db_config, api_token)
         poll_period = int(args.poll_period)
 
         while True:
             try:
-                _run_trigger(args, build_config, db, self._logger)
+                self._iterate_build_configs(args.force)
                 if poll_period:
+                    self._logger.log_message(
+                        logging.INFO,
+                        f"Sleeping for {poll_period}s"
+                    )
                     time.sleep(poll_period)
                 else:
+                    self._logger.log_message(logging.INFO, "Not polling.")
                     break
             except KeyboardInterrupt:
                 self._logger.log_message(logging.INFO, "Stopping.")

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -113,8 +113,10 @@ class cmd_run(Command):
                     break
             except KeyboardInterrupt:
                 self._logger.log_message(logging.INFO, "Stopping.")
+                break
             except Exception:
                 self._logger.log_message(logging.ERROR, traceback.format_exc())
+                return False
 
         return True
 


### PR DESCRIPTION
Rather than specifying a single build config, update the trigger service to iterate over all the build configs defined in the YAML configuration.  Adjust log messages accordingly and fix exception handling as we can now run this in a loop with the `--poll` argument and not the `--force` argument.