### PR TITLE
config/pipeline.yaml: Append API version to config URL

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -60,11 +60,11 @@ db_configs:
 
   docker-host:
     db_type: kernelci_api
-    url: http://172.17.0.1:8001
+    url: http://172.17.0.1:8001/latest/
 
   staging.kernelci.org:
     db_type: kernelci_api
-    url: https://staging.kernelci.org:9000
+    url: https://staging.kernelci.org:9000/latest/
 
 
 labs:


### PR DESCRIPTION
Append API version `latest` to the URL for `docker-host` and `staging.kernelci.org` DB configurations.

Signed-off-by: Jeny Sadadia <jeny.sadadia@collabora.com>