### PR TITLE
Parse and upload LAVA job log as plain text

### DIFF
--- a/docker-compose-lava.yaml
+++ b/docker-compose-lava.yaml
@@ -23,6 +23,7 @@ services:
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
+      - './data/ssh:/home/kernelci/data/ssh'
 
 networks:
   lava-callback:

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -3,22 +3,43 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-import kernelci.api.helper
-import kernelci.config
-from kernelci.runtime.lava import Callback
+import os
+import tempfile
 
 import requests
 from flask import Flask, request
+import toml
+
+import kernelci.api.helper
+import kernelci.config
+import kernelci.runtime.lava
+import kernelci.storage
+
+SETTINGS = toml.load(os.getenv('KCI_SETTINGS', 'config/kernelci.toml'))
+CONFIGS = kernelci.config.load('config/pipeline.yaml')
+
+app = Flask(__name__)
 
 
 def _get_api_helper(api_config_name, api_token):
-    configs = kernelci.config.load('config/pipeline.yaml')
-    api_config = configs['api_configs'][api_config_name]
+    api_config = CONFIGS['api_configs'][api_config_name]
     api = kernelci.api.get_api(api_config, api_token)
     return kernelci.api.helper.APIHelper(api)
 
 
-app = Flask(__name__)
+def _get_storage(storage_config_name):
+    storage_config = CONFIGS['storage_configs'][storage_config_name]
+    section = SETTINGS[(':'.join(('storage', storage_config_name)))]
+    storage_cred = section['storage_cred']
+    return kernelci.storage.get_storage(storage_config, storage_cred)
+
+
+def _upload_log(log_parser, job_node, storage):
+    with tempfile.NamedTemporaryFile(mode='w') as log_txt:
+        log_parser.get_text_log(log_txt)
+        os.chmod(log_txt.name, 0o644)
+        log_dir = '-'.join((job_node['name'], job_node['id']))
+        return storage.upload_single((log_txt.name, 'log.txt'), log_dir)
 
 
 @app.errorhandler(requests.exceptions.HTTPError)
@@ -35,12 +56,20 @@ def hello():
 @app.post('/node/<node_id>')
 def callback(node_id):
     data = request.get_json()
-    job_callback = Callback(data)
+    job_callback = kernelci.runtime.lava.Callback(data)
+
     api_config_name = job_callback.get_meta('api_config_name')
     api_token = request.headers.get('Authorization')
     api_helper = _get_api_helper(api_config_name, api_token)
     results = job_callback.get_results()
     job_node = api_helper.api.get_node(node_id)
+
+    log_parser = job_callback.get_log_parser()
+    storage_config_name = job_callback.get_meta('storage_config_name')
+    storage = _get_storage(storage_config_name)
+    log_txt_url = _upload_log(log_parser, job_node, storage)
+    job_node['artifacts']['log.txt'] = log_txt_url
+
     hierarchy = job_callback.get_hierarchy(results, job_node)
     return api_helper.submit_results(hierarchy, job_node)
 


### PR DESCRIPTION
Parse the job log from the callback data into a plain text file and upload it to storage.

This partly includes some clean-up as a side-effect since the callback service is still very new.  If required the changes could be broken down into separate commits.

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/214