### PR TITLE
kube/aks: add trigger.yaml

### DIFF
--- a/kube/aks/kernelci.toml
+++ b/kube/aks/kernelci.toml
@@ -1,3 +1,8 @@
 [DEFAULT]
 api_config = "early-access"
 verbose = true
+
+[trigger]
+poll_period = 3600
+startup_delay = 3
+build_configs = "mainline"

--- a/kube/aks/monitor.yaml
+++ b/kube/aks/monitor.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: monitor
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: monitor
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/monitor.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token

--- a/kube/aks/trigger.yaml
+++ b/kube/aks/trigger.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: trigger
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: trigger
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/trigger.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token


### PR DESCRIPTION
    Add trigger.yaml to deploy the trigger pipeline step.  Update
    kernelci.toml accordingly to monitor the mainline tree every hour.

Depends on #304