### PR TITLE
Use the new api_config in all services

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-db_config: docker-host
+api_config: docker-host
 storage_url: http://172.17.0.1:8002/
 verbose: true
 
@@ -30,9 +30,3 @@ origin: kernelci
 [timeout]
 
 [regression_tracker]
-
-[db:docker-host]
-api: http://172.17.0.1:8001
-
-[db:staging.kernelci.org]
-api: https://staging.kernelci.org:9000

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -56,14 +56,12 @@ build_configs:
     variants: *build-variants
 
 
-db_configs:
+api_configs:
 
   docker-host:
-    db_type: kernelci_api
     url: http://172.17.0.1:8001
 
   staging.kernelci.org:
-    db_type: kernelci_api
     url: https://staging.kernelci.org:9000
 
 

--- a/src/base.py
+++ b/src/base.py
@@ -9,7 +9,7 @@ import logging
 import os
 
 import kernelci
-import kernelci.db
+from kernelci.db import kernelci_api
 
 from logger import Logger
 
@@ -20,9 +20,9 @@ class Service:
     def __init__(self, configs, args, name):
         self._name = name
         self._logger = Logger("config/logger.conf", name)
-        self._db_config = configs['db_configs'][args.db_config]
+        self._api_config = configs['api_configs'][args.api_config]
         api_token = os.getenv('API_TOKEN')
-        self._db = kernelci.db.get_db(self._db_config, api_token)
+        self._api = kernelci_api.KernelCI_API(self._api_config, api_token)
 
     @property
     def log(self):

--- a/src/job.py
+++ b/src/job.py
@@ -17,9 +17,9 @@ import kernelci
 
 class Job():
     """Implements methods for creating and scheduling jobs"""
-    def __init__(self, db_handler, db_config_yaml, lab_config, output):
-        self._db = db_handler
-        self._db_config_yaml = db_config_yaml
+    def __init__(self, api_handler, api_config_yaml, lab_config, output):
+        self._api = api_handler
+        self._api_config_yaml = api_config_yaml
         self._runtime = kernelci.lab.get_api(lab_config)
         self._output = output
         self._create_output_dir()
@@ -44,7 +44,7 @@ class Job():
             'revision': checkout_node['revision'],
         }
         try:
-            return self._db.submit({'node': node})[0], \
+            return self._api.submit({'node': node})[0], \
                 "Node created successfully"
         except requests.exceptions.HTTPError as err:
             err_msg = json.loads(err.response.content).get("detail", [])
