### PR TITLE
config: pipeline: add initial Tast tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -1,0 +1,62 @@
+_anchors:
+
+  kbuild-gcc-10-arm64-chromeos: &kbuild-gcc-10-arm64-chromeos-job
+    template: kbuild.jinja2
+    kind: kbuild
+    image: kernelci/staging-gcc-10:arm64-kselftest-kernelci
+    params: &kbuild-gcc-10-arm64-chromeos-params
+      arch: arm64
+      compiler: gcc-10
+      cross_compile: 'aarch64-linux-gnu-'
+      cross_compile_compat: 'arm-linux-gnueabihf-'
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromiumos-{arch}-generic.flavour.config'
+      fragments:
+        - arm64-chromebook
+        - CONFIG_MODULE_COMPRESS=n
+
+  kbuild-gcc-10-x86-chromeos: &kbuild-gcc-10-x86-chromeos-job
+    <<: *kbuild-gcc-10-arm64-chromeos-job
+    image: kernelci/staging-gcc-10:x86-kselftest-kernelci
+    params: &kbuild-gcc-10-x86-chromeos-params
+      arch: x86_64
+      compiler: gcc-10
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromiumos-{arch}-generic.flavour.config'
+      fragments:
+        - x86-board
+        - CONFIG_MODULE_COMPRESS=n
+
+jobs:
+
+  baseline-arm64-chromeos-mediatek: &baseline-job
+    template: baseline.jinja2
+    kind: test
+
+  baseline-arm64-chromeos-qualcomm: *baseline-job
+  baseline-x86-pineview: *baseline-job
+  baseline-x86-stoneyridge: *baseline-job
+  baseline-x86-stoneyridge-staging: *baseline-job
+
+  kbuild-gcc-10-arm64-chromeos-mediatek:
+    <<: *kbuild-gcc-10-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-10-arm64-chromeos-params
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromiumos-mediatek.flavour.config'
+
+  kbuild-gcc-10-arm64-chromeos-qualcomm:
+    <<: *kbuild-gcc-10-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-10-arm64-chromeos-params
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromiumos-qualcomm.flavour.config'
+
+  kbuild-gcc-10-x86-chromeos-pineview:
+    <<: *kbuild-gcc-10-x86-chromeos-job
+    params:
+      <<: *kbuild-gcc-10-x86-chromeos-params
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromeos-intel-pineview.flavour.config'
+
+  kbuild-gcc-10-x86-chromeos-stoneyridge:
+    <<: *kbuild-gcc-10-x86-chromeos-job
+    params:
+      <<: *kbuild-gcc-10-x86-chromeos-params
+      defconfig: 'cros://chromeos-{krev}/{arch}/chromeos-amd-stoneyridge.flavour.config'
+

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -25,6 +25,200 @@ _anchors:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
 
