### PR TITLE
src/monitor: print info only for node events with revision info

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -61,14 +61,18 @@ class Monitor(Service):
             event = self._api.receive_event(sub_id)
             obj = event.data
             dt = datetime.datetime.fromisoformat(event['time'])
-            print(self.LOG_FMT.format(
-                time=dt.strftime('%Y-%m-%d %H:%M:%S.%f'),
-                commit=obj['revision']['commit'][:12],
-                id=obj['id'],
-                state=state_map[obj['state']],
-                result=result_map[obj['result']],
-                name=obj['name']
-            ), flush=True)
+            # Print the status line only for events that contain
+            # "revision" data. Implement proper event filtering when the
+            # models are production-ready
+            if 'revision' in obj:
+                print(self.LOG_FMT.format(
+                    time=dt.strftime('%Y-%m-%d %H:%M:%S.%f'),
+                    commit=obj['revision']['commit'][:12],
+                    id=obj['id'],
+                    state=state_map[obj['state']],
+                    result=result_map[obj['result']],
+                    name=obj['name']
+                ), flush=True)
 
         return True
 


### PR DESCRIPTION
This should be safe to merge, it shouldn't break anything.

Related to https://github.com/kernelci/kernelci-core/pull/2212
Both PRs try to get rid of crashes when non-node events are published.

Note that these are provisional fixes. A proper fix would involve a better use of pydantic checks, and for that we'd need to move the models to kernelci-core.