### PR TITLE
src/send_kcidb: fix `_run` with `APIHelper`

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -62,7 +62,7 @@ class KCIDBBridge(Service):
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            node = self._api_helper.receive_node_event(context['sub_id'])
+            node = self._api_helper.receive_event_node(context['sub_id'])
             self.log.info(f"Submitting node to KCIDB: {node['_id']}")
 
             revision = {


### PR DESCRIPTION
Fix below error as the method renamed to `receive_event_node` as per the `APIHelper` implementation.
`AttributeError: 'APIHelper' object has no attribute 'receive_node_event'`