+  tast: &tast-job
+    template: tast.jinja2
+    kind: test
+
+  tast-basic: &tast-basic-job
+    <<: *tast-job
+    params:
+      tests:
+        - platform.CheckDiskSpace
+        - platform.TPMResponsive
+
+  tast-hardware: &tast-hardware-job
+    <<: *tast-job
+    params:
+      tests:
+        - graphics.HardwareProbe
+        - graphics.KernelConfig
+        - graphics.KernelMemory
+        - hardware.DiskErrors
+        - hardware.SensorAccel
+        - hardware.SensorIioservice
+        - hardware.SensorIioserviceHard
+        - hardware.SensorLight
+        - hardware.SensorPresence
+        - hardware.SensorActivity
+        - health.ProbeSensorInfo
+        - health.DiagnosticsRun.*
+        - health.ProbeAudioHardwareInfo
+        - health.ProbeAudioInfo
+        - health.ProbeBacklightInfo
+        - health.ProbeCPUInfo
+        - health.ProbeFanInfo
+        - inputs.PhysicalKeyboardKernelMode
+
+  tast-kernel: &tast-kernel-job
+    <<: *tast-job
+    params:
+      tests:
+        - kernel.Bloat
+        - kernel.ConfigVerify.chromeos_kernelci
+        - kernel.ConfigVerify.chromeos
+        - kernel.CPUCgroup
+        - kernel.Cpuidle
+        - kernel.CryptoAPI
+        - kernel.CryptoDigest
+        - kernel.ECDeviceNode
+        - kernel.HighResTimers
+        - kernel.Limits
+        - kernel.PerfCallgraph
+
+  tast-mm-misc: &tast-mm-misc-job
+    <<: *tast-job
+    params:
+      tests:
+        - camera.Suspend
+        - camera.V4L2
+        - camera.V4L2Compliance
+        - camera.V4L2.certification
+        - camera.V4L2.supported_formats
+        - graphics.Clvk.api_tests
+        - graphics.Clvk.simple_test
+        - graphics.DRM.atomic_test_overlay_upscaling
+        - graphics.DRM.atomic_test_plane_alpha
+        - graphics.DRM.atomic_test_plane_ctm
+        - graphics.DRM.atomic_test_primary_pageflip
+        - graphics.DRM.atomic_test_rgba_primary
+        - graphics.DRM.atomic_test_video_overlay
+        - graphics.DRM.atomic_test_video_underlay
+        - graphics.DRM.dmabuf_test
+        - graphics.DRM.drm_cursor_test
+        - graphics.DRM.gbm_test
+        - graphics.DRM.linear_bo_test
+        - graphics.DRM.mapped_access_perf_test
+        - graphics.DRM.mmap_test
+        - graphics.DRM.null_platform_test
+        - graphics.DRM.swrast_test
+        - graphics.DRM.vk_glow
+        - graphics.DRM.yuv_to_rgb_test
+        - graphics.GLBench
+        - security.GPUSandboxed
+        - video.ImageProcessor.image_processor_unit_test
+        - video.MemCheck.av1_hw
+        - video.PlatformVAAPIUnittest
+
+  tast-perf: &tast-perf-job
+    <<: *tast-job
+    params:
+      tests:
+        - filemanager.UIPerf.directory_list
+        - filemanager.UIPerf.list_apps
+        - settings.DeviceMouseScrollAcceleration
+        - ui.DesksAnimationPerf
+        - ui.DragTabInTabletPerf.touch
+        - ui.OverviewWithExpandedDesksBarPerf
+
+  tast-perf-long-duration: &tast-perf-long-duration-job
+    <<: *tast-job
+    params:
+      tests:
+        - filemanager.ZipPerf
+        - storage.WriteZeroPerf
+        - ui.WindowCyclePerf
+        - ui.WindowResizePerf
+        - ui.BubbleLauncherAnimationPerf
+        - ui.DragMaximizedWindowPerf
+        - ui.DragTabInClamshellPerf
+        - ui.DragTabInTabletPerf
+
+  tast-platform: &tast-platform-job
+    <<: *tast-job
+    params:
+      tests:
+        - platform.CheckDiskSpace
+        - platform.CheckProcesses
+        - platform.CheckTracefsInstances
+        - platform.CrosDisks
+        - platform.CrosDisksArchive
+        - platform.CrosDisksFilesystem
+        - platform.CrosDisksFormat
+        - platform.CrosDisksRename
+        - platform.CrosDisksSSHFS
+        - platform.CrosID
+        - platform.DeviceHwid
+        - platform.DLCService
+        - platform.DLCServiceCrosDeploy
+        - platform.DLCServicePreloading
+        - platform.DMVerity
+        - platform.DumpVPDLog
+        - platform.Firewall
+        - platform.LocalPerfettoTBMTracedProbes
+        - platform.Memd
+        - platform.Mtpd
+        - platform.SerialNumber
+        - platform.TPMResponsive
+        - platform.TPMStatus
+        - storage.HealthInfo
+        - storage.InternalStorage
+        - storage.LowPowerStateResidence
+
+  tast-power: &tast-power-job
+    <<: *tast-job
+    params:
+      tests:
+        - power.CheckStatus
+        - power.CpufreqConf
+        - power.TabletModePowerOffMenu.close_menu
+        - power.TabletModePowerOffMenu.shut_down
+        - power.TabletModePowerOffMenu.sign_out
+        - power.SmartDim.flatbuffer
+        - power.SmartDim
+        - power.SmartDim.lacros
+        - power.UtilCheck
+        - typec.Basic
+
+  tast-sound: &tast-sound-job
+    <<: *tast-job
+    params:
+      tests:
+        - audio.AloopLoadedFixture
+        - audio.AloopLoadedFixture.stereo
+        - audio.ALSAConformance
+        - audio.BrowserShellAudioToneCheck
+        - audio.CheckingAudioFormats
+        - audio.CrasFeatures
+        - audio.CrasPlay
+        - audio.CrasRecord
+        - audio.CrasRecordQuality
+        - audio.DevicePlay
+        - audio.DevicePlay.unstable_model
+        - audio.DevicePlay.unstable_platform
+        - audio.DeviceRecord
+        - audio.UCMSequences.section_device
+        - audio.UCMSequences.section_modifier
+        - audio.UCMSequences.section_verb
+
+  tast-ui: &tast-ui-job
+    <<: *tast-job
+    params:
+      tests:
+        - ui.DesktopControl
+        - ui.HotseatAnimation.non_overflow_shelf
+        - ui.HotseatAnimation.non_overflow_shelf_lacros
+        - ui.HotseatAnimation.overflow_shelf
+        - ui.HotseatAnimation.overflow_shelf_lacros
+        - ui.HotseatAnimation.shelf_with_navigation_widget
+        - ui.HotseatAnimation.shelf_with_navigation_widget_lacros
+        - ui.WindowControl
+
+  tast-video: &tast-video-job
+    <<: *tast-job
+    params:
+      tests:
+        - video.ChromeStackDecoder.*
+
 jobs:
 
   baseline-arm64-chromeos-mediatek: &baseline-job
