### PR TITLE
pipeline.yaml: unify scheduler output path

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -14,7 +14,7 @@ output = "/home/kernelci/data/output"
 storage_config = "docker-host"
 
 [scheduler]
-output = "/home/kernelci/output"
+output = "/home/kernelci/data/output"
 
 [notifier]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
-      - './data/output:/home/kernelci/output'
+      - './data/output:/home/kernelci/data/output'
       - './data/k8s-credentials/.kube:/home/kernelci/.kube'
       - './data/k8s-credentials/.config/gcloud:/home/kernelci/.config/gcloud'
       - './data/k8s-credentials/.azure:/home/kernelci/.azure'


### PR DESCRIPTION
Set the same output path for all scheduler instances, use the same consistent path as the rest of the pipeline stages.