### PR TITLE
pipeline.yaml: Comment as we can retrieve API token from os env

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -79,7 +79,8 @@ runtimes:
     priority_max: 60
     notify:
       callback:
-        token: kernelci-api-token-staging
+        # By default retrieve token from environment variable
+        # token: kernelci-api-token-staging
         url: https://staging.kernelci.org:9100
 
   # ToDo: avoid creating a separate Runtime entry
@@ -88,7 +89,8 @@ runtimes:
     <<: *lava-collabora-staging
     notify:
       callback:
-        token: kernelci-api-token-early-access
+        # By default retrieve token from environment variable
+        # token: kernelci-api-token-early-access
         url: https://staging.kernelci.org:9100
 
   lava-collabora-staging:
@@ -98,7 +100,8 @@ runtimes:
     priority_max: 60
     notify:
       callback:
-        token: kernelci-api-token-lava-staging
+        # By default retrieve token from environment variable
+        # token: kernelci-api-token-lava-staging
         url: https://staging.kernelci.org:9100
 
   shell:


### PR DESCRIPTION
We have support in LAVA runtime to retrieve API token, if it is not set explicitly in config
Depends-on: https://github.com/kernelci/kernelci-core/pull/2258