### PR TITLE
src/test_report: fix command handlers of test report

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -178,7 +178,7 @@ class cmd_loop(Command):
     ]
 
     def __call__(self, configs, args):
-        return TestReportLoop(configs, args).run()
+        return TestReportLoop(configs, args).run(args)
 
 
 class cmd_run(Command):
@@ -203,7 +203,7 @@ class cmd_run(Command):
     ]
 
     def __call__(self, configs, args):
-        return TestReportSingle(configs, args).run()
+        return TestReportSingle(configs, args).run(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix below error when `test_report` service is run
for a single node ID.
```
kernelci-pipeline-test_report | 09/11/2023 07:01:53 AM UTC [ERROR] Traceback (most recent call last):
kernelci-pipeline-test_report |   File "/home/kernelci/pipeline/base.py", line 68, in run
kernelci-pipeline-test_report |     context = self._setup(args)
kernelci-pipeline-test_report |   File "/home/kernelci/pipeline/test_report.py", line 142, in _setup
kernelci-pipeline-test_report |     'root_node': self._api.get_node(args.node_id),
kernelci-pipeline-test_report | AttributeError: 'NoneType' object has no attribute 'node_id'
kernelci-pipeline-test_report |
kernelci-pipeline-test_report exited with code 1
```
The error is due to missing command-line arguments that are not being sent to `Service.run` method from command handlers `cmd_run` and `cmd_loop`.