### PR TITLE
kbuild.jinja2: Add olddefconfig step to build

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -101,6 +101,16 @@ class Config:
                 print(f"[_merge_frags] Failed to merge fragment")
             print(f"[_merge_frags] Merging fragment done")
             os.remove(f"/tmp/{i}.config")
+    
+    def olddefconfig(self, srcdir):
+        cwd = os.getcwd()
+        os.chdir(srcdir)
+        print(f"[_olddefconfig] Running olddefconfig")
+        cmd = f"make ARCH=x86_64 olddefconfig"
+        ret = subprocess.run(cmd, shell=True).returncode
+        if ret != 0:
+            print(f"[_olddefconfig] Failed to run olddefconfig")
+        print(f"[_olddefconfig] Running olddefconfig done")
 
     # TODO(nuclearcat): ChromeOS should have its own config as "defconfig"
     def cros_config(self, config):
@@ -229,6 +239,7 @@ echo '# {command}' | tee -a {job_log}
                 if fwdir:
                     cfg.add_option(f'CONFIG_EXTRA_FIRMWARE_DIR="{fwdir}"')
                 cfg.merge_frags(src_path)
+                cfg.olddefconfig(src_path)
 
         print(f"[_run] Uploading artifacts")
         artifacts = self._upload_artifacts(local_artifacts)


### PR DESCRIPTION
As sometimes defconfig and fragments might miss some options, we need to make sure at compile time config process wont restart and try to ask questions by using olddefconfig.