### PR TITLE
GCE VM sharding

### DIFF
--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -8,7 +8,9 @@
 XFSTESTS_BLD_PATH = '{{xfstests_bld_path}}'
 # TBD: For production, set the appropriate njobs number by default
 NJOBS             = '{{njobs if njobs is not none else 1}}'
-TESTCASE          = '{{testcase if testcase is not none else "smoke"}}'
+TESTCASE          = '{{testcase if testcase is not none else ""}}'
+TESTCFG           = '{{testcfg if testcfg is not none else ""}}'
+TESTGROUP         = '{{testgroup if testgroup is not none else ""}}'
 SKIP_BUILD        = '{{True if skip_build is not none else ""}}'
 GCE               = '{{True if gce is not none else ""}}'
 GCE_PROJECT       = '{{gce_project if gce_project is not none else ""}}'
@@ -142,12 +144,16 @@ class Xfstests(ABC):
         return api_data
 
     @abstractmethod
-    def run(self, kdir, testcase=''):
+    def run(self, kdir, testcase='', group=False, testcfg=''):
         """Runs the specified xfstests testcase using the kernel built in KDIR.
 
         Args:
             kdir (str): directory containing a built Linux kernel
-            testcase (str): xfstest suite to run
+            testcase (str): xfstests to run (single test or
+                comma-separated list)
+            group (bool): true if the testcase argument refers to a test group
+            testcfg (str): xfstests config to run (single config or
+                comma-separated list)
 
         Returns:
             bool: True for success, False otherwise
@@ -168,9 +174,13 @@ class Xfstests(ABC):
 
 
 class KvmXfstests(Xfstests):
-    def run(self, kdir, testcase=''):
+    def run(self, kdir, testcase='', group=False, testcfg=''):
         cmd = ['kvm-xfstests']
-        if testcase:
+        if testcfg:
+            cmd.extend(['-c', testcfg])
+        if group:
+            cmd.extend(['-g', testcase])
+        else:
             cmd.append(testcase)
         try:
             os.chdir(kdir)
@@ -233,12 +243,16 @@ class GceXfstests(Xfstests):
         except KeyboardInterrupt:
             return None
 
-    def run(self, kdir, testcase=''):
+    def run(self, kdir, testcase='', group=False, testcfg=''):
         # Currently uses gce-xfstests to run a single VM
         # TBD: Either use gce-xfstests LTM or use gcloud directly and
         # manage the concurrent VMs ourselves
         cmd = ['gce-xfstests']
-        if testcase:
+        if testcfg:
+            cmd.extend(['-c', testcfg])
+        if group:
+            cmd.extend(['-g', testcase])
+        else:
             cmd.append(testcase)
         try:
             os.chdir(kdir)
@@ -296,6 +310,12 @@ class Job(BaseJob):
 
     # TBD: Implement
     def _check_parameters(self):
+        if TESTCASE and TESTGROUP:
+            print("Error, can't specify both the testcase and the testgroup.")
+            return False
+        if not TESTCASE and not TESTGROUP:
+            print("Error, no testcase or testgroup specified.")
+            return False
         return True
 
     def _run(self, src_path):
@@ -321,7 +341,11 @@ class Job(BaseJob):
             if not all([test.kernel_config(src_path),
                         test.kernel_build(src_path, NJOBS)]):
                 return fail_results
-        if not test.run(src_path, TESTCASE):
+        if TESTGROUP:
+            test_ok = test.run(src_path, TESTGROUP, True, TESTCFG)
+        else:
+            test_ok = test.run(src_path, TESTCASE, False, TESTCFG)
+        if not test_ok:
             return fail_results
 
         # TBD: Currently retrieves only one XML file (for 4k tests).

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -31,6 +31,9 @@ import traceback
 import time
 import glob
 from abc import ABC, abstractmethod
+import datetime
+import random
+import string
 {%- endblock %}
 
 {% block python_job -%}
@@ -264,34 +267,62 @@ class KvmXfstests(Xfstests):
 
 class GceXfstests(Xfstests):
     def __init__(self):
-        self.vm_id = ''
         self.results_tarball = ''
-        # Check and load the GCE-specific parameters. These are defined
-        # as envvars for gce-xfstests
-        gce_params = {
-            'GCE_PROJECT': GCE_PROJECT,
-            'GCE_ZONE'   : GCE_ZONE,
-            'GS_BUCKET'  : GS_BUCKET,
-        }
+        self.kernelimg = ''
         self.gce_env = os.environ.copy()
-        for param, value in gce_params.items():
-            if value:
-                self.gce_env[param] = value
-            if param not in self.gce_env:
-                raise RuntimeError(f"{param.lower()} option or {param} envvar not defined")
+        self.unpacked_results = ''
+        if GCE_PROJECT:
+            self.gce_env['GCE_PROJECT'] = GCE_PROJECT
+        if GCE_ZONE:
+            self.gce_env['GCE_ZONE'] = GCE_ZONE
+        if GS_BUCKET:
+            self.gce_env['GS_BUCKET'] = GS_BUCKET
+        # Generate a (hopefully) unique name for the VM ID and results file
+        self.uniqstr = '{}-{}'.format(
+            datetime.datetime.now().strftime('%Y%m%d%H%M%S'),
+            ''.join(random.choice(string.ascii_lowercase) for i in range(8)))
 
-    def _wait_for_completion(self, vm_id):
+    def __del__(self):
+        """Clean up local and remote temporary resources."""
+        # Delete resources stored in the GS bucket: kernel image and logs
+        if self.kernelimg:
+            subprocess.run(['gsutil', 'rm', self.kernelimg],
+                           check=True,
+                           env=self.gce_env,
+                           capture_output=True,
+                           encoding='utf-8')
+        if self.results_tarball:
+            subprocess.run(['gsutil', 'rm', self.results_tarball],
+                           check=True,
+                           env=self.gce_env,
+                           capture_output=True,
+                           encoding='utf-8')
+
+        # Delete local temporary files: unpacked results and results tarball.
+        # The tarball should be named something like
+        #     /tmp/results.<timestamp>-<unique-string>.<kernel_version>.tar.xz
+        # The directory containing the unpacked results will be:
+        #     /tmp/results-<timestamp>-<unique-string>
+        if self.unpacked_results:
+            shutil.rmtree(self.unpacked_results)
+            packed_results = self.unpacked_results.replace('-', '.', 1)
+            for f in glob.glob(f'{packed_results}.*'):
+                os.remove(f)
+
+    def _wait_for_completion(self):
         """Checks the existence of a test result tarball for VM_ID in the Google
         Storage bucket specified in the GS_BUCKET parameter. This method
         blocks until the result is generated or until a
