### PR TITLE
config/pipeline.yaml: add context to qemu platform/device_type definition

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -167,6 +167,10 @@ device_types:
     arch: x86_64
     boot_method: qemu
     mach: qemu
+    context:
+      arch: x86_64
+      cpu: qemu64
+      guestfs_interface: ide
 
   minnowboard-turbot-E3826:
     arch: x86_64


### PR DESCRIPTION
This patch adds required configuration for LAVA TestJob definition for qemu device_type. Context section was converted to a conditional one in the base template as a part of kernelci/kernelci-core#2153

This patch allows generating equivalent LAVA TestJob definitions.