@@ -54,7 +54,7 @@ class Job():
         """Method to generate jobs"""
         revision = node['revision']
         params = {
-            'db_config_yaml': self._db_config_yaml,
+            'api_config_yaml': self._api_config_yaml,
             'name': plan_config.name,
             'node_id': node['_id'],
             'revision': revision,

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -24,11 +24,11 @@ class Notifier(Service):
         super().__init__(configs, args, 'notifier')
 
     def _setup(self, args):
-        return self._db.subscribe('node')
+        return self._api.subscribe('node')
 
     def _stop(self, sub_id):
         if sub_id:
-            self._db.unsubscribe(sub_id)
+            self._api.unsubscribe(sub_id)
         sys.stdout.flush()
 
     def _run(self, sub_id):
@@ -60,9 +60,9 @@ class Notifier(Service):
         sys.stdout.flush()
 
         while True:
-            event = self._db.get_event(sub_id)
+            event = self._api.get_event(sub_id)
             dt = datetime.datetime.fromisoformat(event['time'])
-            obj = self._db.get_node_from_event(event)
+            obj = self._api.get_node_from_event(event)
             self.log.info(log_fmt.format(
                 time=dt.strftime('%Y-%m-%d %H:%M:%S.%f'),
                 commit=obj['revision']['commit'][:12],
@@ -78,7 +78,7 @@ class Notifier(Service):
 
 class cmd_run(Command):
     help = "Listen for events and report them on stdout"
-    args = [Args.db_config]
+    args = [Args.api_config]
 
     def __call__(self, configs, args):
         return Notifier(configs, args).run(args)

--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -25,14 +25,14 @@ class RegressionTracker(Service):
         ]
 
     def _setup(self, args):
-        return self._db.subscribe_node_channel(filters={
+        return self._api.subscribe_node_channel(filters={
             'state': 'done',
             'result': 'fail',
         })
 
     def _stop(self, sub_id):
         if sub_id:
-            self._db.unsubscribe(sub_id)
+            self._api.unsubscribe(sub_id)
 
     def _create_regression(self, failed_node, last_successful_node):
         """Method to create a regression"""
@@ -41,7 +41,7 @@ class RegressionTracker(Service):
             regression[field] = failed_node[field]
         regression['parent'] = failed_node['_id']
         regression['regression_data'] = [last_successful_node, failed_node]
-        self._db.submit({'regression': regression})
+        self._api.submit({'regression': regression})
 
     def _run(self, sub_id):
         """Method to run regression tracking"""
@@ -50,11 +50,11 @@ class RegressionTracker(Service):
         sys.stdout.flush()
 
         while True:
-            node = self._db.receive_node(sub_id)
+            node = self._api.receive_node(sub_id)
             if not node['group']:
                 continue
 
-            previous_nodes = self._db.get_nodes({
+            previous_nodes = self._api.get_nodes({
                 'name': node['name'],
                 'group': node['group'],
                 'revision.tree': node['revision']['tree'],
@@ -83,7 +83,7 @@ class RegressionTracker(Service):
 
 class cmd_run(Command):
     help = "Regression tracker"
-    args = [Args.db_config]
+    args = [Args.api_config]
 
     def __call__(self, configs, args):
         return RegressionTracker(configs, args).run(args)

--- a/src/runner.py
+++ b/src/runner.py
@@ -8,6 +8,7 @@
 
 import logging
 import sys
+import yaml
 
 import kernelci
 import kernelci.config
@@ -22,7 +23,7 @@ class Runner(Service):
 
     def __init__(self, configs, args):
         super().__init__(configs, args, 'runner')
-        self._api_config_yaml = self._api_config.to_yaml()
+        self._api_config_yaml = yaml.dump(self._api_config)
         self._plan_configs = configs['test_plans']
         self._device_configs = configs['device_types']
         self._verbose = args.verbose

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -14,7 +14,6 @@ import datetime
 import sys
 
 import kernelci
-import kernelci.db
 import kernelci.config
 from kernelci.cli import Args, Command, parse_opts
 from kcidb import Client
@@ -33,7 +32,7 @@ class KCIDBBridge(Service):
                 project_id=args.kcidb_project_id,
                 topic_name=args.kcidb_topic_name
             ),
-            'sub_id': self._db.subscribe_node_channel(filters={
+            'sub_id': self._api.subscribe_node_channel(filters={
                 'name': 'checkout',
                 'state': 'done',
             }),
@@ -42,7 +41,7 @@ class KCIDBBridge(Service):
 
     def _stop(self, context):
         if context['sub_id']:
-            self._db.unsubscribe(context['sub_id'])
+            self._api.unsubscribe(context['sub_id'])
 
     def _send_revision(self, client, revision):
         if kcidb.io.SCHEMA.is_valid(revision):
@@ -63,7 +62,7 @@ class KCIDBBridge(Service):
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            node = self._db.receive_node(context['sub_id'])
+            node = self._api.receive_node(context['sub_id'])
             self.log.info(f"Submitting node to KCIDB: {node['_id']}")
 
             revision = {
@@ -96,7 +95,7 @@ class KCIDBBridge(Service):
 class cmd_run(Command):
     help = "Listen for events and send them to KCDIB"
     args = [
-        Args.db_config,
+        Args.api_config,
         {
             'name': '--kcidb-topic-name',
             'help': "KCIDB topic name",

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -118,13 +118,13 @@ scp \
             'holdoff': str(datetime.utcnow() + timedelta(minutes=10))
         })
         try:
-            self._db.submit({'node': node})
+            self._api.submit({'node': node})
         except requests.exceptions.HTTPError as err:
             err_msg = json.loads(err.response.content).get("detail", [])
             self.log.error(err_msg)
 
     def _setup(self, args):
-        return self._db.subscribe_node_channel(filters={
+        return self._api.subscribe_node_channel(filters={
             'op': 'created',
             'name': 'checkout',
             'state': 'running',
@@ -132,14 +132,14 @@ scp \
 
     def _stop(self, sub_id):
         if sub_id:
-            self._db.unsubscribe(sub_id)
+            self._api.unsubscribe(sub_id)
 
     def _run(self, sub_id):
         self.log.info("Listening for new trigger events")
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            checkout_node = self._db.receive_node(sub_id)
+            checkout_node = self._api.receive_node(sub_id)
 
             build_config = self._find_build_config(checkout_node)
             if build_config is None:
@@ -159,7 +159,7 @@ scp \
 class cmd_run(Command):
     help = "Wait for a new revision event and push a source tarball"
     args = [
-        Args.kdir, Args.output, Args.db_config,
+        Args.kdir, Args.output, Args.api_config,
         {
             'name': '--ssh-key',
             'help': "Path to the ssh key for uploading to storage",

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -34,7 +34,7 @@ class Trigger(Service):
 
     def _run_trigger(self, build_config, force):
         head_commit = kernelci.build.get_branch_head(build_config)
-        node_list = self._db.count_nodes({
+        node_list = self._api.count_nodes({
             "revision.commit": head_commit,
         })
 
@@ -66,7 +66,7 @@ class Trigger(Service):
             'revision': revision,
             'timeout': timeout.isoformat(),
         }
-        self._db.submit({'node': node})
+        self._api.submit({'node': node})
 
     def _iterate_build_configs(self, force, build_configs_list):
         for name, config in self._build_configs.items():
@@ -107,7 +107,7 @@ class Trigger(Service):
 class cmd_run(Command):
     help = "Submit a new revision to the API based on local git repo"
     args = [
-        Args.db_config,
+        Args.api_config,
     ]
     opt_args = [
         {


### PR DESCRIPTION
Replace the now-deprecated db_config with the new api_config which is pending to be merged in kernelci-core with https://github.com/kernelci/kernelci-core/pull/1650

Update all the services accordingly.  This is to start transitioning away from the old Database abstraction layer class in kernelci-core into supporting only the KernelCI API.
