### PR TITLE
src: use kernelci.legacy.cli

### DIFF
--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -15,7 +15,7 @@ import kernelci
 import kernelci.config
 import kernelci.db
 import kernelci.lab
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 
 TEMPLATES_PATHS = ['config/runtime',
                    '/etc/kernelci/runtime',

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -13,7 +13,7 @@ import sys
 
 import kernelci
 import kernelci.config
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 
 from base import Service
 

--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -10,7 +10,7 @@ import sys
 import kernelci
 import kernelci.config
 import kernelci.db
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 
 from base import Service
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -17,7 +17,7 @@ import kernelci.config
 import kernelci.runtime
 import kernelci.scheduler
 import kernelci.storage
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 
 from base import Service
 

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -15,7 +15,7 @@ import sys
 
 import kernelci
 import kernelci.config
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 from kcidb import Client
 import kcidb
 

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -18,7 +18,7 @@ import requests
 import kernelci
 import kernelci.build
 import kernelci.config
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 import kernelci.storage
 
 from base import Service

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -17,7 +17,7 @@ import traceback
 
 import kernelci.config
 import kernelci.db
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 import jinja2
 
 from kernelci_pipeline.email_sender import EmailSender

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -14,7 +14,7 @@ import requests
 import kernelci
 import kernelci.config
 import kernelci.db
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 
 from base import Service
 

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -16,7 +16,7 @@ import kernelci
 import kernelci.build
 import kernelci.config
 import kernelci.db
-from kernelci.cli import Args, Command, parse_opts
+from kernelci.legacy.cli import Args, Command, parse_opts
 import urllib
 import requests
 


### PR DESCRIPTION
The kernelci.cli module is now being moved to kernelci.legacy.cli so we can have the new implementation in kernelci.cli instead.  Update all the pipeline services accordingly.