### PR TITLE
Add more arm64 devices

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -14,6 +14,14 @@ _anchors:
     <<: *arm64-device
     boot_method: depthcharge
 
+  armel-device: &armel-device
+    <<: *arm64-device
+    arch: armel
+
+  armel-chromebook-device: &armel-chromebook-device
+    <<: *armel-device
+    boot_method: depthcharge
+
   baseline: &baseline-job
     template: baseline.jinja2
     kind: test
@@ -171,6 +179,8 @@ jobs:
 
   baseline-arm64: *baseline-job
   baseline-arm64-chromebook: *baseline-job
+  baseline-armel: *baseline-job
+  baseline-armel-chromebook: *baseline-job
   baseline-x86: *baseline-job
   baseline-x86-board: *baseline-job
   baseline-x86-board-staging: *baseline-job
@@ -292,6 +302,16 @@ device_types:
     mach: broadcom
     dtb: dtbs/broadcom/bcm2711-rpi-4-b.dtb
 
+  bcm2836-rpi-2-b:
+    <<: *armel-device
+    mach: broadcom
+    dtb: dtbs/bcm2836-rpi-2-b.dtb
+
+  imx6q-sabrelite:
+    <<: *armel-device
+    mach: imx
+    dtb: dtbs/imx6q-sabrelite.dtb
+
   meson-g12b-a311d-khadas-vim3:
     <<: *arm64-device
     mach: amlogic
@@ -316,6 +336,21 @@ device_types:
     <<: *arm64-chromebook-device
     mach: mediatek
     dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
+
+  odroid-xu3:
+    <<: *armel-device
+    mach: samsung
+    dtb: dtbs/exynos5422-odroidxu3.dtb
+
+  rk3288-rock2-square:
+    <<: *armel-device
+    mach: rockchip
+    dtb: dtbs/rk3288-rock2-square.dtb
+
+  rk3288-veyron-jaq:
+    <<: *armel-chromebook-device
+    mach: rockchip
+    dtb: dtbs/rk3288-veyron-jaq.dtb
 
   rk3399-gru-kevin:
     <<: *arm64-chromebook-device
@@ -389,6 +424,31 @@ scheduler:
       - rk3399-gru-kevin
       - sc7180-trogdor-kingoftown
       - sc7180-trogdor-lazor-limozeen
+
+  - job: baseline-armel
+    event:
+      channel: node
+      name: kbuild-gcc-10-armel
+      result: pass
+    runtime:
+      type: lava
+      name: lava-collabora
+    platforms:
+      - bcm2836-rpi-2-b
+      - imx6q-sabrelite
+      - odroid-xu3
+      - rk3288-rock2-square
+
+  - job: baseline-armel-chromebook
+    event:
+      channel: node
+      name: kbuild-gcc-10-armel
+      result: pass
+    runtime:
+      type: lava
+      name: lava-collabora
+    platforms:
+      - rk3288-veyron-jaq
 
   - job: baseline-x86
     event:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -302,10 +302,30 @@ device_types:
     mach: mediatek
     dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
 
+  mt8186-corsola-steelix-sku131072:
+    <<: *arm64-chromebook-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8186-corsola-steelix-sku131072.dtb
+
+  mt8192-asurada-spherion-r0:
+    <<: *arm64-chromebook-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8192-asurada-spherion-r0.dtb
+
+  mt8195-cherry-tomato-r2:
+    <<: *arm64-chromebook-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
+
   sc7180-trogdor-kingoftown:
     <<: *arm64-chromebook-device
     mach: qcom
     dtb: dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb
+
+  sc7180-trogdor-lazor-limozeen:
+    <<: *arm64-chromebook-device
+    mach: qcom
+    dtb: dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb
 
   kubernetes:
     base_name: kubernetes
@@ -340,7 +360,11 @@ scheduler:
       name: lava-collabora
     platforms:
       - mt8183-kukui-jacuzzi-juniper-sku16
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
       - sc7180-trogdor-kingoftown
+      - sc7180-trogdor-lazor-limozeen
 
   - job: baseline-x86
     event:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -317,6 +317,21 @@ device_types:
     mach: mediatek
     dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
 
+  rk3399-gru-kevin:
+    <<: *arm64-chromebook-device
+    mach: rockchip
+    dtb: dtbs/rockchip/rk3399-gru-kevin.dtb
+
+  rk3399-rock-pi-4b:
+    <<: *arm64-device
+    mach: rockchip
+    dtb: dtbs/rockchip/rk3399-rock-pi-4b.dtb
+
+  rk3588-rock-5b:
+    <<: *arm64-device
+    mach: rockchip
+    dtb: dtbs/rockchip/rk3588-rock-5b.dtb
+
   sc7180-trogdor-kingoftown:
     <<: *arm64-chromebook-device
     mach: qcom
@@ -326,6 +341,11 @@ device_types:
     <<: *arm64-chromebook-device
     mach: qcom
     dtb: dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb
+
+  sun50i-h6-pine-h64:
+    <<: *arm64-device
+    mach: allwinner
+    dtb: dtbs/allwinner/sun50i-h6-pine-h64.dtb
 
   kubernetes:
     base_name: kubernetes
@@ -349,6 +369,9 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
+      - rk3399-rock-pi-4b
+      - rk3588-rock-5b
+      - sun50i-h6-pine-h64
 
   - job: baseline-arm64-chromebook
     event:
@@ -363,6 +386,7 @@ scheduler:
       - mt8186-corsola-steelix-sku131072
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
+      - rk3399-gru-kevin
       - sc7180-trogdor-kingoftown
       - sc7180-trogdor-lazor-limozeen
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -192,7 +192,7 @@ jobs:
       arch: arm
       compiler: gcc-10
       cross_compile: 'arm-linux-gnueabihf-'
-      defconfig: defconfig
+      defconfig: multi_v7_defconfig
 
   kbuild-gcc-10-i386:
     <<: *kbuild-job
@@ -454,6 +454,10 @@ build_variants:
           base_defconfig: 'defconfig'
           filters:
             - regex: { defconfig: 'defconfig' }
+        armel:
+          base_defconfig: 'multi_v7_defconfig'
+          filters:
+            - regex: { defconfig: 'multi_v7_defconfig' }
 
 
 build_configs:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -185,7 +185,7 @@ jobs:
       cross_compile_compat: 'arm-linux-gnueabihf-'
       fragments: ['arm64-chromebook']
 
-  kbuild-gcc-10-arm:
+  kbuild-gcc-10-armel:
     <<: *kbuild-job
     image: kernelci/staging-gcc-10:arm64-kselftest-kernelci
     params:
@@ -389,7 +389,7 @@ scheduler:
   - job: kbuild-gcc-10-arm64
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-10-arm
+  - job: kbuild-gcc-10-armel
     <<: *build-k8s-all
 
   - job: kbuild-gcc-10-arm64-chromebook
@@ -435,6 +435,8 @@ build_environments:
     cc: gcc
     cc_version: 10
     arch_params:
+      armel:
+        name: 'arm'
       x86_64:
         name: 'x86'
 


### PR DESCRIPTION
Now that it seems ARM64 devices work as expected with the pipeline, let's add more of those available in Collabora's LAVA lab.

This PR also includes one commit fixing the name of the default defconfig for armv7 devices.