### PR TITLE
T36848 Set `Node.result` of timed out nodes and skipped tests

### DIFF
--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -66,7 +66,7 @@ class Job(BaseJob):
         tree = {}
         for test_case in root.iter('testcase'):
             if test_case.find('skipped') is not None:
-                result = None
+                result = 'skip'
             elif test_case.find('failure') is not None:
                 result = 'fail'
             else:

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -44,6 +44,8 @@ class cmd_run(Command):
         result_map = {
             "pass": "Pass",
             "fail": "Fail",
+            "skip": "Skipped",
+            "incomplete": "Incomplete",
             None: "-",
         }
 


### PR DESCRIPTION
- fstests: update node result of skipped tests
- src/notifier: add `skip` and `incomplete` results
- src/timeout: set timed out node result
Implement method `_set_node_result` to set node result of timed-out nodes. If the node is in 'running' state, set the
node result to 'incomplete'.
When the timed-out node is not in 'running' state, set the node result to 'fail' if one of the child nodes failed. Otherwise, set the result to 'pass'.