### PR TITLE
config/runtime: use NODE in kbuild and kunit

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -39,8 +39,8 @@ echo '# {command}' | tee -a {job_log}
     def _upload_artifacts(self, local_artifacts):
         artifacts = {}
         storage = self._get_storage()
-        if storage and NODE_ID:
-            root_path = '-'.join([JOB_NAME, NODE_ID])
+        if storage and NODE:
+            root_path = '-'.join([JOB_NAME, NODE['id']])
             print(f"Uploading artifacts to {root_path}")
             for file_name, file_path in local_artifacts.items():
                 if os.path.exists(file_path):
@@ -118,8 +118,8 @@ echo '# {command}' | tee -a {job_log}
 
         return results
 
-    def _submit(self, result, node_id, api):
-        node = api.get_node(node_id)
+    def _submit(self, result, node, api):
+        node = node.copy()
         node['data'] = {
             key: KBUILD_PARAMS[key] for key in [
                 'arch', 'defconfig', 'compiler', 'fragments',

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -64,8 +64,8 @@ cd {src_path}
     def _upload_artifacts(self, local_artifacts):
         artifacts = {}
         storage = self._get_storage()
-        if storage and NODE_ID:
-            root_path = '-'.join([JOB_NAME, NODE_ID])
+        if storage and NODE:
+            root_path = '-'.join([JOB_NAME, NODE['id']])
             print(f"Uploading artifacts to {root_path}")
             for file_name, file_path in local_artifacts.items():
                 if os.path.exists(file_path):


### PR DESCRIPTION
The NODE_ID global variable has been removed so adjust the kbuild and kunit templates accordingly to use the NODE object instead.