@@ -60,3 +254,57 @@ jobs:
       <<: *kbuild-gcc-10-x86-chromeos-params
       defconfig: 'cros://chromeos-{krev}/{arch}/chromeos-amd-stoneyridge.flavour.config'
 
+  tast-basic-arm64-mediatek: *tast-basic-job
+  tast-basic-arm64-qualcomm: *tast-basic-job
+  tast-basic-x86-pineview: *tast-basic-job
+  tast-basic-x86-stoneyridge: *tast-basic-job
+
+  tast-hardware-arm64-mediatek: *tast-hardware-job
+  tast-hardware-arm64-qualcomm: *tast-hardware-job
+  tast-hardware-x86-pineview: *tast-hardware-job
+  tast-hardware-x86-stoneyridge: *tast-hardware-job
+
+  tast-kernel-arm64-mediatek: *tast-kernel-job
+  tast-kernel-arm64-qualcomm: *tast-kernel-job
+  tast-kernel-x86-pineview: *tast-kernel-job
+  tast-kernel-x86-stoneyridge: *tast-kernel-job
+
+  tast-mm-misc-arm64-mediatek: *tast-mm-misc-job
+  tast-mm-misc-arm64-qualcomm: *tast-mm-misc-job
+  tast-mm-misc-x86-pineview: *tast-mm-misc-job
+  tast-mm-misc-x86-stoneyridge: *tast-mm-misc-job
+
+  tast-perf-arm64-mediatek: *tast-perf-job
+  tast-perf-arm64-qualcomm: *tast-perf-job
+  tast-perf-x86-pineview: *tast-perf-job
+  tast-perf-x86-stoneyridge: *tast-perf-job
+
+  tast-perf-long-duration-arm64-mediatek: *tast-perf-long-duration-job
+  tast-perf-long-duration-arm64-qualcomm: *tast-perf-long-duration-job
+  tast-perf-long-duration-x86-pineview: *tast-perf-long-duration-job
+  tast-perf-long-duration-x86-stoneyridge: *tast-perf-long-duration-job
+
+  tast-platform-arm64-mediatek: *tast-platform-job
+  tast-platform-arm64-qualcomm: *tast-platform-job
+  tast-platform-x86-pineview: *tast-platform-job
+  tast-platform-x86-stoneyridge: *tast-platform-job
+
+  tast-power-arm64-mediatek: *tast-power-job
+  tast-power-arm64-qualcomm: *tast-power-job
+  tast-power-x86-pineview: *tast-power-job
+  tast-power-x86-stoneyridge: *tast-power-job
+
+  tast-sound-arm64-mediatek: *tast-sound-job
+  tast-sound-arm64-qualcomm: *tast-sound-job
+  tast-sound-x86-pineview: *tast-sound-job
+  tast-sound-x86-stoneyridge: *tast-sound-job
+
+  tast-ui-arm64-mediatek: *tast-ui-job
+  tast-ui-arm64-qualcomm: *tast-ui-job
+  tast-ui-x86-pineview: *tast-ui-job
+  tast-ui-x86-stoneyridge: *tast-ui-job
+
+  tast-video-arm64-mediatek: *tast-video-job
+  tast-video-arm64-qualcomm: *tast-video-job
+  tast-video-x86-pineview: *tast-video-job
+  tast-video-x86-stoneyridge: *tast-video-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -177,22 +177,11 @@ jobs:
 
   baseline-arm64: *baseline-job
   baseline-arm64-broonie: *baseline-job
-  baseline-arm64-chromebook: *baseline-job
   baseline-armel: *baseline-job
-  baseline-armel-chromebook: *baseline-job
   baseline-x86: *baseline-job
