### PR TITLE
src/base.py: use KCI_API_TOKEN environment variable

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -21,7 +21,7 @@ class Service:
         self._name = name
         self._logger = Logger("config/logger.conf", name)
         self._api_config = configs['api_configs'][args.api_config]
-        api_token = os.getenv('API_TOKEN')
+        api_token = os.getenv('KCI_API_TOKEN')
         self._api = kernelci.api.get_api(self._api_config, api_token)
         self._api_helper = APIHelper(self._api)
 


### PR DESCRIPTION
Look for the KCI_API_TOKEN environment variable rather than API_TOKEN to align with kernelci-core.

This is to follow a convention of having a KCI_ prefix for all the KernelCI environment variables to avoid name clashes.