### PR TITLE
src/notifier: fix program name in `parse_opts`

### DIFF
--- a/src/notifier.py
+++ b/src/notifier.py
@@ -85,7 +85,7 @@ class cmd_run(Command):
 
 
 if __name__ == '__main__':
-    opts = parse_opts('runner', globals())
+    opts = parse_opts('notifier', globals())
     configs = kernelci.config.load('config/pipeline.yaml')
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)


### PR DESCRIPTION
Correct command line program name argument from `runner` to `notifier` for `kernelci.cli.parse_opts` method. The method is used to get `Options` object with command line arguments and user settings.