### PR TITLE
src/regression_tracker: fix `_run` with `APIHelper`

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -50,7 +50,7 @@ class RegressionTracker(Service):
         sys.stdout.flush()
 
         while True:
-            node = self._api_helper.receive_node_event(sub_id)
+            node = self._api_helper.receive_event_node(sub_id)
             if not node['group']:
                 continue
 


### PR DESCRIPTION
Fix below error as the method renamed to `receive_event_node` as per the `APIHelper` implementation.
`AttributeError: 'APIHelper' object has no attribute 'receive_node_event'