-  baseline-x86-board: *baseline-job
-  baseline-x86-board-staging: *baseline-job
 
   kbuild-gcc-10-arm64:
     <<: *kbuild-gcc-10-arm64-job
-
-  kbuild-gcc-10-arm64-chromebook:
-    <<: *kbuild-gcc-10-arm64-job
-    params:
-      <<: *kbuild-gcc-10-arm64-params
-      cross_compile_compat: 'arm-linux-gnueabihf-'
-      fragments: ['arm64-chromebook']
 
   kbuild-gcc-10-armel:
     <<: *kbuild-job
@@ -222,19 +211,6 @@ jobs:
 
   kbuild-gcc-10-x86:
     <<: *kbuild-gcc-10-x86-job
-
-  kbuild-gcc-10-x86-board:
-    <<: *kbuild-gcc-10-x86-job
-    params:
-      <<: *kbuild-gcc-10-x86-params
-      fragments: ['x86-board']
-
-  kbuild-gcc-10-x86-chromeos:
-    <<: *kbuild-gcc-10-x86-job
-    params:
-      <<: *kbuild-gcc-10-x86-params
-      defconfig: 'cros://chromeos-{krev}/x86_64/chromeos-intel-pineview.flavour.config'
-      fragments: ['x86-board','CONFIG_MODULE_COMPRESS=n']
 
   kunit: &kunit-job
     template: kunit.jinja2
@@ -366,6 +342,7 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
+      - rk3399-gru-kevin
       - rk3399-rock-pi-4b
       - rk3588-rock-5b
       - sun50i-h6-pine-h64
@@ -381,23 +358,6 @@ scheduler:
     platforms:
       - sun50i-h5-libretech-all-h3-cc
 
-  - job: baseline-arm64-chromebook
-    event:
-      channel: node
-      name: kbuild-gcc-10-arm64-chromebook
-      result: pass
-    runtime:
-      type: lava
-      name: lava-collabora
-    platforms:
-      - mt8183-kukui-jacuzzi-juniper-sku16
-      - mt8186-corsola-steelix-sku131072
-      - mt8192-asurada-spherion-r0
-      - mt8195-cherry-tomato-r2
-      - rk3399-gru-kevin
-      - sc7180-trogdor-kingoftown
-      - sc7180-trogdor-lazor-limozeen
-
   - job: baseline-armel
     event:
       channel: node
@@ -411,16 +371,6 @@ scheduler:
       - imx6q-sabrelite
       - odroid-xu3
       - rk3288-rock2-square
-
-  - job: baseline-armel-chromebook
-    event:
-      channel: node
-      name: kbuild-gcc-10-armel
-      result: pass
-    runtime:
-      type: lava
-      name: lava-collabora
-    platforms:
       - rk3288-veyron-jaq
 
   - job: baseline-x86
@@ -435,46 +385,10 @@ scheduler:
       - qemu-x86
       - minnowboard-turbot-E3826
 
-  - job: baseline-x86-board
-    event:
-      channel: node
-      name: kbuild-gcc-10-x86-board
-      result: pass
-    runtime:
-      type: lava
-      name: lava-collabora
-    platforms:
-      - acer-R721T-grunt
-      - acer-cb317-1h-c3z6-dedede
-      - acer-cbv514-1h-34uz-brya
-      - acer-chromebox-cxi4-puff
-      - acer-cp514-3wh-r0qs-guybrush
-      - asus-C433TA-AJ0005-rammus
-      - asus-C436FA-Flip-hatch
-      - asus-cx9400-volteer
-      - dell-latitude-3445-7520c-skyrim
-      - dell-latitude-5300-8145U-arcada
-      - hp-14b-na0052xx-zork
-      - hp-x360-12b-ca0010nr-n4020-octopus
-
-  - job: baseline-x86-board-staging
-    event:
-      channel: node
-      name: kbuild-gcc-10-x86-board
-      result: pass
-    runtime:
-      type: lava
-      name: lava-collabora-staging
-    platforms:
-      - dell-latitude-3445-7520c-skyrim
-
   - job: kbuild-gcc-10-arm64
     <<: *build-k8s-all
 
   - job: kbuild-gcc-10-armel
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-10-arm64-chromebook
     <<: *build-k8s-all
 
   - job: kbuild-gcc-10-i386
@@ -484,12 +398,6 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-10-x86
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-10-x86-board
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-10-x86-chromeos
     <<: *build-k8s-all
 
   - job: kunit

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -10,17 +10,9 @@ _anchors:
     arch: arm64
     boot_method: u-boot
 
-  arm64-chromebook-device: &arm64-chromebook-device
-    <<: *arm64-device
-    boot_method: depthcharge
-
   armel-device: &armel-device
     <<: *arm64-device
     arch: armel
