### PR TITLE
lava: look up yaml_config in settings

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -16,7 +16,9 @@ import kernelci.runtime.lava
 import kernelci.storage
 
 SETTINGS = toml.load(os.getenv('KCI_SETTINGS', 'config/kernelci.toml'))
-CONFIGS = kernelci.config.load('config/pipeline.yaml')
+CONFIGS = kernelci.config.load(
+    SETTINGS.get('DEFAULT', {}).get('yaml_config', 'config/pipeline.yaml')
+)
 
 app = Flask(__name__)
 


### PR DESCRIPTION
Replace the hard-coded 'config/pipeline.yaml' path to the YAML config file with the value found in the TOML settings file.  Keep using 'config/pipeline.yaml' by default if it's not defined in the settings file.