### PR TITLE
kernelci.toml: Adjust default values to make local setup easier

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -14,7 +14,7 @@ output = "/home/kernelci/data/output"
 storage_config = "docker-host"
 
 [scheduler]
-output = "/home/kernelci/output"
+output = "/home/kernelci/data/output"
 
 [notifier]
 


### PR DESCRIPTION
In pipeline.yaml we have:
```
- 'data/output/:/home/kernelci/data/output'
```
Let's align it with kernelci.toml, as it might bite if we run local docker runner for kbuild.