-        KeyboardInterrupt is received.  """
-        m = re.search("-(\d{14})", vm_id)
-        tstamp = m.group(1)
+        KeyboardInterrupt is received.
+
+        Returns:
+            (str) The path of the results tarball as a GS link.
+        """
         try:
             while True:
                 result = subprocess.run(
                     ['gsutil', 'ls',
-                     f"gs://{self.gce_env['GS_BUCKET']}/results/results.*-{tstamp}.*"],
+                     f"gs://{self.gce_env['GS_BUCKET']}/results/results.{self.uniqstr}*"],
                     capture_output=True,
                     encoding='utf-8')
                 if result.returncode == 0:
@@ -300,11 +331,45 @@ class GceXfstests(Xfstests):
         except KeyboardInterrupt:
             return None
 
+    def _upload_kernel(self, src_path):
+        """Uploads the kernel binary found in the <src_path> kernel source tree
+        to the GS bucket (self.gce_env['GS_BUCKET']) with a unique file
+        name.
+
+        Args:
+            src_path (str): path of the kernel code tree that contains
+                the kernel image.
+
+        Returns:
+            The location of the uploaded file as a GS link (str) or None
+            in case of failure.
+        """
+        try:
+            os.chdir(src_path)
+        except FileNotFoundError:
+            print(f"Kernel directory not found: {src_path}")
+            return None
+        cmd = ['gce-xfstests', 'upload-kernel']
+        filename = f'kernels/bzImage-{self.uniqstr}'
+        cmd.append(filename)
+        subprocess.run(cmd, check=True,
+                       env=self.gce_env,
+                       capture_output=True,
+                       encoding='utf-8')
+        return f'gs://{self.gce_env["GS_BUCKET"]}/{filename}'
+
     def run(self, kdir, testcase='', group=False, testcfg=''):
-        # Currently uses gce-xfstests to run a single VM
         # TBD: Either use gce-xfstests LTM or use gcloud directly and
         # manage the concurrent VMs ourselves
+        self.kernelimg = self._upload_kernel(kdir)
+        if not self.kernelimg:
+            print((f"Error uploading the kernel image ({kdir}) "
+                   f"to the GS bucket {self.gce_env['GS_BUCKET']}"))
+            return False
         cmd = ['gce-xfstests']
+        cmd.extend(['--kernel', self.kernelimg])
+        vm_id = f'xfstests-{self.uniqstr}'
+        cmd.extend(['--instance-name', vm_id])
         if testcfg:
             cmd.extend(['-c', testcfg])
         if group:
@@ -312,22 +377,11 @@ class GceXfstests(Xfstests):
         else:
             cmd.append(testcase)
         try:
-            os.chdir(kdir)
-        except FileNotFoundError:
-            print(f"Kernel directory not found: {kdir}")
-            return False
-        try:
             result = subprocess.run(cmd, check=True,
                                     env=self.gce_env,
                                     capture_output=True, encoding='utf-8')
-            m = re.search("Launching ([a-zA-Z0-9\-]+) ", result.stdout)
-            if not m:
-                print("Error creating the VM or retrieving the ID.",
-                      f"output: {result.stdout}")
-                return False
-            self.vm_id = m.group(1)
-            print(f"Test started in VM {self.vm_id}. Waiting for it to finish")
-            self.results_tarball = self._wait_for_completion(self.vm_id)
+            print(f"Test started in VM {vm_id}. Waiting for it to finish")
+            self.results_tarball = self._wait_for_completion()
             return True if self.results_tarball else False
         except FileNotFoundError:
             print("Can't find the gce-xfstests script, check $PATH")
@@ -340,6 +394,10 @@ class GceXfstests(Xfstests):
             return False
 
     def get_xml_results(self, path):
