### PR TITLE
Rework the timeout service(s)

### DIFF
--- a/config/logger.conf
+++ b/config/logger.conf
@@ -12,6 +12,7 @@ keys=root,
      tarball,
      test_report,
      timeout,
+     timeout-closing,
      timeout-holdoff,
      trigger
 
@@ -75,6 +76,12 @@ propagate=0
 level=DEBUG
 handlers=consoleHandler
 qualname=timeout
+propagate=0
+
+[logger_timeout-closing]
+level=DEBUG
+handlers=consoleHandler
+qualname=timeout-closing
 propagate=0
 
 [logger_timeout-holdoff]

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -12,6 +12,7 @@ keys=root,
      tarball,
      test_report,
      timeout,
+     timeout-holdoff,
      trigger
 
 [handlers]
@@ -74,6 +75,12 @@ propagate=0
 level=DEBUG
 handlers=consoleHandler
 qualname=timeout
+propagate=0
+
+[logger_timeout-holdoff]
+level=DEBUG
+handlers=consoleHandler
+qualname=timeout-holdoff
 propagate=0
 
 [logger_trigger]

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -4,13 +4,31 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 [loggers]
-keys=root, notifier, runner, regression_tracker, send_kcidb, tarball, test_report, trigger, timeout
+keys=root,
+     notifier,
+     regression_tracker,
+     runner,
+     send_kcidb,
+     tarball,
+     test_report,
+     timeout,
+     trigger
 
 [handlers]
 keys=consoleHandler
 
 [formatters]
 keys=defaultFormatter
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=defaultFormatter
+args=(sys.stdout,)
+
+[formatter_defaultFormatter]
+format=%(asctime)s [%(levelname)s] %(message)s
+datefmt=%m/%d/%Y %I:%M:%S %p %Z
 
 [logger_root]
 level=INFO
@@ -20,6 +38,12 @@ handlers=consoleHandler
 level=DEBUG
 handlers=consoleHandler
 qualname=notifier
+propagate=0
+
+[logger_regression_tracker]
+level=DEBUG
+handlers=consoleHandler
+qualname=regression_tracker
 propagate=0
 
 [logger_runner]
@@ -46,30 +70,14 @@ handlers=consoleHandler
 qualname=test_report
 propagate=0
 
-[logger_trigger]
-level=DEBUG
-handlers=consoleHandler
-qualname=trigger
-propagate=0
-
 [logger_timeout]
 level=DEBUG
 handlers=consoleHandler
 qualname=timeout
 propagate=0
 
-[logger_regression_tracker]
+[logger_trigger]
 level=DEBUG
 handlers=consoleHandler
-qualname=regression_tracker
+qualname=trigger
 propagate=0
-
-[handler_consoleHandler]
-class=StreamHandler
-level=DEBUG
-formatter=defaultFormatter
-args=(sys.stdout,)
-
-[formatter_defaultFormatter]
-format=%(asctime)s [%(levelname)s] %(message)s
-datefmt=%m/%d/%Y %I:%M:%S %p %Z

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,16 @@ services:
       - './config:/home/kernelci/config'
       - './data/kcidb:/home/kernelci/data/kcidb'
 
+  regression_tracker:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-regression_tracker'
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/regression_tracker.py'
+      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
+      - 'run'
+
   test_report:
     <<: *base-service
     container_name: 'kernelci-pipeline-test_report'
@@ -108,13 +118,4 @@ services:
       - '/home/kernelci/pipeline/timeout.py'
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
-
-  regression_tracker:
-    <<: *base-service
-    container_name: 'kernelci-pipeline-regression_tracker'
-    command:
-      - '/usr/bin/env'
-      - 'python3'
-      - '/home/kernelci/pipeline/regression_tracker.py'
-      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
-      - 'run'
+      - '--mode=timeout'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,3 +119,14 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
       - '--mode=timeout'
+
+  timeout-holdoff:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-holdoff'
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/timeout.py'
+      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
+      - 'run'
+      - '--mode=holdoff'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,6 +120,17 @@ services:
       - 'run'
       - '--mode=timeout'
 
+  timeout-closing:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-closing'
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/timeout.py'
+      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
+      - 'run'
+      - '--mode=closing'
+
   timeout-holdoff:
     <<: *base-service
     container_name: 'kernelci-pipeline-holdoff'

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -6,6 +6,7 @@
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
+from datetime import datetime, timedelta
 import json
 import logging
 import sys
@@ -58,10 +59,12 @@ class Trigger(Service):
             'branch': build_config.branch,
             'commit': head_commit,
         }
+        timeout = datetime.utcnow() + timedelta(hours=1)
         node = {
             'name': 'checkout',
             'path': ['checkout'],
             'revision': revision,
+            'timeout': timeout.isoformat(),
         }
         self._db.submit({'node': node})
 


### PR DESCRIPTION
Rework the implementation of the timeout / holdoff / closing services to address the following issues:
* retrieve only the nodes in the state relevant to the code, e.g. nodes in the 'done' state aren't needed for the timeout service
* split the implementation into different classes which run in different services to have better separation of the logic: Timeout for the main timeout, Holdoff for the holdoff timeout and Closing for nodes waiting in the Closing state
* avoid resubmitting the same nodes multiple times by first creating a set of nodes to update and then send them to the API
* work out the shortest time to sleep until next timeout / holdoff to allow longer polling periods and update nodes closer to the timeout / holdoff time
