### PR TITLE
Update templates with new params for `kver` and `kunit`

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -137,9 +137,9 @@ cd {src_path}
 
         return results
 
-    def _submit(self, result, node_id, api):
+    def _submit(self, result, node, api):
         # Ensure top-level name is kept the same
-        node = api.get_node(node_id)
+        result = result.copy()
         result['node']['name'] = node['name']
         api_helper = kernelci.api.helper.APIHelper(api)
         api_helper.submit_results(result, node)

--- a/config/runtime/kver.jinja2
+++ b/config/runtime/kver.jinja2
@@ -5,7 +5,7 @@
 
 {%- block python_globals %}
 {{ super() }}
-REVISION = {{ revision }}
+REVISION = {{ node.revision }}
 {% endblock %}
 
 {% block python_job_constr -%}


### PR DESCRIPTION
Update how parameters are used in `kver.jinja2` and `kunit.jinja2` following the rework in https://github.com/kernelci/kernelci-core/pull/1919.