### PR TITLE
kunit.jinja2: Update node information up to date before submit

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -142,6 +142,8 @@ cd {src_path}
     def _submit(self, result, node, api):
         # Ensure top-level name is kept the same
         result = result.copy()
+        # update node to newest
+        node = api.node.get(node['id'])
         result['node']['name'] = node['name']
         api_helper = kernelci.api.helper.APIHelper(api)
         api_helper.submit_results(result, node)


### PR DESCRIPTION
We need to update node to latest before submit, to not miss jobid and such stuff.