### PR TITLE
scheduler: Add additional parameters for create_job_node

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -72,7 +72,8 @@ class Scheduler(Service):
         self._cleanup_paths()
 
     def _run_job(self, job_config, runtime, platform, input_node):
-        node = self._api_helper.create_job_node(job_config, input_node)
+        node = self._api_helper.create_job_node(job_config, input_node,
+                                                runtime, platform)
         job = kernelci.runtime.Job(node, job_config)
         job.platform_config = platform
         job.storage_config = self._storage_config


### PR DESCRIPTION
It will be useful to add runtime and platform name in node, as it will help to troubleshoot tests failures, build failures and etc.