-
-  armel-chromebook-device: &armel-chromebook-device
-    <<: *armel-device
-    boot_method: depthcharge
 
   baseline: &baseline-job
     template: baseline.jinja2
@@ -61,10 +53,6 @@ _anchors:
     arch: x86_64
     boot_method: grub
     mach: x86
-
-  x86_64-chromebook-device: &x86_64-chromebook-device
-    <<: *x86_64-device
-    boot_method: depthcharge
 
 api:
 
@@ -298,19 +286,6 @@ platforms:
   minnowboard-turbot-E3826: *x86_64-device
   aaeon-UPN-EHLX4RE-A10-0864: *x86_64-device
 
-  acer-R721T-grunt: *x86_64-chromebook-device
-  acer-cb317-1h-c3z6-dedede: *x86_64-chromebook-device
-  acer-cbv514-1h-34uz-brya: *x86_64-chromebook-device
-  acer-chromebox-cxi4-puff: *x86_64-chromebook-device
-  acer-cp514-3wh-r0qs-guybrush: *x86_64-chromebook-device
-  asus-C433TA-AJ0005-rammus: *x86_64-chromebook-device
-  asus-C436FA-Flip-hatch: *x86_64-chromebook-device
-  asus-cx9400-volteer: *x86_64-chromebook-device
-  dell-latitude-3445-7520c-skyrim: *x86_64-chromebook-device
-  dell-latitude-5300-8145U-arcada: *x86_64-chromebook-device
-  hp-14b-na0052xx-zork: *x86_64-chromebook-device
-  hp-x360-12b-ca0010nr-n4020-octopus: *x86_64-chromebook-device
-
   bcm2711-rpi-4-b:
     <<: *arm64-device
     mach: broadcom
@@ -336,26 +311,6 @@ platforms:
     mach: amlogic
     dtb: dtbs/amlogic/meson-g12b-a311d-khadas-vim3.dtb
 
-  mt8183-kukui-jacuzzi-juniper-sku16:
-    <<: *arm64-chromebook-device
-    mach: mediatek
-    dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
-
-  mt8186-corsola-steelix-sku131072:
-    <<: *arm64-chromebook-device
-    mach: mediatek
-    dtb: dtbs/mediatek/mt8186-corsola-steelix-sku131072.dtb
-
-  mt8192-asurada-spherion-r0:
-    <<: *arm64-chromebook-device
-    mach: mediatek
-    dtb: dtbs/mediatek/mt8192-asurada-spherion-r0.dtb
-
-  mt8195-cherry-tomato-r2:
-    <<: *arm64-chromebook-device
-    mach: mediatek
-    dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
-
   odroid-xu3:
     <<: *armel-device
     mach: samsung
@@ -367,12 +322,14 @@ platforms:
     dtb: dtbs/rk3288-rock2-square.dtb
 
   rk3288-veyron-jaq:
-    <<: *armel-chromebook-device
+    <<: *armel-device
+    boot_method: depthcharge
     mach: rockchip
     dtb: dtbs/rk3288-veyron-jaq.dtb
 
   rk3399-gru-kevin:
-    <<: *arm64-chromebook-device
+    <<: *arm64-device
+    boot_method: depthcharge
     mach: rockchip
     dtb: dtbs/rockchip/rk3399-gru-kevin.dtb
 
@@ -385,16 +342,6 @@ platforms:
     <<: *arm64-device
     mach: rockchip
     dtb: dtbs/rockchip/rk3588-rock-5b.dtb
