### PR TITLE
lava_callback.py: Rework lava callback authentication

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -36,3 +36,11 @@ storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"
 
 [storage.k8s-host]
 storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"
+
+#[runtime.lava-collabora]
+#runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
+#callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
+
+#[runtime.lava-collabora-early-access]
+#runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA-EARLY-ACCESS"
+#callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"


### PR DESCRIPTION
This is follow up on discussion of PR:
https://github.com/kernelci/kernelci-pipeline/pull/377 https://github.com/kernelci/kernelci-core/pull/2258

Now workflow of enabling LAVA lab is simplified:
LAVA lab need to enable one or two tokens (two a bit more secure, as one will be used to submit job, another for callback), and provide name(description) of one of tokens to specify in pipeline.yaml.
Also in toml file we need to specify callback token value.