### PR TITLE
docker-compose-kcidb.yaml: add separate file with kcidb bridge

### DIFF
--- a/docker-compose-kcidb.yaml
+++ b/docker-compose-kcidb.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+version: '3'
+
+services:
+
+  kcidb:
+    container_name: 'kernelci-pipeline-kcidb'
+    build: {context: 'docker-kcidb'}
+    env_file: ['.env']
+    stop_signal: 'SIGINT'
+    networks: ['kcidb']
+    command:
+      - '/usr/bin/env'
+      - 'python3'
+      - '/home/kernelci/pipeline/send_kcidb.py'
+      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
+      - 'run'
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+      - './data/kcidb:/home/kernelci/data/kcidb'
+
+networks:
+  kcidb:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,22 +92,6 @@ services:
       - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'run'
 
-  kcidb:
-    container_name: 'kernelci-pipeline-kcidb'
-    build: {context: 'docker-kcidb'}
-    env_file: ['.env']
-    stop_signal: 'SIGINT'
-    command:
-      - '/usr/bin/env'
-      - 'python3'
-      - '/home/kernelci/pipeline/send_kcidb.py'
-      - '--settings=${SETTINGS:-/home/kernelci/config/kernelci.conf}'
-      - 'run'
-    volumes:
-      - './src:/home/kernelci/pipeline'
-      - './config:/home/kernelci/config'
-      - './data/kcidb:/home/kernelci/data/kcidb'
-
   regression_tracker:
     <<: *base-service
     container_name: 'kernelci-pipeline-regression_tracker'


### PR DESCRIPTION
Move the kcidb bridge service to a separate docker-compose-kcidb.yaml file so it can be run only when required by the user.  It also avoid building the Docker image for it when just doing the default "docker-compose build".