### PR TITLE
config/kernelci.toml: use dotted keys

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -28,5 +28,5 @@ origin = "kernelci"
 
 [regression_tracker]
 
-["storage:docker-host"]
+[storage.docker-host]
 storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"


### PR DESCRIPTION
As the syntax for TOML settings file has been switched from using `":"` to dotted keys for child section of components like database and storage, use the new syntax in the settings file.