-
-  sc7180-trogdor-kingoftown:
-    <<: *arm64-chromebook-device
-    mach: qcom
-    dtb: dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb
-
-  sc7180-trogdor-lazor-limozeen:
-    <<: *arm64-chromebook-device
-    mach: qcom
-    dtb: dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb
 
   sun50i-h6-pine-h64:
     <<: *arm64-device

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -1,0 +1,167 @@
+_anchors:
+
+  arm64-chromebook-device: &arm64-chromebook-device
+    arch: arm64
+    boot_method: depthcharge
+    params: &arm64-chromebook-device-params
+      flash_kernel:
+        url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-{mach}
+        image: 'kernel/Image'
+      nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/arm64
+
+  x86-chromebook-device: &x86-chromebook-device
+    arch: x86_64
+    boot_method: depthcharge
+    mach: x86
+    params: &x86-chromebook-device-params
+      flash_kernel:
+        url: https://storage.chromeos.kernelci.org/images/kernel/cros-20230815-amd64/clang-14
+        image: 'kernel/bzImage'
+      nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/amd64
+
+platforms:
+  acer-R721T-grunt: &chromebook-grunt-device
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20240129.0/amd64/tast.tgz
+
+  acer-cb317-1h-c3z6-dedede:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20240129.0/amd64/tast.tgz
+
+  acer-cbv514-1h-34uz-brya:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-brya/20240129.0/amd64/tast.tgz
+
+  acer-chromebox-cxi4-puff:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-puff/20240129.0/amd64/tast.tgz
+
+  acer-cp514-2h-1160g7-volteer: &chromebook-volteer-device
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20240129.0/amd64/tast.tgz
+
+  acer-cp514-3wh-r0qs-guybrush:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-guybrush/20240129.0/amd64/tast.tgz
+
+  asus-C433TA-AJ0005-rammus:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20240129.0/amd64/tast.tgz
+
+  asus-C436FA-Flip-hatch:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20240129.0/amd64/tast.tgz
+
+  asus-C523NA-A20057-coral:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20240129.0/amd64/tast.tgz
+
+  asus-CM1400CXA-dalboz_chromeos: &chromebook-zork-device
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20240129.0/amd64/tast.tgz
+
+  asus-cx9400-volteer: *chromebook-volteer-device
+
+  dell-latitude-3445-7520c-skyrim:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-skyrim/20240129.0/amd64/tast.tgz
+
+  dell-latitude-5300-8145U-arcada: &chromebook-sarien-device
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20240129.0/amd64/tast.tgz
+
+  dell-latitude-5400-4305U-sarien: *chromebook-sarien-device
+  dell-latitude-5400-8665U-sarien: *chromebook-sarien-device
+  hp-14-db0003na-grunt: *chromebook-grunt-device
+  hp-11A-G6-EE-grunt: *chromebook-grunt-device
+  hp-14b-na0052xx-zork: *chromebook-zork-device
+
+  hp-x360-14-G1-sona:
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20240129.0/amd64/tast.tgz
+
+  hp-x360-12b-ca0010nr-n4020-octopus: &chromebook-octopus-device
+    <<: *x86-chromebook-device
+    params:
+      <<: *x86-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20240129.0/amd64/tast.tgz
+
+  hp-x360-12b-ca0500na-n4000-octopus: *chromebook-octopus-device
+  hp-x360-14a-cb0001xx-zork: *chromebook-zork-device
+  lenovo-TPad-C13-Yoga-zork: *chromebook-zork-device
+
+  mt8183-kukui-jacuzzi-juniper-sku16: &mediatek-chromebook-device
+    <<: *arm64-chromebook-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
+    params: &mediatek-chromebook-device-params
+      <<: *arm64-chromebook-device-params
+      flash_kernel:
+        url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-mediatek
+        image: 'kernel/Image'
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20240129.0/arm64/tast.tgz
+
+  mt8186-corsola-steelix-sku131072:
+    <<: *mediatek-chromebook-device
+    dtb: dtbs/mediatek/mt8186-corsola-steelix-sku131072.dtb
+    params:
+      <<: *mediatek-chromebook-device-params
+      flash_kernel:
+        url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240129.0/arm64
+        image: 'Image'
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240129.0/arm64/tast.tgz
+
+  mt8192-asurada-spherion-r0:
+    <<: *mediatek-chromebook-device
+    dtb: dtbs/mediatek/mt8192-asurada-spherion-r0.dtb
+    params:
+      <<: *mediatek-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20240129.0/arm64/tast.tgz
+
+  mt8195-cherry-tomato-r2:
+    <<: *mediatek-chromebook-device
+    dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
+    params:
+      <<: *mediatek-chromebook-device-params
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20240129.0/arm64/tast.tgz
+
+  sc7180-trogdor-kingoftown: &trogdor-chromebook-device
+    <<: *arm64-chromebook-device
+    mach: qcom
+    dtb: dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb
+    params:
+      <<: *arm64-chromebook-device-params
+      flash_kernel:
+        url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-qualcomm
+        image: 'kernel/Image'
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20240129.0/arm64/tast.tgz
+
+  sc7180-trogdor-lazor-limozeen:
+    <<: *trogdor-chromebook-device
+    dtb: dtbs/qcom/sc7180-trogdor-lazor-limozeen-nots-r5.dtb

--- a/config/runtime/tast.jinja2
+++ b/config/runtime/tast.jinja2
@@ -1,9 +1,15 @@
+{%- set base_kurl = platform_config.params.flash_kernel.url %}
 {%- set boot_commands = 'nfs' %}
 {%- set boot_namespace = 'modules' %}
