### PR TITLE
T38987 send_kcidb: mount volume for submission credentials file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,7 +83,10 @@ services:
       - '/home/kernelci/pipeline/send_kcidb.py'
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
-    volumes: *base-volumes
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+      - './data/kcidb:/home/kernelci/data/kcidb'
 
   test_report:
     <<: *base-service


### PR DESCRIPTION
docker-compose: mount volume for kcidb  submission credentials
    
Need to mount `/data/kcidb` volume containing google application credentials file.