### PR TITLE
T41945 src: update `Node._id` field

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -39,7 +39,7 @@ class RegressionTracker(Service):
         regression = {}
         for field in self._regression_fields:
             regression[field] = failed_node[field]
-        regression['parent'] = failed_node['_id']
+        regression['parent'] = failed_node['id']
         regression['regression_data'] = [last_successful_node, failed_node]
         self._api_helper.submit_regression(regression)
 
@@ -74,7 +74,7 @@ class RegressionTracker(Service):
 
             if previous_nodes[0]['result'] == 'pass':
                 self.log.info(f"Detected regression for node id: \
-{node['_id']}")
+{node['id']}")
                 self._create_regression(node, previous_nodes[0])
 
             sys.stdout.flush()

--- a/src/runner.py
+++ b/src/runner.py
@@ -99,7 +99,7 @@ class RunnerLoop(Runner):
                 output_file = self._runtime.save_file(data, tmp.name, params)
                 job_obj = self._runtime.submit(output_file)
                 self.log.info(' '.join([
-                    node['_id'],
+                    node['id'],
                     self._runtime.config.name,
                     str(self._runtime.get_job_id(job_obj)),
                 ]))

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -63,13 +63,13 @@ class KCIDBBridge(Service):
 
         while True:
             node = self._api_helper.receive_event_node(context['sub_id'])
-            self.log.info(f"Submitting node to KCIDB: {node['_id']}")
+            self.log.info(f"Submitting node to KCIDB: {node['id']}")
 
             revision = {
                 'builds': [],
                 'checkouts': [
                     {
-                        'id': f"{context['origin']}:{node['_id']}",
+                        'id': f"{context['origin']}:{node['id']}",
                         'origin': context['origin'],
                         'tree_name': node['revision']['tree'],
                         'git_repository_url': node['revision']['url'],

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -64,7 +64,7 @@ class TestReport(Service):
             'result': 'fail',
         })
         failures = [
-            node for node in failures if node['_id'] != root_node['_id']
+            node for node in failures if node['id'] != root_node['id']
         ]
         parent_path_len = len(root_node['path'])
         for node in failures:
@@ -72,12 +72,12 @@ class TestReport(Service):
         return {'root': root_node, 'nodes': group_nodes, 'failures': failures}
 
     def _get_results_data(self, root_node):
-        group_nodes = self._api.get_nodes({"parent": root_node['_id']})
+        group_nodes = self._api.get_nodes({"parent": root_node['id']})
         groups = {
             node['name']: self._get_group_data(node)
             for node in group_nodes
         }
-        group_stats = self._get_group_stats(root_node['_id'])
+        group_stats = self._get_group_stats(root_node['id'])
         return {
             'stats': group_stats,
             'groups': groups,

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -39,7 +39,7 @@ class TimeoutService(Service):
         for state in self._pending_states:
             node_filters['state'] = state
             for node in self._api.get_nodes(node_filters):
-                nodes[node['_id']] = node
+                nodes[node['id']] = node
         return nodes
 
     def _count_running_child_nodes(self, parent_id):
@@ -53,7 +53,7 @@ class TimeoutService(Service):
 
     def _get_child_nodes_recursive(self, node, state_filter=None):
         recursive = {}
-        child_nodes = self._get_pending_nodes({'parent': node['_id']})
+        child_nodes = self._get_pending_nodes({'parent': node['id']})
         for child_id, child in child_nodes.items():
             if state_filter is None or child['state'] == state_filter:
                 recursive.update(self._get_child_nodes_recursive(
@@ -110,7 +110,7 @@ class Holdoff(TimeoutService):
             'state': 'available',
             'holdoff__lt': datetime.isoformat(datetime.utcnow()),
         })
-        return {node['_id']: node for node in nodes}
+        return {node['id']: node for node in nodes}
 
     def _check_available_nodes(self, available_nodes):
         timeout_nodes = {}
@@ -149,7 +149,7 @@ class Closing(TimeoutService):
 
     def _get_closing_nodes(self):
         nodes = self._api.get_nodes({'state': 'closing'})
-        return {node['_id']: node for node in nodes}
+        return {node['id']: node for node in nodes}
 
     def _check_closing_nodes(self, closing_nodes):
         done_nodes = {}


### PR DESCRIPTION
Changes due to https://github.com/kernelci/kernelci-api/pull/254

Now the API will send responses with field names and not with the alias, update `Node._id` to `Node.id` in all the services.