### PR TITLE
docker-compose.yaml: Add proper mapping of gateway hostname

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
     volumes: &base-volumes
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   scheduler: &scheduler
     container_name: 'kernelci-pipeline-scheduler'
@@ -38,6 +40,8 @@ services:
       - './data/k8s-credentials/.kube:/home/kernelci/.kube'
       - './data/k8s-credentials/.config/gcloud:/home/kernelci/.config/gcloud'
       - './data/k8s-credentials/.azure:/home/kernelci/.azure'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   scheduler-docker:
     <<: *scheduler
@@ -55,6 +59,8 @@ services:
       - './data/output:/home/kernelci/data/output'
       - './.docker-env:/home/kernelci/.docker-env'
       - '/var/run/docker.sock:/var/run/docker.sock'  # Docker-in-Docker
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   scheduler-lava:
     <<: *scheduler
@@ -67,6 +73,8 @@ services:
       - 'lava-collabora'
       - 'lava-collabora-staging'
       - 'lava-broonie'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   scheduler-k8s:
     <<: *scheduler
@@ -79,6 +87,8 @@ services:
       - '--runtimes'
       - 'k8s-gke-eu-west4'
       - 'k8s-all'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   tarball:
     <<: *base-service
@@ -93,6 +103,8 @@ services:
       - './data/ssh:/home/kernelci/data/ssh'
       - './data/src:/home/kernelci/data/src'
       - './data/output:/home/kernelci/data/output'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   trigger:
     <<: *base-service
@@ -101,6 +113,8 @@ services:
       - './pipeline/trigger.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   regression_tracker:
     <<: *base-service
@@ -111,6 +125,8 @@ services:
       - '/home/kernelci/pipeline/regression_tracker.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   test_report:
     <<: *base-service
@@ -121,6 +137,8 @@ services:
       - '/home/kernelci/pipeline/test_report.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   timeout:
     <<: *base-service
@@ -132,6 +150,8 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
       - '--mode=timeout'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   timeout-closing:
     <<: *base-service
@@ -143,6 +163,8 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
       - '--mode=closing'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   timeout-holdoff:
     <<: *base-service
@@ -154,3 +176,5 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
       - '--mode=holdoff'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Using 172.17.0.1 assuming default docker subnet and single instance, that might not work in some cases.
Proper scenario is to use mapping in docker-compose file to hostname host.docker.internal.

This is part of the efforts to make local development setup easier.