### PR TITLE
lava_callback.py: Handle failed jobs properly

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -44,6 +44,10 @@ def _upload_log(log_parser, job_node, storage):
         os.chmod(log_txt.name, 0o644)
         log_dir = '-'.join((job_node['name'], job_node['id']))
         log_txt.flush()
+        # Check size of log file before uploading,
+        # if it's empty, don't upload
+        if os.path.getsize(log_txt.name) == 0:
+            return None
         return storage.upload_single((log_txt.name, 'log.txt'), log_dir)
 
 
@@ -72,19 +76,17 @@ def async_job_submit(api_helper, node_id, job_callback):
 
     log_parser = job_callback.get_log_parser()
     job_result = job_callback.get_job_status()
-    if job_result and job_result == 'pass':
-        storage_config_name = job_callback.get_meta('storage_config_name')
-        storage = _get_storage(storage_config_name)
-        log_txt_url = _upload_log(log_parser, job_node, storage)
+    storage_config_name = job_callback.get_meta('storage_config_name')
+    storage = _get_storage(storage_config_name)
+    log_txt_url = _upload_log(log_parser, job_node, storage)
+    if log_txt_url:
         job_node['artifacts']['lava_log'] = log_txt_url
-        hierarchy = job_callback.get_hierarchy(results, job_node)
-        api_helper.submit_results(hierarchy, job_node)
-    else:
-        # As in https://github.com/kernelci/kernelci-api/issues/474
-        # failed LAVA job should not upload empty log file and set result
-        # as 'pass'
-        job_node['result'] = job_result
-        api_helper.api.node.update(job_node)
+        print(f"Log uploaded to {log_txt_url}")
+    # failed LAVA job should have result set to 'incomplete'
+    job_node['result'] = job_result
+    job_node['state'] = 'done'
+    hierarchy = job_callback.get_hierarchy(results, job_node)
+    api_helper.submit_results(hierarchy, job_node)
 
 
 @app.post('/node/<node_id>')


### PR DESCRIPTION
As mentioned in https://github.com/kernelci/kernelci-api/issues/474, even if job failed, node still registered as pass, and trying to upload non-existing log file. Fix that, if job is not completed, set proper node status, and dont upload non-existing log file, if it is not present.

Fixes: https://github.com/kernelci/kernelci-api/issues/474

Depends on: https://github.com/kernelci/kernelci-core/pull/2363