### PR TITLE
trigger: Get count of nodes to check existing revisions

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -56,7 +56,7 @@ class cmd_run(Command):
 
     def _run_trigger(self, build_config, force):
         head_commit = kernelci.build.get_branch_head(build_config)
-        node_list = self._db.get_nodes({
+        node_list = self._db.count_nodes({
             "revision.commit": head_commit,
         })
 

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -86,7 +86,7 @@ class cmd_run(Command):
             'path': ['checkout'],
             'revision': revision,
         }
-        self._db.submit({'node': node})[0]
+        self._db.submit({'node': node})
 
     def _iterate_build_configs(self, force):
         for name, config in self._build_configs.items():


### PR DESCRIPTION
Follow-up PR of https://github.com/kernelci/kernelci-pipeline/pull/140

src/trigger: use `count_nodes` to get existing revisions
src/trigger: drop further extraction from response of `db.submit`