### PR TITLE
src/scheduler: store k8s context in the job node

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -96,12 +96,18 @@ class Scheduler(Service):
 
         job_id = str(runtime.get_job_id(running_job))
         node['data']['job_id'] = job_id
+
+        if platform.name == "kubernetes":
+            context = runtime.get_context()
+            node['data']['k8s_context'] = context
+
         try:
             self._api.node.update(node)
         except requests.exceptions.HTTPError as err:
             err_msg = json.loads(err.response.content).get("detail", [])
             self.log.error(err_msg)
 
+        self.log.debug(f"job node: {node}")
         self.log.info(' '.join([
             node['id'],
             runtime.config.name,


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2341

For the job running in k8s runtime, get k8s cluster name that ran the job and store it in the node data field i.e. `data.k8s_context`.