### PR TITLE
src/fstests: sync with new kernelci.lab generate param name

### DIFF
--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -60,7 +60,7 @@ class FstestsRunner:
                          '/etc/kernelci/runtime',
                          'src/fstests']
             job = self._runtime.generate(
-                params, device_config, self._plan, templates_path=templates
+                params, device_config, self._plan, templates_paths=templates
             )
             output_file = self._runtime.save_file(job, tmp, params)
             job_result = self._runtime.submit(output_file)


### PR DESCRIPTION
kernelci-core commit 186635335aa2bfc3429eaece83de56f1455dd213 changed the 'templates_path' keyword argument of LabAPI.generate() to 'templates_paths'. Update the call to use the new parameter name.

Signed-off-by: Ricardo Cañuelo <ricardo.canuelo@collabora.com>