### PR TITLE
scheduler: abort job generation if params are invalid

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -78,6 +78,15 @@ class Scheduler(Service):
         job.platform_config = platform
         job.storage_config = self._storage_config
         params = runtime.get_params(job, self._api.config)
+        if not params:
+            self.log.error(' '.join([
+                node['id'],
+                runtime.config.name,
+                platform.name,
+                job_config.name,
+                "Invalid job parameters, aborting...",
+            ]))
+            return
         data = runtime.generate(job, params)
         tmp = tempfile.TemporaryDirectory(dir=self._output)
         output_file = runtime.save_file(data, tmp.name, params)


### PR DESCRIPTION
The `get_params()` function might return `None`, in which case we should abort job generation as it will fail anyway.