### PR TITLE
pipeline: add "octopus" Chromebook

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -208,6 +208,11 @@ device_types:
     boot_method: depthcharge
     mach: x86
 
+  hp-x360-12b-ca0010nr-n4020-octopus:
+    arch: x86_64
+    boot_method: depthcharge
+    mach: x86
+
   kubernetes:
     base_name: kubernetes
     class: kubernetes
@@ -239,6 +244,7 @@ scheduler:
       type: lava
       name: lava-collabora
     platforms:
+      - hp-x360-12b-ca0010nr-n4020-octopus
       - asus-cx9400-volteer
 
   - job: baseline-x86-board-staging


### PR DESCRIPTION
This enables testing on an additional device type. `octopus` is a good candidate as it's known to work fine with the legacy pipeline and also uses a pineview chip.