### PR TITLE
kube/aks: add tarball.yaml to create tarball pod

### DIFF
--- a/kube/aks/kernelci.toml
+++ b/kube/aks/kernelci.toml
@@ -1,8 +1,13 @@
 [DEFAULT]
 api_config = "early-access"
 verbose = true
+storage_config = "early-access-azure"
 
 [trigger]
 poll_period = 3600
 startup_delay = 3
 build_configs = "mainline"
+
+[tarball]
+kdir = "/home/kernelci/pipeline/data/src/linux"
+output = "/home/kernelci/pipeline/data/output"

--- a/kube/aks/tarball.yaml
+++ b/kube/aks/tarball.yaml
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tarball
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: tarball
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 500m
+      limits:
+        memory: 4Gi
+        cpu: 2
+    command:
+    - ./src/tarball.py
+    - --settings=/home/kernelci/secrets/kernelci.toml
+    - run
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token
+    volumeMounts:
+    - name: secrets
+      mountPath: /home/kernelci/secrets
+    - name: src
+      mountPath: /home/kernelci/pipeline/data/src
+  initContainers:
+  - name: secrets
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    env:
+    - name: AZURE_FILES_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: azure-files-token
+          key: token
+    volumeMounts:
+    - name: secrets
+      mountPath: /tmp/secrets
+    command:
+    - /bin/bash
+    - -e
+    - -c
+    - "\
+cp /home/kernelci/pipeline/kube/aks/kernelci.toml /tmp/secrets/; \
+echo -e \"\
+\\n\
+[storage.early-access-azure]\\n\
+storage_cred = \\\"$AZURE_FILES_TOKEN\\\"\
+\" >> /tmp/secrets/kernelci.toml;"
+  # Until we have a mirror on persistent storage, pre-populate a linux kernel
+  # checkout with some amount of git history to speed things up a bit
+  # https://github.com/kernelci/kernelci-pipeline/issues/310
+  - name: git-clone
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: src
+      mountPath: /tmp/src
+    command:
+    - git
+    - clone
+    - --depth=100
+    - https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    - /tmp/src/linux
+  - name: git-tags
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: src
+      mountPath: /tmp/src
+    workingDir: /tmp/src/linux
+    command:
+    - git
+    - fetch
+    - --tags
+    - origin
+  volumes:
+  - name: src
+    emptyDir: {}
+  - name: secrets
+    emptyDir: {}


### PR DESCRIPTION
    Add tarball.yaml to create the pod running the tarball.py script.
    
    This relies on the AzureFiles storage credentials to be stored in
    kernelci.toml which is done via a Kubernetes secret passed in the
    environment and stored in the file in an initContainer.  It's using a
    copy of the file from the git repository in the ephemeral data volume
    which is also used to create the source tarballs.
    
    Some other initContainers are also pre-populating a linux git clone
    with tags to speed things up when receiving the first events about new
    checkouts.  This could be improved with a full git mirror on a
    persistent volume.
