### PR TITLE
src: use 'api' instead of 'api_configs' in YAML

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -20,7 +20,7 @@ class Service:
     def __init__(self, configs, args, name):
         self._name = name
         self._logger = Logger("config/logger.conf", name)
-        self._api_config = configs['api_configs'][args.api_config]
+        self._api_config = configs['api'][args.api_config]
         api_token = os.getenv('KCI_API_TOKEN')
         self._api = kernelci.api.get_api(self._api_config, api_token)
         self._api_helper = APIHelper(self._api)

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -24,7 +24,7 @@ app = Flask(__name__)
 
 
 def _get_api_helper(api_config_name, api_token):
-    api_config = CONFIGS['api_configs'][api_config_name]
+    api_config = CONFIGS['api'][api_config_name]
     api = kernelci.api.get_api(api_config, api_token)
     return kernelci.api.helper.APIHelper(api)
 


### PR DESCRIPTION
The 'api_configs' YAML entry has been renamed to 'api' so update the pipeline code accordingly.