### PR TITLE
Run `kunit` and `kunit-x86_64`  in Kubernetes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
       - '--runtime-config=shell'
-      - '--plan=kver'
+      - 'kver'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
@@ -49,7 +49,8 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
       - '--runtime-config=k8s-gke-eu-west4'
-      - '--plan=kunit'
+      - 'kunit'
+      - 'kunit-x86_64'
 
   tarball:
     <<: *base-service


### PR DESCRIPTION
As a temporary measure until the YAML configuration can provide a full description of all the jobs to run, rework the `runner.py loop --plan` argument as `--plans` to include a number of test plans and iterate over them when receiving a checkout node.  Update `docker-compose.yaml` accordingly with `kunit kunit-x86_64` for the `runner-k8s` service to run KUnit both on the default UML architecture and on `x86_64`.