### PR TITLE
T39465 Optimize timeout service with comparison operators

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -96,7 +96,10 @@ class Holdoff(TimeoutService):
         super().__init__(configs, args, 'timeout-holdoff')
 
     def _get_available_nodes(self):
-        nodes = self._db.get_nodes({'state': 'available'})
+        nodes = self._db.get_nodes({
+            'state': 'available',
+            'holdoff__lt': datetime.isoformat(datetime.utcnow()),
+        })
         return {node['_id']: node for node in nodes}
 
     def _check_available_nodes(self, available_nodes):

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -26,7 +26,11 @@ class TimeoutService(Service):
 
     def __init__(self, configs, args, name):
         super().__init__(configs, args, name)
-        self._poll_period = args.poll_period
+
+    def _setup(self, args):
+        return {
+            'poll_period': args.poll_period,
+        }
 
     def _get_pending_nodes(self, filters=None):
         nodes = {}
@@ -85,7 +89,7 @@ class Timeout(TimeoutService):
                 'timeout__lt': datetime.isoformat(datetime.utcnow())
             })
             self._check_pending_nodes(pending_nodes)
-            sleep(self._poll_period)
+            sleep(ctx['poll_period'])
 
         return True
 
@@ -127,7 +131,7 @@ class Holdoff(TimeoutService):
         while True:
             available_nodes = self._get_available_nodes()
             self._check_available_nodes(available_nodes)
-            sleep(self._poll_period)
+            sleep(ctx['poll_period'])
 
         return True
 
@@ -157,7 +161,7 @@ class Closing(TimeoutService):
         while True:
             closing_nodes = self._get_closing_nodes()
             self._check_closing_nodes(closing_nodes)
-            sleep(self._poll_period)
+            sleep(ctx['poll_period'])
 
         return True
 
@@ -186,7 +190,7 @@ class cmd_run(Command):
     ]
 
     def __call__(self, configs, args):
-        return MODES[args.mode](configs, args).run()
+        return MODES[args.mode](configs, args).run(args)
 
 
 if __name__ == '__main__':

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -70,19 +70,11 @@ class Timeout(TimeoutService):
         super().__init__(configs, args, 'timeout')
 
     def _check_pending_nodes(self, pending_nodes):
-        now = datetime.utcnow()
-        sleep = timedelta(seconds=self._poll_period)
         timeout_nodes = {}
         for node_id, node in pending_nodes.items():
-            timeout = datetime.fromisoformat(node['timeout'])
-            if now > timeout:
-                timeout_nodes[node_id] = node
-                timeout_nodes.update(self._get_child_nodes_recursive(node))
-            else:
-                self.log.debug(f"{node_id} timeout left: {timeout - now}")
-                sleep = min(sleep, timeout - now)
+            timeout_nodes[node_id] = node
+            timeout_nodes.update(self._get_child_nodes_recursive(node))
         self._submit_lapsed_nodes(timeout_nodes, 'done', 'TIMEOUT')
-        return sleep.total_seconds()
 
     def _run(self, ctx):
         self.log.info("Looking for nodes with lapsed timeout...")
@@ -92,8 +84,8 @@ class Timeout(TimeoutService):
             pending_nodes = self._get_pending_nodes({
                 'timeout__lt': datetime.isoformat(datetime.utcnow())
             })
-            sleep_time = self._check_pending_nodes(pending_nodes)
-            sleep(sleep_time)
+            self._check_pending_nodes(pending_nodes)
+            sleep(self._poll_period)
 
         return True
 

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -89,7 +89,9 @@ class Timeout(TimeoutService):
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            pending_nodes = self._get_pending_nodes()
+            pending_nodes = self._get_pending_nodes({
+                'timeout__lt': datetime.isoformat(datetime.utcnow())
+            })
             sleep_time = self._check_pending_nodes(pending_nodes)
             sleep(sleep_time)
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/192

- src/timeout: use `timeout__lt` filter to get timed-out nodes
- src/timeout: use `holdoff__lt` filter to get nodes with lapsed holdoff
- src/timeout: drop logic to check pending and available nodes
- src/timeout: add `_setup` method to `TimeoutService`