### PR TITLE
pipeline.yaml: Add Chromebook for testing on x86-board kernels

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -178,6 +178,11 @@ device_types:
     boot_method: grub
     mach: x86
 
+  asus-cx9400-volteer:
+    arch: x86_64
+    boot_method: depthcharge
+    mach: x86
+
   kubernetes:
     base_name: kubernetes
     class: kubernetes
@@ -199,6 +204,16 @@ scheduler:
     platforms:
       - qemu-x86
       - minnowboard-turbot-E3826
+
+  - job: baseline-x86-board
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-board
+      result: pass
+    runtime:
+      type: lava
+    platforms:
+      - asus-cx9400-volteer
 
   - job: kbuild-gcc-10-x86
     event: *checkout-event

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -104,8 +104,11 @@ jobs:
   #   template: 'fstests.jinja2'
   #   image: 'kernelci/staging-kernelci'
 
-  baseline-x86:
+  baseline-x86: &baseline-x86-job
     template: baseline.jinja2
+
+  baseline-x86-board:
+    <<: *baseline-x86-job
 
   kbuild-gcc-10-x86:
     template: kbuild.jinja2


### PR DESCRIPTION
Add first Chromebook in pipeline testing

Depends-on: https://github.com/kernelci/kernelci-core/pull/2176