### PR TITLE
src/timeout: fix `base.Service` import

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -16,7 +16,7 @@ import kernelci.config
 import kernelci.db
 from kernelci.cli import Args, Command, parse_opts
 
-from .base import Service
+from base import Service
 
 
 class TimeoutService(Service):


### PR DESCRIPTION
Fix the below import error for `from .base import Service` in timeout service:
`ImportError: attempted relative import with no known parent package`.