### PR TITLE
pipeline.yaml: Add one more lab and board

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -91,6 +91,16 @@ runtimes:
         token: kernelci-api-token-early-access
         url: https://staging.kernelci.org:9100
 
+  lava-collabora-staging:
+    lab_type: lava
+    url: https://staging.lava.collabora.dev/
+    priority_min: 40
+    priority_max: 60
+    notify:
+      callback:
+        token: kernelci-api-token-lava-staging
+        url: https://staging.kernelci.org:9100
+
   shell:
     lab_type: shell
 
@@ -108,6 +118,9 @@ jobs:
     template: baseline.jinja2
 
   baseline-x86-board:
+    <<: *baseline-x86-job
+
+  baseline-x86-board-staging:
     <<: *baseline-x86-job
 
   kbuild-gcc-10-x86:
@@ -190,6 +203,11 @@ device_types:
     boot_method: depthcharge
     mach: x86
 
+  dell-latitude-3445-7520c-skyrim:
+    arch: x86_64
+    boot_method: depthcharge
+    mach: x86
+
   kubernetes:
     base_name: kubernetes
     class: kubernetes
@@ -219,8 +237,20 @@ scheduler:
       result: pass
     runtime:
       type: lava
+      name: lava-collabora
     platforms:
       - asus-cx9400-volteer
+
+  - job: baseline-x86-board-staging
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-board
+      result: pass
+    runtime:
+      type: lava
+      name: lava-collabora-staging
+    platforms:
+      - dell-latitude-3445-7520c-skyrim
 
   - job: kbuild-gcc-10-x86
     event: *checkout-event

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,7 +63,9 @@ services:
       - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.conf}'
       - 'loop'
-      - '--runtimes=lava-collabora'
+      - '--runtimes'
+      - 'lava-collabora'
+      - 'lava-collabora-staging'
 
   scheduler-k8s:
     <<: *scheduler


### PR DESCRIPTION
As good example for future improvements and to detect bugs in corner case we can add also one more lab and device. This is also unfortunately required to add one more real hardware device, as production lab doesn't support properly Azure files (yet), and it might be also good case to improve (detect infrastructure failure).