### PR TITLE
src/trigger.py: fix issue with empty --build-configs

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -74,7 +74,7 @@ class Trigger(Service):
         return {
             'poll_period': int(args.poll_period),
             'force': args.force,
-            'build_configs_list': args.build_configs.split() or [],
+            'build_configs_list': (args.build_configs or '').split(),
             'startup_delay': int(args.startup_delay or 0),
         }
 


### PR DESCRIPTION
Fix the case where no --build-configs optional argument is provided using an empty string instead of None which can't be split.

Fixes: 81387ab4786d ("src/trigger.py: add --build-configs optional argument")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>