### PR TITLE
config/runtime: kunit: parse JSON results if the file is present

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -115,7 +115,7 @@ cd {src_path}
                 print(job_log_file.read())
                 print("--------------------------------------------------")
 
-        if step_results['exec'][0] == 'pass':
+        if os.path.exists(kunit_json_path):
             exec_results = self._parse_exec_results(kunit_json_path)
             step_results['exec'] = ('pass', exec_results['child_nodes'])
 


### PR DESCRIPTION
Always parse the JSON results file if it's present, regardless of the status of the 'exec' step.  If any test case failed, the result will be "fail" but the data in the JSON file will still be present.

Fixes: 8015b47b18f0 ("config/runtime/kunit.jinja2: rework with separate steps")