### PR TITLE
kver.jinja2: delete hack for `kver` failure

### DIFF
--- a/config/runtime/kver.jinja2
+++ b/config/runtime/kver.jinja2
@@ -51,10 +51,10 @@ class Job(BaseJob):
                 return False
 
         return (
-            int(kver['version']) == mkver['VERSION'] and
-            int(kver['patchlevel']) == mkver['PATCHLEVEL'] and (
+            kver['version'] == mkver['VERSION'] and
+            kver['patchlevel'] == mkver['PATCHLEVEL'] and (
                 not mkver['SUBLEVEL'] or
-                int(kver['sublevel']) == mkver['SUBLEVEL']
+                kver['sublevel'] == mkver['SUBLEVEL']
             ) and (
                 not mkver['EXTRAVERSION'] or
                 kver['extra'].startswith(mkver['EXTRAVERSION'])


### PR DESCRIPTION
The hack was added as a temporary fix for `kver` job. As now the actual fix has been sent to the API, drop the hack from the job template.