### PR TITLE
lava_callback: Job processing can be done asynchronously

### DIFF
--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -11,9 +11,11 @@ services:
     # With uWSGI in socket mode, to use with reverse proxy e.g. Nginx and SSL
     command:
       - '/usr/local/bin/uwsgi'
+      - '--master'
       - '--socket=:8000'
       - '--buffer-size=32768'
       - '-p${NPROC:-4}'
+      - '--enable-threads'
       - '--wsgi-file=/home/kernelci/pipeline/lava_callback.py'
       - '--callable=app'
 


### PR DESCRIPTION
LAVA have very short timeouts for callbacks, so better to do job submission process asynchronously.