### PR TITLE
kube/aks: add monitor.yaml to create the monitor pod

### DIFF
--- a/kube/aks/monitor.yaml
+++ b/kube/aks/monitor.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: monitor
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: monitor
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/monitor.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token


### PR DESCRIPTION
    Add monitor.yaml to deploy the monitor in AKS.
    
    This is not strictly speaking a service in Kubernetes terminology as
    it doesn't expose any ports and it's only a Pod.  It is kind of a
    service as far as the pipeline is concerned.