### PR TITLE
config/pipeline.yaml: Add minnowboard-turbot-E3826 to baseline tests

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -150,6 +150,11 @@ device_types:
     boot_method: qemu
     mach: qemu
 
+  minnowboard-turbot-E3826:
+    arch: x86_64
+    boot_method: grub
+    mach: x86
+
   kubernetes:
     base_name: kubernetes
     class: kubernetes
@@ -170,6 +175,7 @@ scheduler:
       type: lava
     platforms:
       - qemu-x86
+      - minnowboard-turbot-E3826
 
   - job: kbuild-gcc-10-x86
     event: *checkout-event


### PR DESCRIPTION
Issue mentioned below will be reopened after merging this patch (this patch only partially covers use cases required to close the issue).

Fixes: kernelci/kernelci-api#295