### PR TITLE
config/pipeline.yaml: add early access API entry

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -20,6 +20,9 @@ api_configs:
   staging:
     url: https://staging.kernelci.org:9000
 
+  early-access:
+    url: https://kernelci-api.eastus.cloudapp.azure.com
+
 
 storage_configs:
 


### PR DESCRIPTION
Add an API config entry in pipeline.yaml for the Early Access instance deployed in AKS.