### PR TITLE
config/pipeline.yaml: replace api_configs with api

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -12,7 +12,7 @@ _anchors:
     state: available
 
 
-api_configs:
+api:
 
   docker-host:
     url: http://172.17.0.1:8001
@@ -40,7 +40,7 @@ storage_configs:
     host: staging.kernelci.org
     port: 9022
     base_url: http://storage.staging.kernelci.org/api/
-  
+
   k8s-host:
     storage_type: ssh
     host: kernelci-api-ssh


### PR DESCRIPTION
The YAML configuration is being finalised and api_configs is now renamed to api.  Update pipeline.yaml accordingly.