### PR TITLE
T39644 Implement job class

### DIFF
--- a/src/job.py
+++ b/src/job.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+
+"""KernelCI Job module"""
+
+import os
+import tempfile
+import json
+import requests
+
+import kernelci
+
+
+class Job():
+    """Implements methods for creating and scheduling jobs"""
+    def __init__(self, db_handler, db_config_yaml, lab_config, output):
+        self._db = db_handler
+        self._db_config_yaml = db_config_yaml
+        self._runtime = kernelci.lab.get_api(lab_config)
+        self._output = output
+        self._create_output_dir()
+
+    def _create_output_dir(self):
+        """Create output directory"""
+        if not os.path.exists(self._output):
+            os.makedirs(self._output)
+
+    def get_device_type(self):
+        """Method to get device type"""
+        return self._runtime.config.lab_type
+
+    def create_node(self, checkout_node, plan_config):
+        """Method to generate node for the job"""
+        node = {
+            'parent': checkout_node['_id'],
+            'name': plan_config.name,
+            'path': checkout_node['path'] + [plan_config.name],
+            'group': plan_config.name,
+            'artifacts': checkout_node['artifacts'],
+            'revision': checkout_node['revision'],
+        }
+        try:
+            return self._db.submit({'node': node})[0], \
+                "Node created successfully"
+        except requests.exceptions.HTTPError as err:
+            err_msg = json.loads(err.response.content).get("detail", [])
+            return None, err_msg
+
+    def _generate_job(self, node, plan_config, device_config, tmp):
+        """Method to generate jobs"""
+        revision = node['revision']
+        params = {
+            'db_config_yaml': self._db_config_yaml,
+            'name': plan_config.name,
+            'node_id': node['_id'],
+            'revision': revision,
+            'runtime': self._runtime.config.lab_type,
+            'runtime_image': plan_config.image,
+            'tarball_url': node['artifacts']['tarball'],
+            'workspace': tmp,
+        }
+        params.update(plan_config.params)
+        params.update(device_config.params)
+        templates = ['config/runtime', '/etc/kernelci/runtime']
+        job = self._runtime.generate(
+            params, device_config, plan_config, templates_paths=templates
+        )
+        output_file = self._runtime.save_file(job, tmp, params)
+        return output_file
+
+    def schedule_job(self, node, plan, device):
+        """Generate and schedule jobs"""
+        tmp = tempfile.TemporaryDirectory(dir=self._output)
+        output_file = self._generate_job(node, plan, device, tmp.name)
+        job = self._runtime.submit(output_file)
+        return job, tmp

--- a/src/runner.py
+++ b/src/runner.py
@@ -118,13 +118,13 @@ class RunnerSingleJob(Runner):
 
     def _run(self, ctx):
         node, plan, device = (ctx[key] for key in ('node', 'plan', 'device'))
-        job, tmp = self._schedule_test(node, plan, device)
+        job, tmp = self._job.schedule_job(node, plan, device)
         if not job:
             self.log.error(
                 f"Failed to schedule job for {plan.name}. Error: {tmp}"
             )
             return False
-        if self._runtime.config.lab_type == 'shell':
+        if self._job.get_device_type() == 'shell':
             self.log.info("Waiting...")
             job.wait()
             self.log.info("...done")

--- a/src/runner.py
+++ b/src/runner.py
@@ -7,11 +7,7 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 import logging
-import os
 import sys
-import tempfile
-import json
-import requests
 
 import kernelci
 import kernelci.config
@@ -29,11 +25,6 @@ class Runner(Service):
         self._db_config_yaml = self._db_config.to_yaml()
         self._plan_configs = configs['test_plans']
         self._device_configs = configs['device_types']
-        runtime_config = configs['labs'][args.lab_config]
-        self._runtime = kernelci.lab.get_api(runtime_config)
-        self._output = args.output
-        if not os.path.exists(self._output):
-            os.makedirs(self._output)
         self._verbose = args.verbose
         self._job = Job(
             self._db,
@@ -41,63 +32,6 @@ class Runner(Service):
             configs['labs'][args.lab_config],
             args.output
         )
