### PR TITLE
Add rules based on legacy config

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -128,6 +128,9 @@ runtimes:
       callback:
         token: kernelci-new-api-callback
         url: https://staging.kernelci.org:9100
+    rules:
+      tree:
+      - '!android'
 
   lava-collabora: &lava-collabora-staging
     lab_type: lava
@@ -138,6 +141,9 @@ runtimes:
       callback:
         token: kernelci-api-token-staging
         url: https://staging.kernelci.org:9100
+    rules:
+      tree:
+      - '!android'
 
   # ToDo: avoid creating a separate Runtime entry
   # https://github.com/kernelci/kernelci-core/issues/2088
@@ -149,10 +155,8 @@ runtimes:
         url: https://staging.kernelci.org:9100
 
   lava-collabora-staging:
-    lab_type: lava
+    <<: *lava-collabora-staging
     url: https://staging.lava.collabora.dev/
-    priority_min: 40
-    priority_max: 60
     notify:
       callback:
         token: kernelci-api-token-lava-staging

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -136,6 +136,11 @@ platforms:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-mediatek
         image: 'kernel/Image'
       tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20240129.0/arm64/tast.tgz
+    rules:
+      <<: *arm64-chromebook-device-rules
+      min_version:
+        version: 6
+        patchlevel: 1
 
   mt8186-corsola-steelix-sku131072:
     <<: *mediatek-chromebook-device
@@ -146,6 +151,11 @@ platforms:
         url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240129.0/arm64
         image: 'Image'
       tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240129.0/arm64/tast.tgz
+    rules:
+      <<: *arm64-chromebook-device-rules
+      min_version:
+        version: 6
+        patchlevel: 9
 
   mt8192-asurada-spherion-r0:
     <<: *mediatek-chromebook-device
@@ -153,6 +163,11 @@ platforms:
     params:
       <<: *mediatek-chromebook-device-params
       tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20240129.0/arm64/tast.tgz
+    rules:
+      <<: *arm64-chromebook-device-rules
+      min_version:
+        version: 6
+        patchlevel: 4
 
   mt8195-cherry-tomato-r2:
     <<: *mediatek-chromebook-device
@@ -160,6 +175,11 @@ platforms:
     params:
       <<: *mediatek-chromebook-device-params
       tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20240129.0/arm64/tast.tgz
+    rules:
+      <<: *arm64-chromebook-device-rules
+      min_version:
+        version: 6
+        patchlevel: 7
 
   sc7180-trogdor-kingoftown: &trogdor-chromebook-device
     <<: *arm64-chromebook-device

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -8,6 +8,12 @@ _anchors:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-{mach}
         image: 'kernel/Image'
       nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/arm64
+    rules: &arm64-chromebook-device-rules
+      defconfig:
+        - '!allnoconfig'
+        - '!allmodconfig'
+      fragments:
+        - 'arm64-chromebook'
 
   x86-chromebook-device: &x86-chromebook-device
     arch: x86_64
@@ -18,6 +24,10 @@ _anchors:
         url: https://storage.chromeos.kernelci.org/images/kernel/cros-20230815-amd64/clang-14
         image: 'kernel/bzImage'
       nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/amd64
+    rules:
+      <<: *arm64-chromebook-device-rules
+      fragments:
+        - 'x86-board'
 
 platforms:
   acer-R721T-grunt: &chromebook-grunt-device


### PR DESCRIPTION
This PR adds a few rules matching those currently present in the legacy configs. Most of those will have no effect for now, as we're either not monitoring the corresponding tree (e.g. `android`) or already ensure the proper defconfig/fragments are used through job definitions and platforms allocation.

The lab rules make sense nonetheless as we'll likely start monitoring the Android tree at some point.

I also think the rules for Mediatek Chromebooks make sense due to fairly recent upstream support of some of those.

I'd happily get rid of per-platform rules on "generic" devices (those found in `pipeline.yaml`) though and defconfig/fragments rules for Chromebooks (see `platforms-chromeos.yaml`).
