### PR TITLE
src/trigger.py: drop Context object

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -73,16 +73,14 @@ class Trigger(Service):
             self._run_trigger(config, force)
 
     def _setup(self, args):
-        ctx = Service.Context()
-        ctx.data.update({
+        return {
             'poll_period': int(args.poll_period),
             'force': args.force,
-        })
-        return ctx
+        }
 
     def _run(self, ctx):
         poll_period, force = (
-            ctx.data[key] for key in ('poll_period', 'force')
+            ctx[key] for key in ('poll_period', 'force')
         )
         while True:
             self._iterate_build_configs(force)


### PR DESCRIPTION
The Context object was in a previous implementation which got reverted.  Fix this by returning a plain dictionary instead.

Fixes: ae0529889d08 ("src/trigger.py: use args in context rather than in constructor")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>