### PR TITLE
src/test_report: fix missing job stats and details

### DIFF
--- a/src/test_report.py
+++ b/src/test_report.py
@@ -52,21 +52,21 @@ class TestReport(Service):
         revision = checkout_node['data']['kernel_revision']
 
         root_node = self._api.node.find({
-            'revision.commit': revision['commit'],
-            'revision.tree': revision['tree'],
-            'revision.branch': revision['branch'],
+            'data.kernel_revision.commit': revision['commit'],
+            'data.kernel_revision.tree': revision['tree'],
+            'data.kernel_revision.branch': revision['branch'],
             'name': job,
         })[0]
         job_nodes = self._api.node.count({
-            'revision.commit': revision['commit'],
-            'revision.tree': revision['tree'],
-            'revision.branch': revision['branch'],
+            'data.kernel_revision.commit': revision['commit'],
+            'data.kernel_revision.tree': revision['tree'],
+            'data.kernel_revision.branch': revision['branch'],
             'group': job,
         })
         failures = self._api.node.find({
-            'revision.commit': revision['commit'],
-            'revision.tree': revision['tree'],
-            'revision.branch': revision['branch'],
+            'data.kernel_revision.commit': revision['commit'],
+            'data.kernel_revision.tree': revision['tree'],
+            'data.kernel_revision.branch': revision['branch'],
             'group': job,
             'result': 'fail',
         })
@@ -85,9 +85,9 @@ class TestReport(Service):
         jobs = []
         revision = root_node['data']['kernel_revision']
         nodes = self._api.node.find({
-            'revision.commit': revision['commit'],
-            'revision.tree': revision['tree'],
-            'revision.branch': revision['branch']
+            'data.kernel_revision.commit': revision['commit'],
+            'data.kernel_revision.tree': revision['tree'],
+            'data.kernel_revision.branch': revision['branch']
         })
         for node in nodes:
             if node['group'] and node['group'] not in jobs:


### PR DESCRIPTION
Job stats and details are missing in test reports. e.g. staging logs shows 0 runs and no details even if jobs data exists for particular `checkout` node:
```
today at 16:59:02[STAGING] kernelci/staging-stable staging-stable-20240119.0: 0 runs 0 failures
today at 16:59:02
today at 16:59:02Summary
today at 16:59:02=======
today at 16:59:02
today at 16:59:02Tree:     kernelci
today at 16:59:02Branch:   staging-stable
today at 16:59:02Describe: staging-stable-20240119.0
today at 16:59:02URL:      https://github.com/kernelci/linux.git
today at 16:59:02SHA1:     38272e396092098ffb59c8dd43fadf3e5a8cfcfb
```
Fix the issue by updating functions for getting job information from root node as per `Node` schema changes.