### PR TITLE
src/test_report: remove default value for `smtp_port`

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -174,7 +174,6 @@ class cmd_loop(Command):
             'name': '--smtp-port',
             'help': "SMTP server port number",
             'type': int,
-            'default': 25,
         },
     ]
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/273

Provided default value `25` for `smtp_port` command line option takes precedence over TOML setting for it.
This is causing SMTP connection errors and emails are not working.
Remove the default value to fix it.