### PR TITLE
Update `kunit.jinaj2` to use new API and split job in 3 steps

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -45,21 +45,49 @@ class Job(BaseJob):
             'child_nodes': child_nodes,
         }
 
-    def _parse_exec_results(self, src_path, kunit_json):
-        kunit_json_path = os.path.join(src_path, kunit_json)
+    def _parse_exec_results(self, kunit_json_path):
         print(f"Parsing results from {kunit_json_path}")
-        with open(kunit_json_path) as results_json:
+        with open(kunit_json_path, encoding='utf-8') as results_json:
             results_raw = json.load(results_json)
-        results = self._parse_results(results_raw)
-        return results
+        return self._parse_results(results_raw)
 
-    def _run_kunit(self, src_path, kunit_json, command):
-        cmd = f"(cd {src_path} && ./tools/testing/kunit/kunit.py {command})"
+    def _run_kunit(self, src_path, command, job_log):
+        cmd = f"""(\
+set -e
+cd {src_path}
+./tools/testing/kunit/kunit.py {command} >> {job_log} 2>&1
+)"""
         ret = subprocess.run(cmd, shell=True).returncode
-        return True if ret == 0 else False
+        return ret == 0
+
+    def _upload_artifacts(self, local_artifacts):
+        artifacts = {}
+        storage = self._get_storage()
+        if storage and NODE_ID:
+            root_path = '-'.join(['kunit', NODE_ID])
+            print(f"Uploading artifacts to {root_path}")
+            for file_name, file_path in local_artifacts.items():
+                if os.path.exists(file_path):
+                    file_url = storage.upload_single(
+                        (file_path, file_name), root_path
+                    )
+                    print(file_url)
+                    artifacts[file_name] = file_url
+        return artifacts
 
     def _run(self, src_path):
+        job_log = 'job.txt'
         kunit_json = 'kunit.json'
+        job_log_path, kunit_json_path = (
+            os.path.join(src_path, file_name)
+            for file_name in [job_log, kunit_json]
+        )
+        local_artifacts = {
+            job_log: job_log_path,
+            kunit_json: kunit_json_path,
+            'test.log': os.path.join(src_path, '.kunit/test.log')
+        }
+
         steps = {
             'config': 'config',
             'build': 'build --jobs=$(nproc)',
@@ -68,19 +96,28 @@ class Job(BaseJob):
         step_results = {name: (None, []) for name in steps.keys()}
 
         for name, command in steps.items():
-            res = self._run_kunit(src_path, kunit_json, command)
+            res = self._run_kunit(src_path, command, job_log)
             res_str = 'pass' if res is True else 'fail'
             step_results[name] = (res_str, [])
             if res is False:
                 break
 
+        artifacts = self._upload_artifacts(local_artifacts)
+
+        if os.path.exists(job_log_path):
+            with open(job_log_path, encoding='utf-8') as job_log_file:
+                print("--------------------------------------------------")
+                print(job_log_file.read())
+                print("--------------------------------------------------")
+
         if step_results['exec'][0] == 'pass':
-            exec_results = self._parse_exec_results(src_path, kunit_json)
+            exec_results = self._parse_exec_results(kunit_json_path)
             step_results['exec'] = ('pass', exec_results['child_nodes'])
 
         results = {
             'node': {
                 'result': step_results['exec'][0] or 'fail',
+                'artifacts': artifacts,
             },
             'child_nodes': [
                 {
@@ -92,9 +129,6 @@ class Job(BaseJob):
                 } for name, (result, child_nodes) in step_results.items()
             ]
         }
-
-        # ToDo: send {src_path}/.kunit/test.log as artifact
-        # ToDo: send {src_path}/kunit.json as artifact
 
         return results
 

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -45,28 +45,56 @@ class Job(BaseJob):
             'child_nodes': child_nodes,
         }
 
