### PR TITLE
kube/aks: add scheduler-lava.yaml to create the LAVA scheduler

### DIFF
--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2023 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: scheduler-lava
+  namespace: kernelci-pipeline
+spec:
+  containers:
+  - name: scheduler
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    command:
+    - ./src/scheduler.py
+    - --settings=/home/kernelci/secrets/kernelci.toml
+    - loop
+    # Note: This sould be lava-collabora but the callback token name is
+    # different depending on the API instance (staging vs early-access).  So
+    # for now we have 2 configs for the same runtime.
+    - --runtimes=lava-collabora-early-access
+    env:
+    - name: KCI_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: kernelci-api-token
+          key: token
+    volumeMounts:
+    - name: secrets
+      mountPath: /home/kernelci/secrets
+  initContainers:
+  - name: settings
+    image: kernelci/pipeline
+    imagePullPolicy: Always
+    env:
+    - name: LAVA_COLLABORA_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: lava-collabora-token
+          key: token
+    volumeMounts:
+    - name: secrets
+      mountPath: /tmp/secrets
+    command:
+    - /bin/bash
+    - -e
+    - -c
+    - "\
+cp /home/kernelci/pipeline/kube/aks/kernelci.toml /tmp/secrets/; \
+echo -e \"\
+\\n\
+[runtime.lava-collabora-early-access]\\n\
+runtime_token = \\\"$LAVA_COLLABORA_TOKEN\\\"\
+\" >> /tmp/secrets/kernelci.toml;"
+  volumes:
+  - name: secrets
+    emptyDir: {}


### PR DESCRIPTION
Add scheduler-lava.yaml to create the pod with the scheduler for LAVA jobs, currently only to be run in the lava-collabora runtime.