### PR TITLE
config/pipeline.yaml: rename storage_configs to storage

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -27,7 +27,7 @@ api_configs:
     url: http://kernelci-api:8001
 
 
-storage_configs:
+storage:
 
   docker-host:
     storage_type: ssh


### PR DESCRIPTION
The YAML pipeline configuration is getting finalised and storage_configs is being renamed to storage.  Update pipeline.yaml accordingly.