### PR TITLE
Get API config and token from callback data

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -3,8 +3,6 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-import os
-
 import kernelci.api.helper
 import kernelci.config
 from kernelci.runtime.lava import Callback
@@ -12,10 +10,9 @@ from kernelci.runtime.lava import Callback
 from flask import Flask, request
 
 
-def _get_api_helper(api_config_name):
+def _get_api_helper(api_config_name, api_token):
     configs = kernelci.config.load('config/pipeline.yaml')
     api_config = configs['api_configs'][api_config_name]
-    api_token = os.getenv(api_token)
     api = kernelci.api.get_api(api_config, api_token)
     return kernelci.api.helper.APIHelper(api)
 
@@ -33,7 +30,8 @@ def callback(node_id):
     data = request.get_json()
     job_callback = Callback(data)
     api_config_name = job_callback.get_meta('api_config_name')
-    api_helper = _get_api_helper(api_config_name)
+    api_token = request.headers.get('Authorization')
+    api_helper = _get_api_helper(api_config_name, api_token)
     results = job_callback.get_results()
     job_node = api_helper.api.get_node(node_id)
     hierarchy = job_callback.get_hierarchy(results, job_node)

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -12,15 +12,14 @@ from kernelci.runtime.lava import Callback
 from flask import Flask, request
 
 
-def _get_api_helper():
+def _get_api_helper(api_config_name):
     configs = kernelci.config.load('config/pipeline.yaml')
-    api_config = configs['api_configs']['staging.kernelci.org']
-    api_token = os.getenv('KCI_API_TOKEN')
+    api_config = configs['api_configs'][api_config_name]
+    api_token = os.getenv(api_token)
     api = kernelci.api.get_api(api_config, api_token)
     return kernelci.api.helper.APIHelper(api)
 
 
-api_helper = _get_api_helper()
 app = Flask(__name__)
 
 
@@ -33,6 +32,8 @@ def hello():
 def callback(node_id):
     data = request.get_json()
     job_callback = Callback(data)
+    api_config_name = job_callback.get_meta('api_config_name')
+    api_helper = _get_api_helper(api_config_name)
     results = job_callback.get_results()
     job_node = api_helper.api.get_node(node_id)
     hierarchy = job_callback.get_hierarchy(results, job_node)

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -7,6 +7,7 @@ import kernelci.api.helper
 import kernelci.config
 from kernelci.runtime.lava import Callback
 
+import requests
 from flask import Flask, request
 
 
@@ -18,6 +19,12 @@ def _get_api_helper(api_config_name, api_token):
 
 
 app = Flask(__name__)
+
+
+@app.errorhandler(requests.exceptions.HTTPError)
+def handle_http_error(ex):
+    detail = ex.response.json().get('detail') or str(ex)
+    return detail, ex.response.status_code
 
 
 @app.route('/')


### PR DESCRIPTION
Rather than using a hard-coded API config and loading the API token from the environment, get the API config name from the job's metadata and the token from the HTTP Authorization header sent by lava.