### PR TITLE
src/job.py: drop the templates_paths argument

### DIFF
--- a/src/job.py
+++ b/src/job.py
@@ -65,10 +65,7 @@ class Job():
         }
         params.update(plan_config.params)
         params.update(device_config.params)
-        templates = ['config/runtime', '/etc/kernelci/runtime']
-        job = self._runtime.generate(
-            params, device_config, plan_config, templates_paths=templates
-        )
+        job = self._runtime.generate(params, device_config, plan_config)
         output_file = self._runtime.save_file(job, tmp, params)
         return output_file
 


### PR DESCRIPTION
The templates_paths argument has been dropped from Runtime.generate() as the templates are now all located in the config/runtime directory. Update the code in src/job.py accordingly.

Depends on https://github.com/kernelci/kernelci-core/pull/1777