### PR TITLE
Add Service.log_* helpers and align test_report and timeout

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -7,7 +7,6 @@
 
 import logging
 import os
-import traceback
 
 import kernelci
 import kernelci.db
@@ -24,6 +23,10 @@ class Service:
         self._db_config = configs['db_configs'][args.db_config]
         api_token = os.getenv('API_TOKEN')
         self._db = kernelci.db.get_db(self._db_config, api_token)
+
+    @property
+    def log(self):
+        return self._logger
 
     def _setup(self, args):
         """Set up the service
@@ -64,9 +67,9 @@ class Service:
             context = self._setup(args)
             status = self._run(context)
         except KeyboardInterrupt:
-            self._logger.log_message(logging.INFO, "Stopping.")
+            self.log.info("Stopping.")
         except Exception:
-            self._logger.log_message(logging.ERROR, traceback.format_exc())
+            self.log.traceback()
             status = False
         finally:
             self._stop(context)

--- a/src/logger.py
+++ b/src/logger.py
@@ -9,6 +9,7 @@
 
 import logging
 import logging.config
+import traceback
 
 
 class Logger:
@@ -27,3 +28,21 @@ class Logger:
     def log_message(self, log_level, msg):
         """Creates a log record with provided log level and message"""
         self._logger.log(log_level, msg)
+
+    def debug(self, msg):
+        self.log_message(logging.DEBUG, msg)
+
+    def info(self, msg):
+        self.log_message(logging.INFO, msg)
+
+    def warning(self, msg):
+        self.log_message(logging.WARNING, msg)
+
+    def error(self, msg):
+        self.log_message(logging.ERROR, msg)
+
+    def critical(self, msg):
+        self.log_message(logging.CRITICAL, msg)
+
+    def traceback(self):
+        self.error(traceback.format_exc())

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -51,9 +51,9 @@ class Notifier(Service):
             None: "-",
         }
 
-        self._logger.log_message(logging.INFO, "Listening for events... ")
-        self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
-        self._logger.log_message(logging.INFO, log_fmt.format(
+        self.log.info("Listening for events... ")
+        self.log.info("Press Ctrl-C to stop.")
+        self.log.info(log_fmt.format(
             time="Time", commit="Commit", id="Node Id", state="State",
             result="Result", name="Name"
         ))
@@ -63,7 +63,7 @@ class Notifier(Service):
             event = self._db.get_event(sub_id)
             dt = datetime.datetime.fromisoformat(event['time'])
             obj = self._db.get_node_from_event(event)
-            self._logger.log_message(logging.INFO, log_fmt.format(
+            self.log.info(log_fmt.format(
                 time=dt.strftime('%Y-%m-%d %H:%M:%S.%f'),
                 commit=obj['revision']['commit'][:12],
                 id=obj['_id'],

--- a/src/runner.py
+++ b/src/runner.py
@@ -45,8 +45,8 @@ class Runner(Service):
         return self._db.submit({'node': node})[0]
 
     def _generate_job(self, node, plan_config, device_config, tmp):
-        self._logger.log_message(logging.INFO, "Generating job")
-        self._logger.log_message(logging.INFO, f"tmp: {tmp}")
+        self.log.info("Generating job")
+        self.log.info(f"tmp: {tmp}")
         revision = node['revision']
         params = {
             'db_config_yaml': self._db_config_yaml,
@@ -65,21 +65,21 @@ class Runner(Service):
             params, device_config, plan_config, templates_paths=templates
         )
         output_file = self._runtime.save_file(job, tmp, params)
-        self._logger.log_message(logging.INFO, f"output_file: {output_file}")
+        self.log.info(f"output_file: {output_file}")
         return output_file
 
     def _schedule_test(self, checkout_node, plan, device):
-        self._logger.log_message(logging.INFO, "Tarball: {}".format(
+        self.log.info("Tarball: {}".format(
             checkout_node['artifacts']['tarball']
         ))
 
-        self._logger.log_message(logging.INFO, "Creating test node")
+        self.log.info("Creating test node")
         node = self._create_node(checkout_node, plan)
 
         tmp = tempfile.TemporaryDirectory(dir=self._output)
         output_file = self._generate_job(node, plan, device, tmp.name)
 
-        self._logger.log_message(logging.INFO, "Running test")
+        self.log.info("Running test")
         job = self._runtime.submit(output_file)
         return job, tmp
 
@@ -113,18 +113,14 @@ class RunnerLoop(Runner):
         self._cleanup_paths()
 
     def _run(self, sub_id):
-        self._logger.log_message(logging.INFO,
-                                 "Listening for complete checkout events")
-        self._logger.log_message(logging.INFO,
-                                 "Press Ctrl-C to stop.")
+        self.log.info("Listening for complete checkout events")
+        self.log.info("Press Ctrl-C to stop.")
 
         # ToDo: iterate over device types for the current runtime
         device_type = self._runtime.config.lab_type
         device = self._device_configs.get(device_type)
         if device is None:
-            self._logger.log_message(
-                logging.ERROR, "Device type not found: {device_type}"
-            )
+            self.log.error("Device type not found: {device_type}")
             return False
 
         while True:
@@ -168,9 +164,9 @@ class RunnerSingleJob(Runner):
         node, plan, device = (ctx[key] for key in ('node', 'plan', 'device'))
         job, tmp = self._schedule_test(node, plan, device)
         if self._runtime.config.lab_type == 'shell':
-            self._logger.log_message(logging.INFO, "Waiting...")
+            self.log.info("Waiting...")
             job.wait()
-            self._logger.log_message(logging.INFO, "...done")
+            self.log.info("...done")
         return True
 
 

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -53,31 +53,30 @@ class Tarball(Service):
                 return config
 
     def _update_repo(self, config):
-        self._logger.log_message(logging.INFO,
-                                 f"Updating repo for {config.name}")
+        self.log.info(f"Updating repo for {config.name}")
         kernelci.build.update_repo(config, self._kdir)
-        self._logger.log_message(logging.INFO, "Repo updated")
+        self.log.info("Repo updated")
 
     def _make_tarball(self, config, describe):
         name = '-'.join(['linux', config.tree.name, config.branch, describe])
         tarball = f"{name}.tar.gz"
-        self._logger.log_message(logging.INFO, f"Making tarball {tarball}")
+        self.log.info(f"Making tarball {tarball}")
         output_path = os.path.relpath(self._output, self._kdir)
         cmd = """\
 set -e
 cd {kdir}
 git archive --format=tar --prefix={name}/ HEAD | gzip > {output}/{tarball}
 """.format(kdir=self._kdir, name=name, output=output_path, tarball=tarball)
-        self._logger.log_message(logging.INFO, cmd)
+        self.log.info(cmd)
         kernelci.shell_cmd(cmd)
-        self._logger.log_message(logging.INFO, "Tarball created")
+        self.log.info("Tarball created")
         return tarball
 
     def _push_tarball(self, config, describe):
         # ToDo: kernelci.build.make_tarball()
         tarball = self._make_tarball(config, describe)
         tarball_path = os.path.join(self._output, tarball)
-        self._logger.log_message(logging.INFO, f"Uploading {tarball_path}")
+        self.log.info(f"Uploading {tarball_path}")
         # ToDo: self._storage.upload()
         cmd = """\
 scp \
