### PR TITLE
pipeline: use the new platform config for the new system

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -265,11 +265,9 @@ trees:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git'
 
 
-device_types:
+platforms:
 
   docker:
-    base_name: docker
-    class: docker
 
   qemu-x86:
     base_name: qemu
@@ -383,12 +381,8 @@ device_types:
     dtb: dtbs/allwinner/sun50i-h6-pine-h64.dtb
 
   kubernetes:
-    base_name: kubernetes
-    class: kubernetes
 
   shell:
-    base_name: shell
-    class: shell
 
 
 scheduler:

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -26,7 +26,7 @@ class FstestsRunner:
         api_token = os.getenv('API_TOKEN')
         self._db_config = configs['db_configs'][args.db_config]
         self._db = kernelci.db.get_db(self._db_config, api_token)
-        self._device_configs = configs['device_types']
+        self._device_configs = configs['platforms']
         self._gce = args.gce
         self._gce_project = args.gce_project
         self._gce_zone = args.gce_zone


### PR DESCRIPTION
Switch to using the new `platforms` config instead of the legacy `device_types`.

Also remove `base_name` attributes where unnecessary (it is now inferred from the node name if left unspecified) and drop now-unneeded `class` attributes.