### PR TITLE
tarball: use new `kernelci.storage` package

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -10,10 +10,7 @@ startup_delay: 3
 [tarball]
 kdir: /home/kernelci/data/src/linux
 output: /home/kernelci/data/output
-ssh_key: /home/kernelci/data/ssh/id_rsa_tarball
-ssh_port: 8022
-ssh_user: kernelci
-ssh_host: 172.17.0.1
+storage_config: docker-host
 
 [runner]
 output: /home/kernelci/output
@@ -30,3 +27,6 @@ origin: kernelci
 [timeout]
 
 [regression_tracker]
+
+[storage:docker-host]
+storage_cred: /home/kernelci/data/ssh/id_rsa_tarball

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -65,6 +65,21 @@ api_configs:
     url: https://staging.kernelci.org:9000
 
 
+storage_configs:
+
+  docker-host:
+    storage_type: ssh
+    host: 172.17.0.1
+    port: 8022
+    base_url: http://172.17.0.1:8002/
+
+  staging.kernelci.org:
+    storage_type: ssh
+    host: staging.kernelci.org
+    port: 9022
+    base_url: http://staging.kernelci.org:9080/
+
+
 runtimes:
 
   k8s-gke-eu-west4:


### PR DESCRIPTION
Use the new `kernelci.storage` package in `tarball.py` instead of hard-coding SSH commands.