### PR TITLE
[WIP] src/test_report.py: Include patchwork patch metadata into test report

### DIFF
--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -9,7 +9,12 @@ Tree:     {{ root.revision.tree }}
 Branch:   {{ root.revision.branch }}
 Describe: {{ root.revision.describe }}
 URL:      {{ root.revision.url }}
-SHA1:     {{ root.revision.commit }}
+Commit:   {{ root.revision.commit }}
+{%- if patch %}
+Patch Title:    {{ patch["title"] }}
+Patch URL:      {{ patch["url"] }}
+Patch Hash:     {{ patch["hash"] }}
+{%- endif %}
 
 {%- if groups.items() %}
 {{ '%-15s %s %-8s %s %-8s %s %-8s'|format(

--- a/src/base.py
+++ b/src/base.py
@@ -24,6 +24,7 @@ class Service:
         api_token = os.getenv('KCI_API_TOKEN')
         self._api = kernelci.api.get_api(self._api_config, api_token)
         self._api_helper = APIHelper(self._api)
+        self._args = args
 
     @property
     def log(self):
@@ -65,7 +66,7 @@ class Service:
         context = None
 
         try:
-            context = self._setup(args)
+            context = self._setup(args or self._args)
             status = self._run(context)
         except KeyboardInterrupt:
             self.log.info("Stopping.")


### PR DESCRIPTION
- Include patch `title`, `hash` and `web_url` in the report, when available
- Pass `args`  from `__init__` into `_setup()` in `Service` class