@@ -90,7 +89,7 @@ scp \
 """.format(key=self._ssh_key, port=self._ssh_port, user=self._ssh_user,
            host=self._ssh_host, tarball=tarball_path)
         kernelci.shell_cmd(cmd)
-        self._logger.log_message(logging.INFO, "Upload complete")
+        self.log.info("Upload complete")
         os.unlink(tarball_path)
         return tarball
 
@@ -130,9 +129,8 @@ scp \
             self._db.unsubscribe(sub_id)
 
     def _run(self, sub_id):
-        self._logger.log_message(logging.INFO,
-                                 "Listening for new trigger events")
-        self._logger.log_message(logging.INFO, "Press Ctrl-C to stop.")
+        self.log.info("Listening for new trigger events")
+        self.log.info("Press Ctrl-C to stop.")
 
         while True:
             checkout_node = self._db.receive_node(sub_id)

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -29,10 +29,7 @@ class Trigger(Service):
         self._build_configs = configs['build_configs']
 
     def _log_revision(self, message, build_config, head_commit):
-        self._logger.log_message(
-            logging.INFO,
-            f"{message:32s} {build_config.name:32s} {head_commit}"
-        )
+        self.log.info(f"{message:32s} {build_config.name:32s} {head_commit}")
 
     def _run_trigger(self, build_config, force):
         head_commit = kernelci.build.get_branch_head(build_config)
@@ -89,21 +86,16 @@ class Trigger(Service):
         )
 
         if startup_delay:
-            self._logger.log_message(
-                logging.INFO, f"Delay: {startup_delay}s"
-            )
+            self.log.info(f"Delay: {startup_delay}s")
             time.sleep(startup_delay)
 
         while True:
             self._iterate_build_configs(force, build_configs_list)
             if poll_period:
-                self._logger.log_message(
-                    logging.INFO,
-                    f"Sleeping for {poll_period}s"
-                )
+                self.log.info(f"Sleeping for {poll_period}s")
                 time.sleep(poll_period)
             else:
-                self._logger.log_message(logging.INFO, "Not polling.")
+                self.log.info("Not polling.")
                 break
 
         return True


### PR DESCRIPTION
Add `Service.log_*()` helper methods to simplify the syntax for log messages.  Update all services using the `Service` class accordingly.

Update `test_report.py` and `timeout.py` to use the `Service` class and align them with the other services.

Depends on #177