### PR TITLE
restart_services.sh: restart pipeline service when `.env` file changes

### DIFF
--- a/restart_services.sh
+++ b/restart_services.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+FILE=".env"
+inotifywait -m -e close_write $FILE | while read EVENT;
+do 
+  echo $EVENT      
+  echo ".env file changes detected. Restarting pipeline services..."
+  docker-compose down
+  docker-compose up --build --no-cache
+done


### PR DESCRIPTION
Environment variable `KCI_API_TOKEN` is required to run pipeline services. The variable is defined in `.env` file. Add a script to monitor `.env` file using `inotifywait` tool. If the file changes are detected, that is if the token is modified, restart all the services.