### PR TITLE
Fix results in test report

### DIFF
--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -12,12 +12,12 @@ URL:      {{ root.revision.url }}
 SHA1:     {{ root.revision.commit }}
 
 {%- if groups.items() %}
-{{ '%-15s %s %-8s %s %-8s %s %-8s'|format(
+{{ '%-17s %s %-8s %s %-8s %s %-8s'|format(
 "Name", "|", "Result", "|", "Total", "|", "Failures") }}
 {{ '%s%s%s%s%s%s%s'|format(
-"-"*16, "+", "-"*10, "+", "-"*10, "+", "-"*9) }}
+"-"*18, "+", "-"*10, "+", "-"*10, "+", "-"*9) }}
 {%- for group_name, group in groups.items() %}
-{{ '%-15s %s %-8s %s %8d %s %8d'|format(
+{{ '%-17s %s %-8s %s %8d %s %8d'|format(
 group_name, "|",
 group.root.result, "|",
 group.nodes, "|",

--- a/config/reports/test-report.jinja2
+++ b/config/reports/test-report.jinja2
@@ -11,30 +11,30 @@ Describe: {{ root.revision.describe }}
 URL:      {{ root.revision.url }}
 SHA1:     {{ root.revision.commit }}
 
-{%- if groups.items() %}
+{%- if jobs.items() %}
 {{ '%-17s %s %-8s %s %-8s %s %-8s'|format(
 "Name", "|", "Result", "|", "Total", "|", "Failures") }}
 {{ '%s%s%s%s%s%s%s'|format(
 "-"*18, "+", "-"*10, "+", "-"*10, "+", "-"*9) }}
-{%- for group_name, group in groups.items() %}
+{%- for job_name, job in jobs.items() %}
 {{ '%-17s %s %-8s %s %8d %s %8d'|format(
-group_name, "|",
-group.root.result, "|",
-group.nodes, "|",
-group.failures|count) }}
+job_name, "|",
+job.root.result, "|",
+job.nodes, "|",
+job.failures|count) }}
 {%- endfor %}
 
 
 Failing tests
 =============
 
-{%- for group_name, group in groups.items() %}
-{%- if group.failures|count %}
+{%- for job_name, job in jobs.items() %}
+{%- if job.failures|count %}
 
-{{ group_name }}
-{{ '-'*group_name|length }}
+{{ job_name }}
+{{ '-'*job_name|length }}
 
-{% for failure in group.failures %}* {{ failure.path }}
+{% for failure in job.failures %}* {{ failure.path }}
 {% endfor %}
 {%- endif %}
 {%- endfor %}

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -37,13 +37,15 @@ class TestReport(Service):
     def _dump_report(self, content):
         print(content, flush=True)
 
-    def _get_group_stats(self, parent_id):
+    def _get_group_stats(self, groups_data):
+        failures = 0
+        for _, group in groups_data.items():
+            if group['root']['result'] == 'fail':
+                failures += 1
+
         return {
-            'total': self._api.count_nodes({"parent": parent_id}),
-            'failures': self._api.count_nodes({
-                "parent": parent_id,
-                "result": "fail"
-            })
+            'total': len(groups_data),
+            'failures': failures,
         }
 
     def _get_group_data(self, checkout_node, group):
@@ -99,7 +101,7 @@ class TestReport(Service):
             group: self._get_group_data(root_node, group)
             for group in groups
         }
-        group_stats = self._get_group_stats(root_node['id'])
+        group_stats = self._get_group_stats(groups_data)
         return {
             'stats': group_stats,
             'groups': groups_data,


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/279

Group test results based on `Node.group` rather than parent nodes.

Now the report for checkout node `64b799cede9c1b9fa5d3fe58` looks like this:
```
kernelci-pipeline-test_report | [STAGING] kernelci/staging-stable staging-stable-20230719.0: 4 runs 1 failures
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | Summary
kernelci-pipeline-test_report | =======
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | Tree:     kernelci
kernelci-pipeline-test_report | Branch:   staging-stable
kernelci-pipeline-test_report | Describe: staging-stable-20230719.0
kernelci-pipeline-test_report | URL:      https://github.com/kernelci/linux.git
kernelci-pipeline-test_report | SHA1:     92e29cb5bdcfe0755d13b86fd6993e1068be7197
kernelci-pipeline-test_report | Name              | Result   | Total    | Failures
kernelci-pipeline-test_report | ------------------+----------+----------+---------
kernelci-pipeline-test_report | kunit             | pass     |        4 |        0
kernelci-pipeline-test_report | kbuild-gcc-10-x86 | pass     |        6 |        0
kernelci-pipeline-test_report | kver              | fail     |        1 |        1
kernelci-pipeline-test_report | kunit-x86_64      | pass     |      105 |        2
kernelci-pipeline-test_report | baseline-x86      | None     |        1 |        0
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | Failing tests
kernelci-pipeline-test_report | =============
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | kver
kernelci-pipeline-test_report | ----
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | * kver
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | kunit-x86_64
kernelci-pipeline-test_report | ------------
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report | * exec.example.example_skip_test # SKIP this test should be skipped
kernelci-pipeline-test_report | * exec.example.example_mark_skipped_test # SKIP this test should be skipped
kernelci-pipeline-test_report | 
kernelci-pipeline-test_report exited with code 0
```