### PR TITLE
Use storage config in runner service

### DIFF
--- a/config/kernelci.conf
+++ b/config/kernelci.conf
@@ -1,6 +1,6 @@
 [DEFAULT]
 api_config: docker-host
-storage_url: http://172.17.0.1:8002/
+storage_config: docker-host
 verbose: true
 
 [trigger]

--- a/src/job.py
+++ b/src/job.py
@@ -17,10 +17,12 @@ import kernelci
 
 class Job():
     """Implements methods for creating and scheduling jobs"""
-    def __init__(self, api_helper, api_config_yaml, runtime_config, output):
+    def __init__(self, api_helper, api_config_yaml, runtime_config,
+                 storage, output):
         self._helper = api_helper
         self._api_config_yaml = api_config_yaml
         self._runtime = kernelci.runtime.get_runtime(runtime_config)
+        self._storage = storage
         self._output = output
         self._create_output_dir()
 
@@ -60,7 +62,8 @@ class Job():
     def _generate_job(self, node, plan_config, platform_config, tmp):
         """Method to generate jobs"""
         params = self._runtime.get_params(
-            node, plan_config, platform_config, self._helper.api.config
+            node, plan_config, platform_config, self._helper.api.config,
+            self._storage.config
         )
         job = self._runtime.generate(params, plan_config)
         output_file = self._runtime.save_file(job, tmp, params)

--- a/src/runner.py
+++ b/src/runner.py
@@ -7,12 +7,14 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 import logging
+import os
 import sys
 import yaml
 
 import kernelci
 import kernelci.config
 import kernelci.runtime
+import kernelci.storage
 from kernelci.cli import Args, Command, parse_opts
 
 from base import Service
@@ -27,10 +29,16 @@ class Runner(Service):
         self._plan_configs = configs['test_plans']
         self._device_configs = configs['device_types']
         self._verbose = args.verbose
+        self._storage_config = configs['storage_configs'][args.storage_config]
+        storage_cred = os.getenv('KCI_STORAGE_CREDENTIALS')
+        self._storage = kernelci.storage.get_storage(
+            self._storage_config, storage_cred
+        )
         self._job = Job(
             self._api_helper,
             self._api_config_yaml,
             configs['runtimes'][args.runtime_config],
+            self._storage,
             args.output
         )
 
@@ -149,8 +157,8 @@ class cmd_loop(Command):
 class cmd_run(Command):
     help = "Run one arbitrary test and exit"
     args = [
-        Args.api_config, Args.runtime_config, Args.output,
-        Args.plan, Args.target,
+        Args.api_config, Args.runtime_config, Args.storage_config,
+        Args.output, Args.plan, Args.target,
     ]
     opt_args = [
         Args.verbose,


### PR DESCRIPTION
Use `--storage-config` in the runner service to generate jobs that can upload artifacts to storage.