### PR TITLE
config/pipeline.yaml: use new base_url for staging storage

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -33,7 +33,7 @@ storage_configs:
     storage_type: ssh
     host: staging.kernelci.org
     port: 9022
-    base_url: http://staging.kernelci.org:9080/
+    base_url: http://storage.staging.kernelci.org/api/
 
 
 runtimes:


### PR DESCRIPTION
Use the new base URL for the staging storage which allows plaintext HTTP as well as HTTPS (part of the regular staging storage Nginx setup).