### PR TITLE
kbuild.jinja2: bugfix, invoke script correctly

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -44,7 +44,7 @@ def main(args):
     build.set_storage_config(STORAGE_CONFIG_YAML)
     build.write_script("build.sh")
     build.serialize("_build.json")
-    r = os.system("bash build.sh")
+    r = os.system("bash -e build.sh")
     build2 = KBuild.from_json("_build.json")
     build2.verify_build()
     results = build2.submit(r)


### PR DESCRIPTION
Without flag -e script will never fail and trigger build fail, which means we will have broken kernel builds submitted to LAVA lab.