### PR TITLE
docker/pipeline: base Dockerfile.production on k8s:kernelci

### DIFF
--- a/docker/pipeline/Dockerfile.production
+++ b/docker/pipeline/Dockerfile.production
@@ -3,7 +3,7 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-FROM kernelci/kernelci
+FROM kernelci/k8s:kernelci
 MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 
 ARG git_url=https://github.com/kernelci/kernelci-pipeline.git


### PR DESCRIPTION
Change the base image for kernelci/pipeline to be
kernelci/k8s:kernelci rather than kernelci/kernelci.  This is required to include all the Kubernetes packages which are needed to run scheduler-k8s.

We could have different images e.g. kernelci/pipeline:k8s instead but that would mean more Dockerfile template rework, so this could be done as a follow-up improvement to optimise Docker images.