-{%- set kernel_url = platform_config.params.flash_kernel.image %}
-{%- set modules_url = platform_config.params.flash_kernel.modules %}
+{%- set flash_modules = 'modules.tar.xz' %}
+{%- if platform_config.params.flash_kernel.modules %}
+{%-   set flash_modules = platform_config.params.flash_kernel.modules %}
+{%- endif %}
+
+{%- set kernel_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.image %}
+{%- set modules_url = base_kurl ~ '/' ~ flash_modules %}
 {%- if platform_config.dtb %}
-{%-   set dtb_url = platform_config.params.flash_kernel.dtb %}
+{%-   set dtb_url = base_kurl ~ '/' ~ platform_config.dtb %}
 {%- endif %}
 {%- set nfsroot = platform_config.params.nfsroot %}
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -1,0 +1,117 @@
+_anchors:
+
+  amd-stoneyridge-platforms: &amd-stoneyridge-platforms
+    - acer-R721T-grunt
+    - acer-cp514-3wh-r0qs-guybrush
+    - asus-CM1400CXA-dalboz_chromeos
+    - dell-latitude-3445-7520c-skyrim
+    - hp-14-db0003na-grunt
+    - hp-11A-G6-EE-grunt
+    - hp-14b-na0052xx-zork
+    - hp-x360-14a-cb0001xx-zork
+    - lenovo-TPad-C13-Yoga-zork
+
+  intel-pineview-platforms: &intel-pineview-platforms
+    - acer-cb317-1h-c3z6-dedede
+    - acer-cbv514-1h-34uz-brya
+    - acer-chromebox-cxi4-puff
+    - acer-cp514-2h-1160g7-volteer
+    - asus-cx9400-volteer
+    - asus-C433TA-AJ0005-rammus
+    - asus-C436FA-Flip-hatch
+    - asus-C523NA-A20057-coral
+    - dell-latitude-5300-8145U-arcada
+    - dell-latitude-5400-4305U-sarien
+    - dell-latitude-5400-8665U-sarien
+    - hp-x360-14-G1-sona
+    - hp-x360-12b-ca0010nr-n4020-octopus
+    - hp-x360-12b-ca0500na-n4000-octopus
+
+  mediatek-platforms: &mediatek-platforms
+    - mt8183-kukui-jacuzzi-juniper-sku16
+    - mt8186-corsola-steelix-sku131072
+    - mt8192-asurada-spherion-r0
+    - mt8195-cherry-tomato-r2
+
+  qualcomm-platforms: &qualcomm-platforms
+    - sc7180-trogdor-kingoftown
+    - sc7180-trogdor-lazor-limozeen
+
+  build-k8s-all: &build-k8s-all
+    event:
+      channel: node
+      name: checkout
+      state: available
+    runtime:
+      name: k8s-all
+
+  lava-job-collabora: &lava-job-collabora
+    runtime:
+      type: lava
+      name: lava-collabora
+
+  test-job-mediatek: &test-job-mediatek
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-arm64-chromeos-mediatek
+      result: pass
+    platforms: *mediatek-platforms
+
+  test-job-pineview: &test-job-pineview
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-chromeos-pineview
+      result: pass
+    platforms: *intel-pineview-platforms
+
+  test-job-qualcomm: &test-job-qualcomm
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-arm64-chromeos-qualcomm
+      result: pass
+    platforms: *qualcomm-platforms
+
+  test-job-stoneyridge: &test-job-stoneyridge
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-chromeos-stoneyridge
+      result: pass
+    platforms: *amd-stoneyridge-platforms
+
+scheduler:
+
+  - job: baseline-arm64-chromeos-mediatek
+    <<: *test-job-mediatek
+
+  - job: baseline-arm64-chromeos-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: baseline-x86-pineview
+    <<: *test-job-pineview
+
+  - job: baseline-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: baseline-x86-stoneyridge-staging
+    <<: *test-job-stoneyridge
+    runtime:
+      type: lava
+      name: lava-collabora-staging
+    platforms:
+    - dell-latitude-3445-7520c-skyrim
+
+  - job: kbuild-gcc-10-arm64-chromeos-mediatek
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-10-arm64-chromeos-qualcomm
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-10-x86-chromeos-pineview
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-10-x86-chromeos-stoneyridge
+    <<: *build-k8s-all

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -115,3 +115,135 @@ scheduler:
 
   - job: kbuild-gcc-10-x86-chromeos-stoneyridge
     <<: *build-k8s-all
