### PR TITLE
docker-compose.yaml: disable kcidb bridge service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,21 +92,21 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
 
-  kcidb:
-    container_name: 'kernelci-pipeline-kcidb'
-    build: {context: 'docker-kcidb'}
-    env_file: ['.env']
-    stop_signal: 'SIGINT'
-    command:
-      - '/usr/bin/env'
-      - 'python3'
-      - '/home/kernelci/pipeline/send_kcidb.py'
-      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
-      - 'run'
-    volumes:
-      - './src:/home/kernelci/pipeline'
-      - './config:/home/kernelci/config'
-      - './data/kcidb:/home/kernelci/data/kcidb'
+  # kcidb:
+  #   container_name: 'kernelci-pipeline-kcidb'
+  #   build: {context: 'docker-kcidb'}
+  #   env_file: ['.env']
+  #   stop_signal: 'SIGINT'
+  #   command:
+  #     - '/usr/bin/env'
+  #     - 'python3'
+  #     - '/home/kernelci/pipeline/send_kcidb.py'
+  #     - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
+  #     - 'run'
+  #   volumes:
+  #     - './src:/home/kernelci/pipeline'
+  #     - './config:/home/kernelci/config'
+  #     - './data/kcidb:/home/kernelci/data/kcidb'
 
   regression_tracker:
     <<: *base-service


### PR DESCRIPTION
Comment out the section in docker-compose.yaml for the kcidb bridge service as it's currently broken and rebuilding the image takes a while on staging.  This should be addressed again once the core services have settled down.  It might be a good idea to move kcidb to a separate docker-compose file so users with a local deployment don't build the image etc. for nothing.