### PR TITLE
src/scheduler: fix field name for storing k8s context name

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -124,7 +124,7 @@ class Scheduler(Service):
 
         if platform.name == "kubernetes":
             context = runtime.get_context()
-            node['data']['k8s_context'] = context
+            node['data']['job_context'] = context
 
         try:
             self._api.node.update(node)


### PR DESCRIPTION
Correct field name for storing k8s cluster name to `Node.data`. Set `data.job_context` field to align with model definition.

Fixes: d916ba8 ("src/scheduler: store k8s context in the job node")