### PR TITLE
src/trigger: make checkout node timeout configurable

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -6,6 +6,7 @@ verbose = true
 [trigger]
 poll_period = 0
 startup_delay = 3
+timeout = 60
 
 [tarball]
 kdir = "/home/kernelci/data/src/linux"


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/319

At the moment, timeout for `checkout` node has been calculated statically in the `trigger` service.
Make it configurable by adding optional command line arguments. Add default timeout configuration values in settings file.