### PR TITLE
pipeline: add stable-rc tree and build config for 6.6

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -210,6 +210,9 @@ trees:
   mainline:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 
+  stable-rc:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git'
+
 
 device_types:
 
@@ -400,4 +403,9 @@ build_configs:
   mainline:
     tree: mainline
     branch: 'master'
+    variants: *build-variants
+
+  stable-rc_6.6:
+    tree: stable-rc
+    branch: 'linux-6.6.y'
     variants: *build-variants


### PR DESCRIPTION
We want to monitor this tree so we can test -rc releases targetting the stable branch before they're released. Add a build config for the 6.6 branch in the `stable-rc` tree.