### PR TITLE
T37834 src/test_report: use `count_nodes` to get group stats

### DIFF
--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -19,7 +19,7 @@ SHA1:     {{ root.revision.commit }}
 {{ '%-15s %s %-8s %s %8d %s %8d'|format(
 group_name, "|",
 group.root.result, "|",
-group.nodes|count, "|",
+group.nodes, "|",
 group.failures|count) }}
 {%- endfor %}
 

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -70,10 +70,13 @@ class TestReport:
             )
             return None
 
-    def _get_group_stats(self, group_nodes):
+    def _get_group_stats(self, parent_id):
         return {
-            'total': len(group_nodes),
-            'failures': sum(node['result'] == 'fail' for node in group_nodes)
+            'total': self._db.count_nodes({"parent": parent_id}),
+            'failures': self._db.count_nodes({
+                "parent": parent_id,
+                "result": "fail"
+            })
         }
 
     def _get_group_data(self, root_node):
@@ -98,11 +101,11 @@ class TestReport:
 
     def _get_results_data(self, root_node):
         group_nodes = self._db.get_nodes({"parent": root_node['_id']})
-        group_stats = self._get_group_stats(group_nodes)
         groups = {
             node['name']: self._get_group_data(node)
             for node in group_nodes
         }
+        group_stats = self._get_group_stats(root_node['_id'])
         return {
             'stats': group_stats,
             'groups': groups,

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -82,20 +82,25 @@ class TestReport:
     def _get_group_data(self, root_node):
         group = root_node['group']
         revision = root_node['revision']
-        group_nodes = self._db.get_nodes({
+        # Get count of group nodes and exclude the root node from it
+        group_nodes = self._db.count_nodes({
             'revision.commit': revision['commit'],
             'revision.tree': revision['tree'],
             'revision.branch': revision['branch'],
             'group': group,
+        })-1
+        failures = self._db.get_nodes({
+            'revision.commit': revision['commit'],
+            'revision.tree': revision['tree'],
+            'revision.branch': revision['branch'],
+            'group': group,
+            'result': 'fail',
         })
-        group_nodes = [
-            node for node in group_nodes if node['_id'] != root_node['_id']
-        ]
         failures = [
-            node for node in group_nodes if node['result'] == 'fail'
+            node for node in failures if node['_id'] != root_node['_id']
         ]
         parent_path_len = len(root_node['path'])
-        for node in group_nodes:
+        for node in failures:
             node['path'] = '.'.join(node['path'][parent_path_len:])
         return {'root': root_node, 'nodes': group_nodes, 'failures': failures}
 


### PR DESCRIPTION
Use `Database.count_nodes` method to request `/count` endpoint to get node group statistics.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>