### PR TITLE
config/pipeline.yaml: add aaeon-UPN-EHLX4RE-A10-0864 to baseline tests

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -173,6 +173,11 @@ device_types:
     boot_method: grub
     mach: x86
 
+  aaeon-UPN-EHLX4RE-A10-0864:
+    arch: x86_64
+    boot_method: grub
+    mach: x86
+
   kubernetes:
     base_name: kubernetes
     class: kubernetes


### PR DESCRIPTION
Minnowboard Turbot E3826 is currently in use as a generic x86 board. It might be decomissioned soon. This patch introduces a new generic x86 board with planned long-term support in the Collabora LAVA labs.