### PR TITLE
trigger.py: Quit, if error 401

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -72,6 +72,11 @@ class Trigger(Service):
             detail = ex.response.json().get('detail')
             if detail:
                 self.log.error(detail)
+            # TODO(nuclearcat): Re-read authorization token if it's failing
+            # if error Unauthorized 401 - quit
+            if ex.response.status_code == 401:
+                self.log.error("Unauthorized 401 - Quit")
+                sys.exit(1)
         except Exception as ex:
             self.traceback(ex)
 


### PR DESCRIPTION
In some cases token might get updated, but to re-read it we need to restart container.
In future we need to implement re-read of token only.

Improves https://github.com/kernelci/kernelci-pipeline/issues/358