### PR TITLE
src/tarball: type conversion for version dict

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -138,6 +138,8 @@ git archive --format=tar --prefix={name}/ HEAD | gzip > {output}/{tarball}
                 build_config.tree.name, self._kdir
             )
             version = self._get_version_from_describe()
+            # Make the field data types compatible with API version model
+            version = self._api_helper.translate_version_fields(version)
             tarball_url = self._push_tarball(build_config, describe)
             self._update_node(checkout_node, describe, version, tarball_url)
 


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2382

As the API has enforced strict int data type for some of the version information fields, data type cast is required to make sure `int` fields are not sent off as `str` fields. Otherwise, the below error will be encountered:
```
kernelci-pipeline-tarball | 02/16/2024 07:15:59 AM UTC [ERROR] 2 validation errors for Checkout
kernelci-pipeline-tarball | data -> kernel_revision -> version -> version
kernelci-pipeline-tarball |   value is not a valid integer (type=type_error.integer)
kernelci-pipeline-tarball | data -> kernel_revision -> version -> patchlevel
kernelci-pipeline-tarball |   value is not a valid integer (type=type_error.integer)
```