-
-    def _create_node(self, checkout_node, plan_config):
-        node = {
-            'parent': checkout_node['_id'],
-            'name': plan_config.name,
-            'path': checkout_node['path'] + [plan_config.name],
-            'group': plan_config.name,
-            'artifacts': checkout_node['artifacts'],
-            'revision': checkout_node['revision'],
-        }
-        try:
-            return self._db.submit({'node': node})[0], \
-                "Node created successfully"
-        except requests.exceptions.HTTPError as err:
-            err_msg = json.loads(err.response.content).get("detail", [])
-            return None, err_msg
-
-    def _generate_job(self, node, plan_config, device_config, tmp):
-        self.log.info("Generating job")
-        self.log.info(f"tmp: {tmp}")
-        revision = node['revision']
-        params = {
-            'db_config_yaml': self._db_config_yaml,
-            'name': plan_config.name,
-            'node_id': node['_id'],
-            'revision': revision,
-            'runtime': self._runtime.config.lab_type,
-            'runtime_image': plan_config.image,
-            'tarball_url': node['artifacts']['tarball'],
-            'workspace': tmp,
-        }
-        params.update(plan_config.params)
-        params.update(device_config.params)
-        templates = ['config/runtime', '/etc/kernelci/runtime']
-        job = self._runtime.generate(
-            params, device_config, plan_config, templates_paths=templates
-        )
-        output_file = self._runtime.save_file(job, tmp, params)
-        self.log.info(f"output_file: {output_file}")
-        return output_file
-
-    def _schedule_test(self, checkout_node, plan, device):
-        self.log.info("Tarball: {}".format(
-            checkout_node['artifacts']['tarball']
-        ))
-
-        self.log.info("Creating test node")
-        node, msg = self._create_node(checkout_node, plan)
-        if not node:
-            return None, msg
-
-        tmp = tempfile.TemporaryDirectory(dir=self._output)
-        output_file = self._generate_job(node, plan, device, tmp.name)
-
-        self.log.info("Running test")
-        job = self._runtime.submit(output_file)
-        return job, tmp
 
 
 class RunnerLoop(Runner):
@@ -129,11 +63,11 @@ class RunnerLoop(Runner):
         self._cleanup_paths()
 
     def _run(self, sub_id):
-        self.log.info("Listening for complete checkout events")
+        self.log.info("Listening for available checkout events")
         self.log.info("Press Ctrl-C to stop.")
 
         # ToDo: iterate over device types for the current runtime
-        device_type = self._runtime.config.lab_type
+        device_type = self._job.get_device_type()
         device = self._device_configs.get(device_type)
         if device is None:
             self.log.error("Device type not found: {device_type}")
@@ -141,15 +75,17 @@ class RunnerLoop(Runner):
 
         while True:
             checkout_node = self._db.receive_node(sub_id)
-            job, tmp = self._schedule_test(
-                checkout_node, self._plan, device
-            )
+            node, msg = self._job.create_node(checkout_node, self._plan)
+            if not node:
+                self.log.error(f"Failed to create node for \
+{self._plan.name}. Error: {msg}")
+                continue
+            job, tmp = self._job.schedule_job(node, self._plan, device)
             if not job:
                 self.log.error(f"Failed to schedule job for \
 {self._plan.name}. Error: {tmp}")
                 continue
-
-            if self._runtime.config.lab_type == 'shell':
+            if device_type == 'shell':
                 self._job_tmp_dirs[job] = tmp
 
         return True

--- a/src/runner.py
+++ b/src/runner.py
@@ -19,6 +19,7 @@ import kernelci.lab
 from kernelci.cli import Args, Command, parse_opts
 
 from base import Service
+from job import Job
 
 
 class Runner(Service):
@@ -34,6 +35,12 @@ class Runner(Service):
         if not os.path.exists(self._output):
             os.makedirs(self._output)
         self._verbose = args.verbose
+        self._job = Job(
+            self._db,
+            self._db_config_yaml,
+            configs['labs'][args.lab_config],
+            args.output
+        )
 
     def _create_node(self, checkout_node, plan_config):
         node = {


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/183

`Job` class has been implemented in order to separate logic for generating and scheduling various jobs (e.g. tests and builds) from `Runner`.
Instantiate it in the `Runner` and use it in `RunnerLoop` and `RunnerSingleJob` classes.