### PR TITLE
src/{runner,job}.py: use kernelci.runtime

### DIFF
--- a/src/job.py
+++ b/src/job.py
@@ -20,7 +20,7 @@ class Job():
     def __init__(self, api_handler, api_config_yaml, runtime_config, output):
         self._api = api_handler
         self._api_config_yaml = api_config_yaml
-        self._runtime = kernelci.lab.get_api(runtime_config)
+        self._runtime = kernelci.runtime.get_runtime(runtime_config)
         self._output = output
         self._create_output_dir()
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -12,7 +12,7 @@ import yaml
 
 import kernelci
 import kernelci.config
-import kernelci.lab
+import kernelci.runtime
 from kernelci.cli import Args, Command, parse_opts
 
 from base import Service


### PR DESCRIPTION
Update src/runner.py and src/job.py to use kernelci.runtime rather than kernelci.lab.

Fixes #207