### PR TITLE
scheduler: return early if node creation skipped

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -75,6 +75,8 @@ class Scheduler(Service):
     def _run_job(self, job_config, runtime, platform, input_node):
         node = self._api_helper.create_job_node(job_config, input_node,
                                                 runtime, platform)
+        if not node:
+            return
         job = kernelci.runtime.Job(node, job_config)
         job.platform_config = platform
         job.storage_config = self._storage_config


### PR DESCRIPTION
Due to platform filters, `create_job_node()` could skip a node creation and return `None`. In such cases, we should stop processing immediately and quietly return.