### PR TITLE
Convert email configs .env variables to TOML settings

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -23,6 +23,8 @@ kcidb_project_id = "kernelci-production"
 origin = "kernelci"
 
 [test_report]
+email_sender = "bot@kernelci.org"
+email_recipient = "kernelci-results-staging@groups.io"
 
 [timeout]
 

--- a/src/kernelci_pipeline/email_sender.py
+++ b/src/kernelci_pipeline/email_sender.py
@@ -16,11 +16,11 @@ import smtplib
 
 class EmailSender:
     """Class to send email report using SMTP"""
-    def __init__(self, smtp_host, smtp_port, email_send_from, email_send_to):
+    def __init__(self, smtp_host, smtp_port, email_sender, email_recipient):
         self._smtp_host = smtp_host
         self._smtp_port = smtp_port
-        self._email_send_from = email_send_from
-        self._email_send_to = email_send_to
+        self._email_sender = email_sender
+        self._email_recipient = email_recipient
         self._email_user = os.getenv('EMAIL_USER')
         self._email_pass = os.getenv('EMAIL_PASSWORD')
 
@@ -42,11 +42,11 @@ class EmailSender:
         email_text.replace_header('Content-Transfer-Encoding', 'quopri')
         email_text.set_payload(email_content, 'utf-8')
         email_msg.attach(email_text)
-        if isinstance(self._email_send_to, list):
-            email_msg['To'] = ','.join(self._email_send_to)
+        if isinstance(self._email_recipient, list):
+            email_msg['To'] = ','.join(self._email_recipient)
         else:
-            email_msg['To'] = self._email_send_to
-        email_msg['From'] = self._email_send_from
+            email_msg['To'] = self._email_recipient
+        email_msg['From'] = self._email_sender
         email_msg['Subject'] = email_subject
         return email_msg
 

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -30,8 +30,8 @@ class TestReport(Service):
         super().__init__(configs, args, 'test_report')
         self._email_sender = EmailSender(
             args.smtp_host, args.smtp_port,
-            email_send_from='bot@kernelci.org',
-            email_send_to='kernelci-results-staging@groups.io',
+            email_sender=args.email_sender,
+            email_recipient=args.email_recipient,
         ) if args.smtp_host and args.smtp_port else None
 
     def _dump_report(self, content):
@@ -175,6 +175,14 @@ class cmd_loop(Command):
             'help': "SMTP server port number",
             'type': int,
             'default': 25,
+        },
+        {
+            'name': '--email-sender',
+            'help': "Email address of test report sender",
+        },
+        {
+            'name': '--email-recipient',
+            'help': "Email address of test report recipient",
         },
     ]
 


### PR DESCRIPTION
To keep the settings in standard way, remove environment variables for email sender and recipient and convert them to command line arguments.