### PR TITLE
config/kernelci.toml: rename runner section to scheduler

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -12,7 +12,7 @@ kdir = "/home/kernelci/data/src/linux"
 output = "/home/kernelci/data/output"
 storage_config = "docker-host"
 
-[runner]
+[scheduler]
 output = "/home/kernelci/output"
 
 [notifier]


### PR DESCRIPTION
Fix the name of the scheduler section which needs to be renamed from runner.

Fixes: 004e9df2fdd8 ("src/scheduler.py: rename from runner")