### PR TITLE
Debug facilities (part 1)

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -50,10 +50,14 @@ def main(args):
     build.set_storage_config(STORAGE_CONFIG_YAML)
     build.write_script("build.sh")
     build.serialize("_build.json")
-    r = os.system("bash -e build.sh")
     build2 = KBuild.from_json("_build.json")
     build2.verify_build()
-    results = build2.submit(r)
+    if NODE.get('debug') and NODE['debug'].get('dry_run'):
+        retcode = 0 if NODE['debug']['result'] == 'pass' else 1
+        results = build2.submit(retcode, dry_run=True)
+    else:
+        r = os.system("bash -e build.sh")
+        results = build2.submit(r)
     return results
 
 {% endblock %}

--- a/debug_run.sh
+++ b/debug_run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Runs pipeline services in a debugging-friendly way.
+
+# Without arguments, it builds and starts the docker containers for all
+# services and it leaves the monitor running.
+# When called with arguments, the first one is the service to run, the
+# rest is the set of commands to run on it.
+#
+# If the command to run is "shell", it starts an interactive bash
+# session on the specified service.
+#
+# It's recommended to run each service in a separate terminal
+
+# EXAMPLES!
+#
+# 1: start the containers
+#     ./debug_run.sh
+#
+# 2: run the tarball service
+#     ./debug_run.sh tarball run
+#
+# 3: run the trigger service
+#     ./debug_run.sh trigger run
+#
+# 4: run the scheduler service with the shell runtime
+#     ./debug_run.sh scheduler loop --runtimes=shell
+#
+# 5: run an interactive shell on the scheduler service
+#     ./debug_run.sh scheduler shell
+
+
+stage=$1
+
+if [ $# -eq 0 ]
+then
+    docker-compose -f docker-compose-debug.yaml up --build
+    exit
+fi
+
+stage=$1
+shift
+cmds=($@)
+
+if [ ${cmds[0]} = "shell" ]
+then
+    docker-compose -f docker-compose-debug.yaml exec $stage bash
+else
+    docker-compose -f docker-compose-debug.yaml exec $stage ./pipeline/$stage.py --settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml} $@
+fi

--- a/docker-compose-debug.yaml
+++ b/docker-compose-debug.yaml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2021, 2022, 2024 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Jeny Sadadia <jeny.sadadia@collabora.com>
+# Author: Ricardo Cañuelo <ricardo.canuelo@collabora.com>
+
+version: '3'
+
+services:
+
+  base-service: &base-service
+    container_name: 'kernelci-pipeline-base-service'
+    image: 'kernelci/staging-kernelci'
+    env_file: ['.env']
+    stop_signal: 'SIGINT'
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+    tty: true
+
+  monitor:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-monitor'
+    command:
+      - './pipeline/monitor.py'
+      - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
+      - 'run'
+
+  scheduler: &scheduler
+    container_name: 'kernelci-pipeline-scheduler'
+    image: 'kernelci/staging-kernelci'
+    env_file: ['.env']
+    stop_signal: 'SIGINT'
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+      - './data/output:/home/kernelci/output'
+      - './data/k8s-credentials/.kube:/home/kernelci/.kube'
+      - './data/k8s-credentials/.config/gcloud:/home/kernelci/.config/gcloud'
+      - './data/k8s-credentials/.azure:/home/kernelci/.azure'
+    tty: true
+
+  scheduler-docker:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-docker'
+    user: root  # Docker-in-Docker
+    working_dir: /home/kernelci
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+      - './data/output:/home/kernelci/data/output'
+      - './.docker-env:/home/kernelci/.docker-env'
+      - '/var/run/docker.sock:/var/run/docker.sock'  # Docker-in-Docker
+
+  scheduler-lava:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-lava'
+
+  scheduler-k8s:
+    <<: *scheduler
+    container_name: 'kernelci-pipeline-scheduler-k8s'
+    image: 'kernelci/staging-k8s:kernelci'
+
+  tarball:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-tarball'
+    volumes:
+      - './src:/home/kernelci/pipeline'
+      - './config:/home/kernelci/config'
+      - './data/ssh:/home/kernelci/data/ssh'
+      - './data/src:/home/kernelci/data/src'
+      - './data/output:/home/kernelci/data/output'
+
+  trigger:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-trigger'
+
+  regression_tracker:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-regression_tracker'
+
+  test_report:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-test_report'
+
+  timeout:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-timeout'
+
+  timeout-closing:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-closing'
+
+  timeout-holdoff:
+    <<: *base-service
+    container_name: 'kernelci-pipeline-holdoff'

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -75,6 +75,8 @@ class Scheduler(Service):
     def _run_job(self, job_config, runtime, platform, input_node):
         node = self._api_helper.create_job_node(job_config, input_node,
                                                 runtime, platform)