+        # Get the results from the GS bucket (defined in the GS_BUCKET
+        # env var) using `gce-xfstests get-results --unpack`.
+        # That will download the results tarball to a temp dir and
+        # decompress it.
         try:
             result = subprocess.run(
                 ['gce-xfstests', 'get-results', '--unpack',
@@ -347,14 +405,16 @@ class GceXfstests(Xfstests):
                 check=True, env=self.gce_env,
                 capture_output=True, encoding='utf-8')
             m = re.match("Unpacked results at (.+)$", result.stdout)
+            self.unpacked_results = m.group(1)
         except subprocess.CalledProcessError as e:
             print("Error running gce-xfstests get-results:", e.stdout)
             return False
         except Exception:
             print("Error parsing gce-xfstests get-results output:", e.stdout)
             return False
+        # Copy the XML result files for all test configs to <path>
         for c in GceXfstests.configs:
-            result_file = os.path.join(m.group(1), 'ext4',
+            result_file = os.path.join(self.unpacked_results, 'ext4',
                                        f'results-{c}', 'results.xml')
             # Will most likely throw a few FileNotFoundError's
             try:
@@ -368,8 +428,15 @@ class GceXfstests(Xfstests):
 class Job(BaseJob):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if os.path.exists(self._workspace):
-            shutil.rmtree(self._workspace)
+        # Use a unique workspace dir for each run
+        uniqstr = '{}-{}'.format(
+            datetime.datetime.now().strftime('%Y%m%d%H%M%S'),
+            ''.join(random.choice(string.ascii_lowercase) for i in range(8)))
+        self._workspace = os.path.join(self._workspace, uniqstr)
+
+    def __del__(self):
+        # Delete the workspace directory
+        shutil.rmtree(self._workspace, ignore_errors=True)
 
     # TBD: Implement
     def _check_parameters(self):

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -9,6 +9,7 @@ GCE               = '{{True if gce is not none else ""}}'
 GCE_PROJECT       = '{{gce_project if gce_project is not none else ""}}'
 GCE_ZONE          = '{{gce_zone if gce_zone is not none else ""}}'
 GS_BUCKET         = '{{gs_bucket if gs_bucket is not none else ""}}'
+MAX_SHARDS        = '{{max_shards if max_shards is not none else NONE}}'
 # TBD: For production, set the appropriate njobs number by default
 NJOBS             = '{{njobs if njobs is not none else 1}}'
 OUTPUT            = '{{output if output is not none else ""}}'
@@ -290,7 +291,8 @@ class GceXfstests(Xfstests):
                'bigalloc_1k'   : 'ext4/results-bigalloc_1k',
     }
 
-    def __init__(self):
+    def __init__(self, max_shards=None):
+        self.max_shards = max_shards
         # List of dicts. Each list element represents a shard (a
         # distinct VM instance). The dict keys are:
         #  - 'id': a unique numeric suffix for each shard in a group, starting from 0
@@ -481,7 +483,7 @@ class GceXfstests(Xfstests):
         if not quotas:
             print("Error retrieving GCE quotas")
             return False
-        max_shards = int(min(quotas['CPUS'],
+        num_shards = int(min(quotas['CPUS'],
                              quotas['IN_USE_ADDRESSES'],
                              quotas['SSD_TOTAL_GB']))
 
@@ -491,14 +493,16 @@ class GceXfstests(Xfstests):
         # and
         # https://github.com/tytso/xfstests-bld/blob/34e81de235cf380d30082779aef5e6f50b9b9548/run-fstests/config.gce#L36
         cpus = self._get_machtype_cpus(self.gce_env['GCE_MACHTYPE'])
-        max_shards = int(min(quotas['IN_USE_ADDRESSES'],
+        num_shards = int(min(quotas['IN_USE_ADDRESSES'],
                              quotas['CPUS'] / cpus,
                              quotas['SSD_TOTAL_GB'] / 100))
-        for n in range(0, max_shards):
+        for n in range(0, num_shards):
             self.shards.append({'id': n})
-        if max_shards < 1:
+        if num_shards < 1:
             print("GCE quota exceeded, can't start a VM")
             return False
+        if self.max_shards != None and self.max_shards < num_shards:
+            num_shards = self.max_shards
 
         # Distribute the test configs into shards. If no test configs
         # are specified, consider all available configs
@@ -506,14 +510,14 @@ class GceXfstests(Xfstests):
             cfgs = self.configs.keys()
         else:
             cfgs = re.split(r',\s*', testcfg)
-        cfgs_per_shard = math.ceil(len(cfgs) / max_shards)
+        cfgs_per_shard = math.ceil(len(cfgs) / num_shards)
         shard_idx = 0
         for c in cfgs:
             if 'configs' in self.shards[shard_idx]:
                 self.shards[shard_idx]['configs'].append(c)
             else:
                 self.shards[shard_idx]['configs'] = [c]
-            shard_idx = (shard_idx + 1) % max_shards
+            shard_idx = (shard_idx + 1) % num_shards
 
         self.kernelimg = self._upload_kernel(kdir)
         if not self.kernelimg:
@@ -624,11 +628,13 @@ class Job(BaseJob):
         if not self._check_parameters():
              return fail_results
 
-        try:
-            test = GceXfstests() if GCE else KvmXfstests()
-        except RuntimeError as e:
-            self._logger.log_message(logging.ERROR, f"Error starting xfstests: {e}")
-            return fail_results
+        if GCE:
+            max_shards = None
+            if MAX_SHARDS:
+                max_shards = int(MAX_SHARDS)
+            test = GceXfstests(max_shards)
+        else:
+            test = KvmXfstests()
 
         # Config and build kernel
         if not SKIP_BUILD:

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -216,10 +216,9 @@ class Xfstests(ABC):
 
 
 class KvmXfstests(Xfstests):
-    def _results_cleanup(self):
-        """Removes all the results.xml files from the results virtual disk
-           (vdg).
-        """
+    def __del__(self):
+        """Clean up temporary resources."""
+        # Remove all the results.xml files from the results virtual disk (vdg)
         for c in KvmXfstests.configs:
             subprocess.run((f'debugfs -wR "rm ext4/results-{c}/results.xml" '
                             f'{XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
@@ -241,7 +240,7 @@ class KvmXfstests(Xfstests):
             print(f"Kernel directory not found: {kdir}")
             return False
         try:
-            self._results_cleanup()
+            #self._results_cleanup()
             result = subprocess.run(cmd, check=True)
             print(f"Test run success.")
             return True

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -34,23 +34,19 @@ from abc import ABC, abstractmethod
 import datetime
 import random
 import string
+import math
+import threading
 {%- endblock %}
 
 {% block python_job -%}
 
-POLL_PERIOD = 10        # seconds
+POLL_PERIOD      = 10                   # seconds
+DEFAULT_MACHTYPE = 'e2-standard-2'
 
 class Xfstests(ABC):
     """Base class (abstract) to handle the setup, running and collection of
     results for xfstests.
     """
-
-    # xfstests fs configs
-    configs = ['4k',           '1k',       'ext3',        'encrypt',
-               'nojournal',    'ext3conv', 'adv',         'dioread_nolock',
-               'data_journal', 'bigalloc', 'bigalloc_1k',
-    ]
-
     def kernel_config(self, kdir):
         """Uses the kvm-xfstests script to configure a kernel for xfstests. The
         kernel source must be already decompressed in KDIR.
@@ -216,11 +212,26 @@ class Xfstests(ABC):
 
 
 class KvmXfstests(Xfstests):
+    # xfstests fs configs (key = config name, value = results path)
+    configs = {'4k'            : 'ext4/results-4k',
+               '1k'            : 'ext4/results-1k',
+               'ext3'          : 'ext4/results-ext3',
+               'encrypt'       : 'ext4/results-encrypt',
+               'nojournal'     : 'ext4/results-nojournal',
+               'ext3conv'      : 'ext4/results-ext3conv',
+               'adv'           : 'ext4/results-adv',
+               'dioread_nolock': 'ext4/results-dioread_nolock',
+               'data_journal'  : 'ext4/results-data_journal',
+               'bigalloc'      : 'ext4/results-bigalloc',
+               'bigalloc_1k'   : 'ext4/results-bigalloc_1k',
+    }
+
     def __del__(self):
         """Clean up temporary resources."""
         # Remove all the results.xml files from the results virtual disk (vdg)
-        for c in KvmXfstests.configs:
-            subprocess.run((f'debugfs -wR "rm ext4/results-{c}/results.xml" '
+        for path in self.configs.values():
+            xml_path = os.path.join(path, 'results.xml')
+            subprocess.run((f'debugfs -wR "rm {xml_path}" '
                             f'{XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
                            shell=True,
                            check=True,
@@ -240,7 +251,6 @@ class KvmXfstests(Xfstests):
             print(f"Kernel directory not found: {kdir}")
             return False
         try:
-            #self._results_cleanup()
             result = subprocess.run(cmd, check=True)
             print(f"Test run success.")
             return True
@@ -250,10 +260,11 @@ class KvmXfstests(Xfstests):
 
     def get_xml_results(self, path):
         try:
-            for c in KvmXfstests.configs:
+            for k, v in self.configs.items():
+                xml_path = os.path.join(v, 'results.xml')
                 result = subprocess.run(
-                    (f'debugfs -R "dump ext4/results-{c}/results.xml '
-                     f'{path}/results-{c}.xml" {XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
+                    (f'debugfs -R "dump {xml_path} '
+                     f'{path}/results-{k}.xml" {XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
                     shell=True,
                     check=True,
                     capture_output=True)
@@ -265,11 +276,36 @@ class KvmXfstests(Xfstests):
 
 
 class GceXfstests(Xfstests):
+    # xfstests fs configs (key = config name, value = results path)
+    configs = {'4k'            : 'ext4/results-4k',
+               '1k'            : 'ext4/results-1k',
+               'ext3'          : 'ext3/results-default',
+               'encrypt'       : 'ext4/results-encrypt',
+               'nojournal'     : 'ext4/results-nojournal',
+               'ext3conv'      : 'ext4/results-ext3conv',
+               'adv'           : 'ext4/results-adv',
+               'dioread_nolock': 'ext4/results-dioread_nolock',
+               'data_journal'  : 'ext4/results-data_journal',
+               'bigalloc'      : 'ext4/results-bigalloc',
+               'bigalloc_1k'   : 'ext4/results-bigalloc_1k',
+    }
+
     def __init__(self):
-        self.results_tarball = ''
+        # List of dicts. Each list element represents a shard (a
+        # distinct VM instance). The dict keys are:
+        #  - 'id': a unique numeric suffix for each shard in a group, starting from 0
+        #  - 'configs': list of fs configs to run in the shard
+        #  - 'results_tarball': GS bucket path of the results tarball
+        #  - 'unpacked_results': local path where the results are unpacked
+        #  - 'thread': thread that polls the VM
+        self.shards = []
         self.kernelimg = ''
+        # NOTE: this script will most likely be launched as a subprocess
+        # (see kernelci-core/kernelci/lab/shell.py), so these variables
+        # should be __exported__ in order to be visible here.
         self.gce_env = os.environ.copy()
-        self.unpacked_results = ''
+        if 'GCE_MACHTYPE' not in self.gce_env:
+            self.gce_env['GCE_MACHTYPE'] = DEFAULT_MACHTYPE
         if GCE_PROJECT:
             self.gce_env['GCE_PROJECT'] = GCE_PROJECT
         if GCE_ZONE:
@@ -283,30 +319,89 @@ class GceXfstests(Xfstests):
 
     def __del__(self):
         """Clean up local and remote temporary resources."""
-        # Delete resources stored in the GS bucket: kernel image and logs
+        # Delete kernel image stored in the GS bucket
         if self.kernelimg:
             subprocess.run(['gsutil', 'rm', self.kernelimg],
                            check=True,
                            env=self.gce_env,
                            capture_output=True,
                            encoding='utf-8')
-        if self.results_tarball:
-            subprocess.run(['gsutil', 'rm', self.results_tarball],
-                           check=True,
-                           env=self.gce_env,
-                           capture_output=True,
-                           encoding='utf-8')
+        for shard in self.shards:
+            # Delete shard logs in the GS bucket
+            if 'results_tarball' in shard:
+                subprocess.run(['gsutil', 'rm', shard['results_tarball']],
+                               check=True,
+                               env=self.gce_env,
+                               capture_output=True,
+                               encoding='utf-8')
+            # Delete local temporary files: unpacked results and results tarball.
+            # The tarball should be named something like
+            #     /tmp/results.<timestamp>-<unique-string>.<kernel_version>.tar.xz
+            # The directory containing the unpacked results will be:
+            #     /tmp/results-<timestamp>-<unique-string>
+            if 'unpacked_results' in shard:
+                shutil.rmtree(shard['unpacked_results'])
+                packed_results = shard['unpacked_results'].replace('-', '.', 1)
+                for f in glob.glob(f'{packed_results}.*'):
+                    os.remove(f)
 
-        # Delete local temporary files: unpacked results and results tarball.
-        # The tarball should be named something like
-        #     /tmp/results.<timestamp>-<unique-string>.<kernel_version>.tar.xz
-        # The directory containing the unpacked results will be:
-        #     /tmp/results-<timestamp>-<unique-string>
-        if self.unpacked_results:
-            shutil.rmtree(self.unpacked_results)
-            packed_results = self.unpacked_results.replace('-', '.', 1)
-            for f in glob.glob(f'{packed_results}.*'):
-                os.remove(f)
+    def _get_quotas(self):
+        """Gets the quotas for the GCE region that contains
+        self.gce_enc['GCE_ZONE'].
+
+        Returns:
+            A dict with keys = resource name, and values = quota,
+            None if failure
+        """
+        quotas = {}
+        # Get the region from the GCE_ZONE: the zone could be named as a
+        # region with an additional suffix
+        region = re.match('(\w+-\w+)', self.gce_env['GCE_ZONE']).group()
+        if not region:
+            print(f"Error: can't get GCE region from zone: {self.gce_env['GCE_ZONE']}")
+            return None
+        result = subprocess.run(
+            ['gcloud', 'compute', 'regions', 'describe', region],
+            check=True,
+            capture_output=True,
+            encoding='utf-8')
+        # Discard output header
+        lines = result.stdout.splitlines()[6:]
+        limit = 0
+        metric = ''
+        for l in lines:
+            m = re.match('\W+(\w+): (.*)', l)
+            if m:
+                if m.group(1) == 'limit':
+                   limit = float(m.group(2))
+                elif m.group(1) == 'metric':
+                   metric = m.group(2)
+                elif m.group(1) == 'usage':
+                   quotas[metric] = limit - float(m.group(2))
+        return quotas
+
+    def _get_machtype_cpus(self, machtype):
+        """Retrieves the number of CPUs for a specific GCE machine type.
+
+        Args:
+            machtype (str): the machine type to query
+
+        Returns:
+            The number of CPUs of the specified machine type (int)
+            None if failure
+        """
+        result = subprocess.run(['gcloud', 'compute', 'machine-types',
+                                 'describe', machtype],
+                                check=True,
+                                env=self.gce_env,
+                                capture_output=True,
+                                encoding='utf-8')
+        m = re.search("guestCpus: (\d+)", result.stdout)
+        if not m:
+            print((f"Error getting the number of CPUs for machine {machtype}: "
+                   f"{result.stdout}"))
+            return None
+        return int(m.group(1))
 
     def _wait_for_completion(self):
         """Checks the existence of a test result tarball for VM_ID in the Google
@@ -317,18 +412,34 @@ class GceXfstests(Xfstests):
         Returns:
             (str) The path of the results tarball as a GS link.
         """
-        try:
-            while True:
-                result = subprocess.run(
-                    ['gsutil', 'ls',
-                     f"gs://{self.gce_env['GS_BUCKET']}/results/results.{self.uniqstr}*"],
-                    capture_output=True,
-                    encoding='utf-8')
-                if result.returncode == 0:
-                    return result.stdout
-                time.sleep(POLL_PERIOD)
-        except KeyboardInterrupt:
-            return None
+        def poll_shard(shard):
+            pattern = f'gs://{self.gce_env["GS_BUCKET"]}/results/results.{self.uniqstr}-{shard["id"]}*'
+            print(f"wait for result: {pattern}")
+            try:
+                while True:
+                    result = subprocess.run(
+                        ['gsutil', 'ls', pattern],
+                        capture_output=True,
+                        encoding='utf-8')
+                    if result.returncode == 0:
+                        shard['results_tarball'] = result.stdout
+                        return
+                    time.sleep(POLL_PERIOD)
+            except KeyboardInterrupt:
+                return
+
+        # Poll all threads in parallel
+        for shard in self.shards:
+            if not 'configs' in shard:
+                break
+            shard['thread'] = threading.Thread(target=poll_shard, args=(shard,))
+            shard['thread'].start()
+        # Wait for all threads to finish
+        for shard in self.shards:
+            if not 'thread' in shard:
+                break
+            shard['thread'].join()
+        return True
 
     def _upload_kernel(self, src_path):
         """Uploads the kernel binary found in the <src_path> kernel source tree
@@ -358,69 +469,118 @@ class GceXfstests(Xfstests):
         return f'gs://{self.gce_env["GS_BUCKET"]}/{filename}'
 
     def run(self, kdir, testcase='', group=False, testcfg=''):
-        # TBD: Either use gce-xfstests LTM or use gcloud directly and
-        # manage the concurrent VMs ourselves
+        # Calculate the number of parallel shards depending on the
+        # region quotas
+        quotas = self._get_quotas()
+        if not quotas:
+            print("Error retrieving GCE quotas")
+            return False
+        max_shards = int(min(quotas['CPUS'],
+                             quotas['IN_USE_ADDRESSES'],
+                             quotas['SSD_TOTAL_GB']))
+
+        # Shard requirements: Every shard needs 2 vCPUs and SSD space of
+        # GCE_MIN_SCR_SIZE (100GB), see
+        # https://github.com/tytso/xfstests-bld/blob/34e81de235cf380d30082779aef5e6f50b9b9548/test-appliance/files/usr/local/lib/gce-server/util/gcp/gcp.go#L124
+        # and
+        # https://github.com/tytso/xfstests-bld/blob/34e81de235cf380d30082779aef5e6f50b9b9548/run-fstests/config.gce#L36
+        cpus = self._get_machtype_cpus(self.gce_env['GCE_MACHTYPE'])
+        max_shards = int(min(quotas['IN_USE_ADDRESSES'],
+                             quotas['CPUS'] / cpus,
+                             quotas['SSD_TOTAL_GB'] / 100))
+        for n in range(0, max_shards):
+            self.shards.append({'id': n})
+        if max_shards < 1:
+            print("GCE quota exceeded, can't start a VM")
+            return False
+
+        # Distribute the test configs into shards. If no test configs
+        # are specified, consider all available configs
+        if not testcfg:
+            cfgs = self.configs.keys()
+        else:
+            cfgs = re.split(r',\s*', testcfg)
+        cfgs_per_shard = math.ceil(len(cfgs) / max_shards)
+        shard_idx = 0
+        for c in cfgs:
+            if 'configs' in self.shards[shard_idx]:
+                self.shards[shard_idx]['configs'].append(c)
+            else:
+                self.shards[shard_idx]['configs'] = [c]
+            shard_idx = (shard_idx + 1) % max_shards
+
         self.kernelimg = self._upload_kernel(kdir)
         if not self.kernelimg:
             print((f"Error uploading the kernel image ({kdir}) "
                    f"to the GS bucket {self.gce_env['GS_BUCKET']}"))
             return False
-        cmd = ['gce-xfstests']
-        cmd.extend(['--kernel', self.kernelimg])
-        vm_id = f'xfstests-{self.uniqstr}'
-        cmd.extend(['--instance-name', vm_id])
-        if testcfg:
-            cmd.extend(['-c', testcfg])
-        if group:
-            cmd.extend(['-g', testcase])
-        else:
-            cmd.append(testcase)
-        try:
-            result = subprocess.run(cmd, check=True,
-                                    env=self.gce_env,
-                                    capture_output=True, encoding='utf-8')
-            print(f"Test started in VM {vm_id}. Waiting for it to finish")
-            self.results_tarball = self._wait_for_completion()
-            return True if self.results_tarball else False
-        except FileNotFoundError:
-            print("Can't find the gce-xfstests script, check $PATH")
-            return False
-        except subprocess.CalledProcessError as e:
-            print("Error running gce-xfstests:", e.stdout)
-            return False
-        except Exception:
-            traceback.print_exc()
-            return False
+
+        for shard in self.shards:
+            if not 'configs' in shard:
+                break
+            cmd = ['gce-xfstests']
+            cmd.extend(['--kernel', self.kernelimg])
+            vm_id = f'xfstests-{self.uniqstr}-{shard["id"]}'
+            cmd.extend(['--instance-name', vm_id])
+            cmd.extend(['-c', ','.join(shard['configs'])])
+            if group:
+                cmd.extend(['-g', testcase])
+            else:
+                cmd.append(testcase)
+            try:
+                result = subprocess.run(cmd, check=True,
+                                        env=self.gce_env,
+                                        capture_output=True, encoding='utf-8')
+                print(f"Test started in VM {vm_id}. Waiting for it to finish")
+            except FileNotFoundError:
+                print("Can't find the gce-xfstests script, check $PATH")
+                return False
+            except subprocess.CalledProcessError as e:
+                print("Error running gce-xfstests:", e.stdout)
+                return False
+            except Exception:
+                traceback.print_exc()
+                return False
+        return self._wait_for_completion()
+
 
     def get_xml_results(self, path):
         # Get the results from the GS bucket (defined in the GS_BUCKET
         # env var) using `gce-xfstests get-results --unpack`.
         # That will download the results tarball to a temp dir and
         # decompress it.
-        try:
-            result = subprocess.run(
-                ['gce-xfstests', 'get-results', '--unpack',
-                 os.path.basename(self.results_tarball)],
-                check=True, env=self.gce_env,
-                capture_output=True, encoding='utf-8')
-            m = re.match("Unpacked results at (.+)$", result.stdout)
-            self.unpacked_results = m.group(1)
-        except subprocess.CalledProcessError as e:
-            print("Error running gce-xfstests get-results:", e.stdout)
-            return False
-        except Exception:
-            print("Error parsing gce-xfstests get-results output:", e.stdout)
-            return False
-        # Copy the XML result files for all test configs to <path>
-        for c in GceXfstests.configs:
-            result_file = os.path.join(self.unpacked_results, 'ext4',
-                                       f'results-{c}', 'results.xml')
-            # Will most likely throw a few FileNotFoundError's
+        for shard in self.shards:
+            if 'results_tarball' not in shard:
+                break
             try:
-                shutil.copy(result_file, os.path.join(path, f'results-{c}.xml'))
-            except FileNotFoundError:
-                continue
-        print(f"XML files extracted to {path}")
+                result = subprocess.run(
+                    ['gce-xfstests', 'get-results', '--unpack',
+                     os.path.basename(shard['results_tarball'])],
+                    check=True, env=self.gce_env,
+                    capture_output=True, encoding='utf-8')
+                m = re.match("Unpacked results at (.+)$", result.stdout)
+                if not m:
+                    print(f"Error unpacking results: {result.stdout}")
+                    return False
+                shard['unpacked_results'] = m.group(1)
+            except subprocess.CalledProcessError as e:
+                print("Error running gce-xfstests get-results:", e.stdout)
+                return False
+            except Exception:
+                traceback.print_exc()
+                return False
+
+            # Copy the XML result files for all test configs to <path>
+            for c in shard['configs']:
+                result_file = os.path.join(shard['unpacked_results'],
+                                           self.configs[c],
+                                           'results.xml')
+                try:
+                    shutil.copy(result_file, os.path.join(path, f'results-{c}.xml'))
+                except FileNotFoundError:
+                    print(f"File not found: {result_file}")
+                    return False
+            print(f"XML files extracted to {path}")
         return True
 
 
@@ -437,7 +597,6 @@ class Job(BaseJob):
         # Delete the workspace directory
         shutil.rmtree(self._workspace, ignore_errors=True)
 
-    # TBD: Implement
     def _check_parameters(self):
         if TESTCASE and TESTGROUP:
             print("Error, can't specify both the testcase and the testgroup.")

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -367,6 +367,11 @@ class GceXfstests(Xfstests):
             encoding='utf-8')
         # Discard output header
         lines = result.stdout.splitlines()[6:]
+        # The quotas output of 'gcloud compute regions describe <region>'
+        # looks like this for each metric:
+        # - limit: <float>
+        #   metric: <string>
+        #   usage: <float>
         limit = 0
         metric = ''
         for l in lines:

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -420,30 +420,31 @@ class GceXfstests(Xfstests):
         def poll_shard(shard):
             pattern = f'gs://{self.gce_env["GS_BUCKET"]}/results/results.{self.uniqstr}-{shard["id"]}*'
             print(f"wait for result: {pattern}")
-            try:
-                while True:
-                    result = subprocess.run(
-                        ['gsutil', 'ls', pattern],
-                        capture_output=True,
-                        encoding='utf-8')
-                    if result.returncode == 0:
-                        shard['results_tarball'] = result.stdout
-                        return
-                    time.sleep(POLL_PERIOD)
-            except KeyboardInterrupt:
-                return
+            while True:
+                result = subprocess.run(
+                    ['gsutil', 'ls', pattern],
+                    capture_output=True,
+                    encoding='utf-8')
+                if result.returncode == 0:
+                    shard['results_tarball'] = result.stdout
+                    return
+                time.sleep(POLL_PERIOD)
 
         # Poll all threads in parallel
         for shard in self.shards:
             if not 'configs' in shard:
                 break
-            shard['thread'] = threading.Thread(target=poll_shard, args=(shard,))
+            shard['thread'] = threading.Thread(target=poll_shard,
+                                               args=(shard,), daemon=True)
             shard['thread'].start()
         # Wait for all threads to finish
-        for shard in self.shards:
-            if not 'thread' in shard:
-                break
-            shard['thread'].join()
+        try:
+            for shard in self.shards:
+                if not 'thread' in shard:
+                    break
+                shard['thread'].join()
+        except KeyboardInterrupt:
+            return False
         return True
 
     def _upload_kernel(self, src_path):

--- a/src/fstests/fstests.jinja2
+++ b/src/fstests/fstests.jinja2
@@ -5,17 +5,18 @@
 
 {%- block python_globals %}
 {{ super() }}
-XFSTESTS_BLD_PATH = '{{xfstests_bld_path}}'
-# TBD: For production, set the appropriate njobs number by default
-NJOBS             = '{{njobs if njobs is not none else 1}}'
-TESTCASE          = '{{testcase if testcase is not none else ""}}'
-TESTCFG           = '{{testcfg if testcfg is not none else ""}}'
-TESTGROUP         = '{{testgroup if testgroup is not none else ""}}'
-SKIP_BUILD        = '{{True if skip_build is not none else ""}}'
 GCE               = '{{True if gce is not none else ""}}'
 GCE_PROJECT       = '{{gce_project if gce_project is not none else ""}}'
 GCE_ZONE          = '{{gce_zone if gce_zone is not none else ""}}'
 GS_BUCKET         = '{{gs_bucket if gs_bucket is not none else ""}}'
+# TBD: For production, set the appropriate njobs number by default
+NJOBS             = '{{njobs if njobs is not none else 1}}'
+OUTPUT            = '{{output if output is not none else ""}}'
+SKIP_BUILD        = '{{True if skip_build is not none else ""}}'
+TESTCASE          = '{{testcase if testcase is not none else ""}}'
+TESTCFG           = '{{testcfg if testcfg is not none else ""}}'
+TESTGROUP         = '{{testgroup if testgroup is not none else ""}}'
+XFSTESTS_BLD_PATH = '{{xfstests_bld_path}}'
 {% endblock %}
 
 {%- block python_imports %}
@@ -28,6 +29,7 @@ import xml.etree.ElementTree as ET
 import re
 import traceback
 import time
+import glob
 from abc import ABC, abstractmethod
 {%- endblock %}
 
@@ -39,6 +41,12 @@ class Xfstests(ABC):
     """Base class (abstract) to handle the setup, running and collection of
     results for xfstests.
     """
+
+    # xfstests fs configs
+    configs = ['4k',           '1k',       'ext3',        'encrypt',
+               'nojournal',    'ext3conv', 'adv',         'dioread_nolock',
+               'data_journal', 'bigalloc', 'bigalloc_1k',
+    ]
 
     def kernel_config(self, kdir):
         """Uses the kvm-xfstests script to configure a kernel for xfstests. The
@@ -78,19 +86,32 @@ class Xfstests(ABC):
             print("Kernel build error:", e)
             return False
 
-    def _parse_xml_results(self, f):
+    def _parse_xml_test_results(self, f, tree):
         """Parses the xfstests XML-formatted test results into an in-memory
-        tree.
+        tree (dict).
 
         Args:
             f (str): path of the XML file to parse
+            tree (dict): dict to save the data to. It may be populated
+                already.
 
         Returns:
-            A dict containing the result tree, None if something failed.
+            A dict containing the result tree.
         """
         xml_file = ET.parse(f)
         root = xml_file.getroot()
-        tree = {}
+
+        # Parse the test config: filesystem type and config, create the
+        # initial tree nodes for them if they don't exist yet
+        testcfg = root.find('properties/property[@name="TESTCFG"]').attrib['value']
+        fs, cfg = testcfg.split('/')
+        if fs in tree:
+            if cfg not in tree[fs]:
+                tree[fs][cfg] = {}
+        else:
+            tree[fs] = {cfg: {}}
+
+        # Parse the test results
         for test_case in root.iter('testcase'):
             if test_case.find('skipped') is not None:
                 result = 'skip'
@@ -98,30 +119,43 @@ class Xfstests(ABC):
                 result = 'fail'
             else:
                 result = 'pass'
-            name = test_case.attrib['name'].split('/')
-            if not name[0] == 'ext4':
-                name.insert(0, 'ext4')
-            current = tree
-            for item in name:
-                if not item in current:
-                    current[item] = {}
-                current = current[item]
-            current['result'] = result
+            suite, test = test_case.attrib['name'].split('/')
+            if not suite in tree[fs][cfg]:
+                tree[fs][cfg][suite] = {}
+            tree[fs][cfg][suite][test] = {
+                'result'   : result,
+                # Save the path of the original XML results file as test
+                # artifacts
+                'artifacts': {'log': f},
+            }
         return tree
 
     def _convert_results_for_api(self, tree, name):
+        """Takes a tree containing the xfstests results and formats it as
+        KernelCI-API nodes.
+
+        Args:
+            tree (dict): xfstests results
+            name (str): name of the result root node
+
+        Returns:
+            A dict containing the KernelCI API nodes ready to be
+            submitted.
+        """
         if 'result' in tree:
             return {
                 'node': {
                     'name': name,
                     'result': tree['result'],
+                    'artifacts': tree.get('artifacts'),
                 },
                 'child_nodes':[]
             }
         else:
             child_nodes = []
             for child_name in tree:
-                child_nodes.append(self._convert_results_for_api(tree[child_name], child_name))
+                child_nodes.append(
+                    self._convert_results_for_api(tree[child_name], child_name))
             return {
                 'node':{
                     'name': name,
@@ -139,8 +173,13 @@ class Xfstests(ABC):
             A dict containing the test results formatted according to the
             KernelCI-API.
         """
-        tree_data = self._parse_xml_results(os.path.join(path, 'results.xml'))
-        api_data = self._convert_results_for_api(tree_data, 'fstests')
+        # Parse the test results
+        test_results = {}
+        for xmlfile in glob.glob(os.path.join(path, 'results-*.xml')):
+            test_results = self._parse_xml_test_results(xmlfile, test_results)
+
+        # Turn them into KernelCI-API data
+        api_data = self._convert_results_for_api(test_results, 'fstests')
         return api_data
 
     @abstractmethod
@@ -174,6 +213,17 @@ class Xfstests(ABC):
 
 
 class KvmXfstests(Xfstests):
+    def _results_cleanup(self):
+        """Removes all the results.xml files from the results virtual disk
+           (vdg).
+        """
+        for c in KvmXfstests.configs:
+            subprocess.run((f'debugfs -wR "rm ext4/results-{c}/results.xml" '
+                            f'{XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
+                           shell=True,
+                           check=True,
+                           capture_output=True)
+
     def run(self, kdir, testcase='', group=False, testcfg=''):
         cmd = ['kvm-xfstests']
         if testcfg:
@@ -188,6 +238,7 @@ class KvmXfstests(Xfstests):
             print(f"Kernel directory not found: {kdir}")
             return False
         try:
+            self._results_cleanup()
             result = subprocess.run(cmd, check=True)
             print(f"Test run success.")
             return True
@@ -197,11 +248,17 @@ class KvmXfstests(Xfstests):
 
     def get_xml_results(self, path):
         try:
-            result = subprocess.run([f'debugfs -R "dump ext4/results-4k/results.xml {path}/results.xml" {XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'], check=True, shell=True)
-            print(f"XML file extracted in {path}.")
+            for c in KvmXfstests.configs:
+                result = subprocess.run(
+                    (f'debugfs -R "dump ext4/results-{c}/results.xml '
+                     f'{path}/results-{c}.xml" {XFSTESTS_BLD_PATH}/run-fstests/disks/vdg'),
+                    shell=True,
+                    check=True,
+                    capture_output=True)
             return True
         except Exception as e:
-            print("XML not found.", e)
+            # TBD: proper error handling
+            traceback.print_exc()
             return False
 
 
@@ -290,15 +347,21 @@ class GceXfstests(Xfstests):
                 check=True, env=self.gce_env,
                 capture_output=True, encoding='utf-8')
             m = re.match("Unpacked results at (.+)$", result.stdout)
-            result_file = os.path.join(m.group(1), 'ext4', 'results-4k', 'results.xml')
-            shutil.copy(result_file, path)
-            print(f"XML file extracted in {path}.")
         except subprocess.CalledProcessError as e:
             print("Error running gce-xfstests get-results:", e.stdout)
             return False
         except Exception:
             print("Error parsing gce-xfstests get-results output:", e.stdout)
             return False
+        for c in GceXfstests.configs:
+            result_file = os.path.join(m.group(1), 'ext4',
+                                       f'results-{c}', 'results.xml')
+            # Will most likely throw a few FileNotFoundError's
+            try:
+                shutil.copy(result_file, os.path.join(path, f'results-{c}.xml'))
+            except FileNotFoundError:
+                continue
+        print(f"XML files extracted to {path}")
         return True
 
 
@@ -348,18 +411,23 @@ class Job(BaseJob):
         if not test_ok:
             return fail_results
 
-        # TBD: Currently retrieves only one XML file (for 4k tests).
-        # extend it to get the results for all the test types
-        if not test.get_xml_results(src_path):
+        # TBD: If no output dir is specified, use the kernel src dir to
+        # store the test artifacts. Find a better default solution
+        if OUTPUT:
+            output = OUTPUT
+        else:
+            output = src_path
+        if not test.get_xml_results(output):
             return fail_results
         try:
-            results = test.parse_results(src_path)
+            results = test.parse_results(output)
+            # TBD: What does 'pass' mean in the root node?
             results['node']['result'] = 'pass'
             results['node']['state'] = 'done'
-            with open(os.path.join(src_path, 'results.json'), 'w') as result_file:
+            with open(os.path.join(output, 'results.json'), 'w') as result_file:
                 result_file.write(json.dumps(results))
         except Exception as e:
-            print(f"Exception raised while parsing results: {e}")
+            traceback.print_exc()
             return fail_results
         return results
 

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -31,6 +31,7 @@ class FstestsRunner:
         self._gce_project = args.gce_project
         self._gce_zone = args.gce_zone
         self._gs_bucket = args.gs_bucket
+        self._max_shards = args.max_shards
         self._njobs = args.j
         self._node_id = args.node_id
         self._plan = configs['test_plans']['fstests']
@@ -65,6 +66,7 @@ class FstestsRunner:
                 'gce_project': self._gce_project,
                 'gce_zone': self._gce_zone,
                 'gs_bucket': self._gs_bucket,
+                'max_shards': self._max_shards,
                 'name': self._plan.name,
                 'njobs': self._njobs,
                 'node_id': node['_id'],
@@ -164,6 +166,10 @@ class cmd_run(Command):
             'name': '--gce',
             'help': "run the tests in a GCE VM instance. If not defined, use KVM locally",
             'action': 'store_true',
+        },
+        {
+            'name': '--max-shards',
+            'help': "maximum number of shards to use for GCE. If not defined it'll use the maximum available",
         },
         {
             'name': '--skip-build',

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -36,6 +36,8 @@ class FstestsRunner:
         self._src_dir = args.src_dir
         self._output = args.output
         self._testcase = args.testcase
+        self._testcfg = args.testcfg
+        self._testgroup = args.testgroup
         self._xfstests_bld_path = args.xfstests_bld_path
         if not os.path.exists(self._output):
             os.makedirs(self._output)
@@ -70,6 +72,8 @@ class FstestsRunner:
                 'src_dir': self._src_dir,
                 'tarball_url': node['artifacts']['tarball'],
                 'testcase': self._testcase,
+                'testcfg': self._testcfg,
+                'testgroup': self._testgroup,
                 'workspace': tmp,
                 'xfstests_bld_path' : self._xfstests_bld_path
             }
@@ -160,7 +164,15 @@ class cmd_run(Command):
         },
         {
             'name': '--testcase',
-            'help': "xfstests testcase to run. If not defined it'll run a smoke test"
+            'help': "xfstests testcase to run. It can be a single config or a comma separated list"
+        },
+        {
+            'name': '--testcfg',
+            'help': "xfstests test configuration. It can be a single config or a comma separated list"
+        },
+        {
+            'name': '--testgroup',
+            'help': "xfstests test group to run"
         },
     ]
 

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -8,6 +8,8 @@
 import os
 import sys
 import tempfile
+import datetime
+import traceback
 
 import kernelci
 import kernelci.config
@@ -74,7 +76,7 @@ class FstestsRunner:
                 'testcase': self._testcase,
                 'testcfg': self._testcfg,
                 'testgroup': self._testgroup,
-                'workspace': tmp,
+                'output': tmp,
                 'xfstests_bld_path' : self._xfstests_bld_path
             }
             params.update(self._plan.params)
@@ -84,18 +86,23 @@ class FstestsRunner:
             output_file = self._runtime.save_file(job, tmp, params)
             job_result = self._runtime.submit(output_file)
         except Exception as e:
-            print(e)
+            # TBD: proper error handling
+            traceback.print_exc()
         return job_result
 
     def _run_single_job(self, tarball_node, device):
+        tstamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S-')
         try:
-            tmp = tempfile.TemporaryDirectory(dir=self._output)
-            job = self._schedule_job(tarball_node, device, tmp.name)
+            tmp = tempfile.mkdtemp(prefix=tstamp, dir=self._output)
+            job = self._schedule_job(tarball_node, device, tmp)
             print("Waiting...")
             job.wait()
             print("...done")
         except KeyboardInterrupt as e:
             print("Aborting.")
+        except Exception as e:
+            # TBD: proper error handling
+            traceback.print_exc()
         finally:
             return True
 
@@ -112,7 +119,8 @@ class FstestsRunner:
         except KeyboardInterrupt as e:
             print('Stopping.')
         except Exception as e:
-            print('Error', e)
+            # TBD: proper error handling
+            traceback.print_exc()
         finally:
             self._db.unsubscribe(sub_id)
 


### PR DESCRIPTION
This changeset implements automatic sharding for test runs deployed to GCE, as well as a few other enhancements and fixes:

- new command-line parameters: `-g` to specify the test group(s) to run and `-c` to specify the fs configs per test
- extend the collection of results to properly report the results for all combinations of test configs
- fixing and improvement of artifacts cleanup
- automatic VM sharding, including querying of GCE project quotas. By default, the code will try to split the test configurations in as many different VM instances as possible. The `--max-shards` lets the user specify the maximum number of shards to use