### PR TITLE
src/base.py: use kernelci.api.get_api()

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -9,7 +9,6 @@ import logging
 import os
 
 import kernelci
-from kernelci.db import kernelci_api
 
 from logger import Logger
 
@@ -22,7 +21,7 @@ class Service:
         self._logger = Logger("config/logger.conf", name)
         self._api_config = configs['api_configs'][args.api_config]
         api_token = os.getenv('API_TOKEN')
-        self._api = kernelci_api.KernelCI_API(self._api_config, api_token)
+        self._api = kernelci.api.get_api(self._api_config, api_token)
 
     @property
     def log(self):


### PR DESCRIPTION
Use the new kernelci.api.get_api() loader to get an API object rather than the kernelci.db one which is now deprecated.