### PR TITLE
config/runtime: kbuild: fix 'fail' result

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -88,7 +88,7 @@ echo '# {command}' | tee -a {job_log}
             res == 'pass' for res in (
                 step_res for (name, (step_res, _)) in step_results.items()
             )
-        ) else 'false'
+        ) else 'fail'
 
         results = {
             'node': {


### PR DESCRIPTION
Fix a typo where the result was set to 'false' instead of 'fail' when a build step fails.

Fixes: 7d8049dab11b ("config/runtime: kbuild: add basic template for x86_64_defconfig")