+        if 'debug' in input_node:
+            node['debug'] = input_node['debug']
         job = kernelci.runtime.Job(node, job_config)
         job.platform_config = platform
         job.storage_config = self._storage_config

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -81,12 +81,6 @@ class Trigger(Service):
         except Exception as ex:
             self.traceback(ex)
 
-    def _iterate_build_configs(self, force, build_configs_list,
-                               timeout):
-        for name, config in self._build_configs.items():
-            if not build_configs_list or name in build_configs_list:
-                self._run_trigger(config, force, timeout)
-
     def _setup(self, args):
         return {
             'poll_period': int(args.poll_period),
@@ -109,8 +103,10 @@ class Trigger(Service):
             time.sleep(startup_delay)
 
         while True:
-            self._iterate_build_configs(force, build_configs_list,
-                                        timeout)
+            # Iterate through build configs
+            for name, config in self._build_configs.items():
+                if not build_configs_list or name in build_configs_list:
+                    self._run_trigger(config, force, timeout)
             if poll_period:
                 self.log.info(f"Sleeping for {poll_period}s")
                 time.sleep(poll_period)

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -91,25 +91,19 @@ class Trigger(Service):
         }
 
     def _run(self, ctx):
-        poll_period, force, build_configs_list, startup_delay, timeout = (
-            ctx[key] for key in (
-                'poll_period', 'force', 'build_configs_list', 'startup_delay',
-                'timeout'
-            )
-        )
-
-        if startup_delay:
-            self.log.info(f"Delay: {startup_delay}s")
-            time.sleep(startup_delay)
+        if ctx['startup_delay']:
+            self.log.info(f"Delay: {ctx['startup_delay']}s")
+            time.sleep(ctx['startup_delay'])
 
         while True:
             # Iterate through build configs
             for name, config in self._build_configs.items():
-                if not build_configs_list or name in build_configs_list:
-                    self._run_trigger(config, force, timeout)
-            if poll_period:
-                self.log.info(f"Sleeping for {poll_period}s")
-                time.sleep(poll_period)
+                if (not ctx['build_configs_list'] or
+                    name in ctx['build_configs_list']):  # noqa
+                    self._run_trigger(config, ctx['force'], ctx['timeout'])
+            if ctx['poll_period']:
+                self.log.info(f"Sleeping for {ctx['poll_period']}s")
+                time.sleep(ctx['poll_period'])
             else:
                 self.log.info("Not polling.")
                 break


### PR DESCRIPTION
Requirements:

- https://github.com/kernelci/kernelci-core/pull/2326
- https://github.com/kernelci/kernelci-core/pull/2328

Add support for bypassing (dry-running) the initial pipeline stages and add a launcher script (debug_run.sh) to make it easier to run pipeline services individually in a local setup. See the commit messages and the script documentation for more info.

Running the trigger service with `--dry-run <result>` will generate checkout nodes with "dry_run" as a debug parameter and a forced result so that certain subsequent stages will simply run the logic and code generation and bypass actions that require external factors. This is meant as a way to exercise the pipeline stages locally without relying on a full staging instance.