### PR TITLE
Use runtime configuration

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -65,7 +65,7 @@ api_configs:
     url: https://staging.kernelci.org:9000
 
 
-labs:
+runtimes:
 
   k8s-gke-eu-west4:
     lab_type: kubernetes

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - './pipeline/runner.py'
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
-      - '--lab-config=shell'
+      - '--runtime-config=shell'
       - '--plan=kver'
     volumes:
       - './src:/home/kernelci/pipeline'
@@ -48,7 +48,7 @@ services:
       - './pipeline/runner.py'
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
-      - '--lab-config=k8s-gke-eu-west4'
+      - '--runtime-config=k8s-gke-eu-west4'
       - '--plan=kunit'
 
   tarball:

--- a/src/job.py
+++ b/src/job.py
@@ -17,10 +17,10 @@ import kernelci
 
 class Job():
     """Implements methods for creating and scheduling jobs"""
-    def __init__(self, api_handler, api_config_yaml, lab_config, output):
+    def __init__(self, api_handler, api_config_yaml, runtime_config, output):
         self._api = api_handler
         self._api_config_yaml = api_config_yaml
-        self._runtime = kernelci.lab.get_api(lab_config)
+        self._runtime = kernelci.lab.get_api(runtime_config)
         self._output = output
         self._create_output_dir()
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -30,7 +30,7 @@ class Runner(Service):
         self._job = Job(
             self._api,
             self._api_config_yaml,
-            configs['labs'][args.runtime_config],
+            configs['runtimes'][args.runtime_config],
             args.output
         )
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -30,7 +30,7 @@ class Runner(Service):
         self._job = Job(
             self._api,
             self._api_config_yaml,
-            configs['labs'][args.lab_config],
+            configs['labs'][args.runtime_config],
             args.output
         )
 
@@ -134,7 +134,7 @@ class RunnerSingleJob(Runner):
 
 class cmd_loop(Command):
     help = "Listen to pub/sub events and run in a loop"
-    args = [Args.api_config, Args.lab_config, Args.output]
+    args = [Args.api_config, Args.runtime_config, Args.output]
     opt_args = [Args.verbose, Args.plan]
 
     def __call__(self, configs, args):
@@ -144,7 +144,7 @@ class cmd_loop(Command):
 class cmd_run(Command):
     help = "Run one arbitrary test and exit"
     args = [
-        Args.api_config, Args.lab_config, Args.output,
+        Args.api_config, Args.runtime_config, Args.output,
         Args.plan, Args.target,
     ]
     opt_args = [


### PR DESCRIPTION
Update the pipeline YAML configuration and `runner.py` to use the new `runtimes` configuration.

Depends on https://github.com/kernelci/kernelci-core/pull/1737
Fixes #207 