+
+  - job: tast-basic-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-basic-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-basic-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-basic-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-hardware-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-hardware-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-hardware-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-hardware-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-kernel-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-kernel-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-kernel-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-kernel-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-mm-misc-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-mm-misc-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-mm-misc-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-mm-misc-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-perf-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-perf-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-perf-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-perf-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-perf-long-duration-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-perf-long-duration-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-perf-long-duration-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-perf-long-duration-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-platform-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-platform-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-platform-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-platform-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-power-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-power-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-power-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-power-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-sound-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-sound-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-sound-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-sound-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-ui-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-ui-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-ui-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-ui-x86-stoneyridge
+    <<: *test-job-stoneyridge
+
+  - job: tast-video-arm64-mediatek
+    <<: *test-job-mediatek
+
+  - job: tast-video-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-video-x86-pineview
+    <<: *test-job-pineview
+
+  - job: tast-video-x86-stoneyridge
+    <<: *test-job-stoneyridge

--- a/kube/aks/lava-callback.yaml
+++ b/kube/aks/lava-callback.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - python3
             - src/lava_callback.py
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
           env:
             - name: KCI_API_TOKEN
               valueFrom:

--- a/kube/aks/monitor.yaml
+++ b/kube/aks/monitor.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - ./src/monitor.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
           env:
             - name: KCI_API_TOKEN

--- a/kube/aks/nodehandlers.yaml
+++ b/kube/aks/nodehandlers.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - ./src/timeout.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
             - --mode=timeout
           env:
@@ -70,7 +70,7 @@ spec:
           command:
             - ./src/timeout.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
             - --mode=closing
           env:
@@ -114,7 +114,7 @@ spec:
           command:
             - ./src/timeout.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
             - --mode=holdoff
           env:

--- a/kube/aks/scheduler-k8s.yaml
+++ b/kube/aks/scheduler-k8s.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - ./src/scheduler.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - loop
             - --runtimes=k8s-gke-eu-west4
           env:
@@ -79,4 +79,3 @@ spec:
             secretName: k8scredentials
         - name: tmpsecrets
           emptyDir: {}
-

--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - ./src/scheduler.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - loop
             - --runtimes=lava-collabora-early-access
           env:

--- a/kube/aks/tarball.yaml
+++ b/kube/aks/tarball.yaml
@@ -33,7 +33,7 @@ spec:
           command:
             - ./src/tarball.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
           env:
             - name: KCI_API_TOKEN

--- a/kube/aks/trigger.yaml
+++ b/kube/aks/trigger.yaml
@@ -26,7 +26,7 @@ spec:
           command:
             - ./src/trigger.py
             - --settings=/secrets/kernelci.toml
-            - --yaml-config=/config/pipeline.yaml
+            - --yaml-config=/config
             - run
           env:
             - name: KCI_API_TOKEN

--- a/src/fstests/runner.py
+++ b/src/fstests/runner.py
@@ -182,6 +182,6 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('fstests_runner', globals())
-    configs = kernelci.config.load('config/pipeline.yaml')
+    configs = kernelci.config.load('config')
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -19,7 +19,7 @@ import kernelci.storage
 
 SETTINGS = toml.load(os.getenv('KCI_SETTINGS', 'config/kernelci.toml'))
 CONFIGS = kernelci.config.load(
-    SETTINGS.get('DEFAULT', {}).get('yaml_config', 'config/pipeline.yaml')
+    SETTINGS.get('DEFAULT', {}).get('yaml_config', 'config')
 )
 SETTINGS_PREFIX = 'runtime'
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -87,7 +87,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('monitor', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -109,7 +109,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('regression_tracker', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -173,7 +173,7 @@ class cmd_loop(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('scheduler', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -119,7 +119,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('send_kcidb', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -159,7 +159,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('tarball', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -234,7 +234,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('test_report', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -206,7 +206,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('timeout', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     pipeline = kernelci.config.load(yaml_configs)
     status = opts.command(pipeline, opts)
     sys.exit(0 if status is True else 1)

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -159,7 +159,7 @@ class cmd_run(Command):
 
 if __name__ == '__main__':
     opts = parse_opts('trigger', globals())
-    yaml_configs = opts.get_yaml_configs() or 'config/pipeline.yaml'
+    yaml_configs = opts.get_yaml_configs() or 'config'
     configs = kernelci.config.load(yaml_configs)
     status = opts.command(configs, opts)
     sys.exit(0 if status is True else 1)


### PR DESCRIPTION
This change adds a `tast-quickcheck-x86` job, running on 2 Intel-based devices in order to help debug the new Tast implementation.