### PR TITLE
src/trigger: fix duplicate `checkout` node creations

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -36,7 +36,8 @@ class Trigger(Service):
     def _run_trigger(self, build_config, force, timeout):
         head_commit = kernelci.build.get_branch_head(build_config)
         node_count = self._api.node.count({
-            "revision.commit": head_commit,
+            "kind": "checkout",
+            "data.kernel_revision.commit": head_commit,
             "owner": self._current_user['username'],
         })
 


### PR DESCRIPTION
Fix multiple checkout node creation with the same revision commit. Update logic to check existing `checkout` node for specific commit as per `Node` schema changes.