### PR TITLE
src/scheduler.py: rename from runner

### DIFF
--- a/config/logger.conf
+++ b/config/logger.conf
@@ -7,7 +7,7 @@
 keys=root,
      notifier,
      regression_tracker,
-     runner,
+     scheduler,
      send_kcidb,
      tarball,
      test_report,
@@ -48,10 +48,10 @@ handlers=consoleHandler
 qualname=regression_tracker
 propagate=0
 
-[logger_runner]
+[logger_scheduler]
 level=DEBUG
 handlers=consoleHandler
-qualname=runner
+qualname=scheduler
 propagate=0
 
 [logger_send_kcidb]

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -76,8 +76,8 @@ runtimes:
 
 jobs:
 
-  # FIXME This will need to be reworked later when the fstests runner has been
-  # removed
+  # FIXME This will need to be reworked later when the fstests scheduler has
+  # been removed
   #
   # fstests:
   #   template: 'fstests.jinja2'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,13 +21,13 @@ services:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
 
-  runner: &runner
-    container_name: 'kernelci-pipeline-runner'
+  scheduler: &scheduler
+    container_name: 'kernelci-pipeline-scheduler'
     image: 'kernelci/staging-kernelci'
     env_file: ['.env']
     stop_signal: 'SIGINT'
     command:
-      - './pipeline/runner.py'
+      - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--runtimes=shell'
@@ -39,13 +39,13 @@ services:
       - './data/k8s-credentials/.config/gcloud:/home/kernelci/.config/gcloud'
       - './data/k8s-credentials/.azure:/home/kernelci/.azure'
 
-  runner-docker:
-    <<: *runner
-    container_name: 'kernelci-pipeline-runner-docker'
+  scheduler-docker:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-docker'
     user: root  # Docker-in-Docker
     working_dir: /home/kernelci
     command:
-      - './pipeline/runner.py'
+      - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--runtimes=docker'
@@ -56,21 +56,21 @@ services:
       - './.docker-env:/home/kernelci/.docker-env'
       - '/var/run/docker.sock:/var/run/docker.sock'  # Docker-in-Docker
 
-  runner-lava:
-    <<: *runner
-    container_name: 'kernelci-pipeline-runner-lava'
+  scheduler-lava:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-lava'
     command:
-      - './pipeline/runner.py'
+      - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
       - '--runtimes=lava-collabora'
 
-  runner-k8s:
-    <<: *runner
-    container_name: 'kernelci-pipeline-runner-k8s'
+  scheduler-k8s:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-k8s'
     image: 'kernelci/staging-k8s:kernelci'
     command:
-      - './pipeline/runner.py'
+      - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--runtimes=k8s-gke-eu-west4'

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-# Copyright (C) 2021, 2022 Collabora Limited
+# Copyright (C) 2021, 2022, 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
@@ -22,11 +22,11 @@ from kernelci.cli import Args, Command, parse_opts
 from base import Service
 
 
-class Runner(Service):
-    """Service to run jobs that match received events"""
+class Scheduler(Service):
+    """Service to schedule jobs that match received events"""
 
     def __init__(self, configs, args):
-        super().__init__(configs, args, 'runner')
+        super().__init__(configs, args, 'scheduler')
         self._api_config_yaml = yaml.dump(self._api_config)
         self._verbose = args.verbose
         self._output = args.output
@@ -117,11 +117,11 @@ class cmd_loop(Command):
     ]
 
     def __call__(self, configs, args):
-        return Runner(configs, args).run()
+        return Scheduler(configs, args).run()
 
 
 if __name__ == '__main__':
-    opts = parse_opts('runner', globals())
+    opts = parse_opts('scheduler', globals())
     configs = kernelci.config.load('config/pipeline.yaml')
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)


### PR DESCRIPTION
Rename "runner" to "scheduler" as this pipeline stage is really about scheduling jobs rather than running them.  Also it uses the scheduler YAML config so it's a much better match for what it's doing.

Having descriptive names makes it easier to maintain the code and produce meaningful documentation.