-    def _run(self, src_path):
-        kunit_json = 'kunit.json'
-
-        print("Running KUnit...")
-        cmd = f"\
-cd {src_path} && \
-./tools/testing/kunit/kunit.py run --json={kunit_json} --jobs=$(nproc)"
-        kunit_res = subprocess.run(cmd, shell=True).returncode
-
-        # ToDo: send {src_path}/.kunit/test.log as artifact
-        # ToDo: send {src_path}/kunit.json as artifact
-
+    def _parse_exec_results(self, src_path, kunit_json):
         kunit_json_path = os.path.join(src_path, kunit_json)
         print(f"Parsing results from {kunit_json_path}")
         with open(kunit_json_path) as results_json:
             results_raw = json.load(results_json)
         results = self._parse_results(results_raw)
-        results['node']['result'] = 'fail' if kunit_res else 'pass'
-        results_path = os.path.join(src_path, 'results.json')
-        print(f"Saving results file {results_path}")
-        with open(os.path.join(src_path, 'results.json'), 'w') as results_file:
-            json.dump(results, results_file, indent='  ')
+        return results
+
+    def _run_kunit(self, src_path, kunit_json, command):
+        cmd = f"(cd {src_path} && ./tools/testing/kunit/kunit.py {command})"
+        ret = subprocess.run(cmd, shell=True).returncode
+        return True if ret == 0 else False
+
+    def _run(self, src_path):
+        kunit_json = 'kunit.json'
+        steps = {
+            'config': 'config',
+            'build': 'build --jobs=$(nproc)',
+            'exec': f'exec --json={kunit_json}',
+        }
+        step_results = {name: (None, []) for name in steps.keys()}
+
+        for name, command in steps.items():
+            res = self._run_kunit(src_path, kunit_json, command)
+            res_str = 'pass' if res is True else 'fail'
+            step_results[name] = (res_str, [])
+            if res is False:
+                break
+
+        if step_results['exec'][0] == 'pass':
+            exec_results = self._parse_exec_results(src_path, kunit_json)
+            step_results['exec'] = ('pass', exec_results['child_nodes'])
+
+        results = {
+            'node': {
+                'result': step_results['exec'][0] or 'fail',
+            },
+            'child_nodes': [
+                {
+                    'node': {
+                        'name': name,
+                        'result': result,
+                    },
+                    'child_nodes': child_nodes,
+                } for name, (result, child_nodes) in step_results.items()
+            ]
+        }
+
+        # ToDo: send {src_path}/.kunit/test.log as artifact
+        # ToDo: send {src_path}/kunit.json as artifact
 
         return results
 

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -9,6 +9,11 @@ import json
 import subprocess
 {%- endblock %}
 
+{%- block python_local_imports %}
+{{ super() }}
+import kernelci.api.helper
+{%- endblock %}
+
 {%- block python_globals %}
 {{ super() }}
 RESULT_MAP = {
@@ -65,10 +70,11 @@ cd {src_path} && \
 
         return results
 
-    def _submit(self, results, node_id, db):
+    def _submit(self, results, node_id, api):
         # Ensure top-level name is kept the same
-        node = db.get_node(node_id)
+        node = api.get_node(node_id)
         results['node']['name'] = node['name']
-        db.submit_results(results, node)
+        api_helper = kernelci.api.helper.APIHelper(api)
+        api_helper.submit_results(results, node)
         return node
 {% endblock %}

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -98,11 +98,12 @@ class Job(BaseJob):
 
         return results
 
-    def _submit(self, results, node_id, api):
+    def _submit(self, result, node_id, api):
         # Ensure top-level name is kept the same
         node = api.get_node(node_id)
-        results['node']['name'] = node['name']
+        result['node']['name'] = node['name']
         api_helper = kernelci.api.helper.APIHelper(api)
-        api_helper.submit_results(results, node)
+        api_helper.submit_results(result, node)
+
         return node
 {% endblock %}


### PR DESCRIPTION
Update the `kunit.jinja2` job template to use the new `API` and `APIHelper` classes.  Also improve how the results are sent by splitting the job into 3 steps: `config`, `build` and `exec`.  This is to avoid losing results when e.g. the build fails.