### PR TITLE
src/test_report: optimize `TestReport._get_report` method

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -89,23 +89,15 @@ class TestReport(Service):
                         )
         template = template_env.get_template("test-report.jinja2")
         revision = root_node['revision']
-        if root_node['result'] == 'incomplete':
-            subject = (f"\
+        results = self._get_results_data(root_node)
+        stats = results['stats']
+        groups = results['groups']
+        subject = f"\
 [STAGING] {revision['tree']}/{revision['branch']} {revision['describe']}: \
-Failed to create source tarball for {root_node['name']}")
-            content = template.render(
-                subject=subject, root=root_node, groups={}
-            )
-        else:
-            results = self._get_results_data(root_node)
-            stats = results['stats']
-            groups = results['groups']
-            subject = (f"\
-[STAGING] {revision['tree']}/{revision['branch']} {revision['describe']}: \
-{stats['total']} runs {stats['failures']} failures")
-            content = template.render(
-                subject=subject, root=root_node, groups=groups
-            )
+{stats['total']} runs {stats['failures']} failures"
+        content = template.render(
+            subject=subject, root=root_node, groups=groups
+        )
         return content, subject
 
     def _send_report(self, subject, content):


### PR DESCRIPTION
As the API design has been involved over time, we have eliminated `incomplete` from the set of possible values for `Node.result` field.
Optimize the method to get reports accordingly.
Also, remove the unnecessary parenthesis from a line.