### PR TITLE
config: runtime: adapt to python template changes

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -39,9 +39,8 @@ KBUILD_PARAMS = {
 WORKSPACE = '/tmp/kci'
 
 def main(args):
-    build = KBuild(node=NODE, jobname=JOB_NAME, params=KBUILD_PARAMS)
+    build = KBuild(node=NODE, jobname=JOB_NAME, params=KBUILD_PARAMS, apiconfig=API_CONFIG_YAML)
     build.set_workspace(WORKSPACE)
-    build.set_api_config(API_CONFIG_YAML)
     build.set_storage_config(STORAGE_CONFIG_YAML)
     build.write_script("build.sh")
     build.serialize("_build.json")

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -64,8 +64,8 @@ cd {src_path}
     def _upload_artifacts(self, local_artifacts):
         artifacts = {}
         storage = self._get_storage()
-        if storage and NODE:
-            root_path = '-'.join([JOB_NAME, NODE['id']])
+        if storage and self._node:
+            root_path = '-'.join([JOB_NAME, self._node['id']])
             print(f"Uploading artifacts to {root_path}")
             for file_name, file_path in local_artifacts.items():
                 # Normalize field names
@@ -139,12 +139,12 @@ cd {src_path}
 
         return results
 
-    def _submit(self, result, node, api):
+    def _submit(self, result):
         # Ensure top-level name is kept the same
         result = result.copy()
-        result['node']['name'] = node['name']
-        api_helper = kernelci.api.helper.APIHelper(api)
-        api_helper.submit_results(result, node)
+        result['node']['name'] = self._node['name']
+        api_helper = kernelci.api.helper.APIHelper(self._api)
+        api_helper.submit_results(result, self._node)
 
         return node
 {% endblock %}


### PR DESCRIPTION
The `base/python.jinja2` template has evolved with changes to the `Job` class API. Reflect and leverage those changes in both the `kunit` and `kbuild` templates.

Depends on https://github.com/kernelci/kernelci-core/pull/2428