### PR TITLE
HACK tarball holdoff set to 1min

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -113,7 +113,7 @@ scp \
             'artifacts': {
                 'tarball': urllib.parse.urljoin(self._storage_url, tarball),
             },
-            'holdoff': str(datetime.utcnow() + timedelta(minutes=10))
+            'holdoff': str(datetime.utcnow() + timedelta(minutes=1))
         })
         return self._db.submit({'node': node})
 


### PR DESCRIPTION
This is to cover the scenario where the tarball node enters Closing state while some tests are still running.