### PR TITLE
src/scheduler: remove debug log

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -116,7 +116,6 @@ class Scheduler(Service):
             err_msg = json.loads(err.response.content).get("detail", [])
             self.log.error(err_msg)
 
-        self.log.debug(f"job node: {node}")
         self.log.info(' '.join([
             node['id'],
             runtime.config.name,


### PR DESCRIPTION
Remove debug log for printing job node.

Fixes: d916ba8 ("src/scheduler: store k8s context in the job node")