### PR TITLE
kube/aks: add timeout.yaml to create the timeout pods

### DIFF
--- a/kube/aks/timeout.yaml
+++ b/kube/aks/timeout.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: timeout
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: timeout
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/timeout.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    - --mode=timeout
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: closing
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: timeout
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/timeout.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    - --mode=closing
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: holdoff
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: timeout
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/timeout.py
+    - --settings=/home/kernelci/pipeline/kube/aks/kernelci.toml
+    - run
+    - --mode=holdoff
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token


### PR DESCRIPTION
Add timeout.yaml to create the timeout, holdoff and closing pods.