### PR TITLE
scheduler: apply rules before running job

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 100

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -150,9 +150,10 @@ class Scheduler(Service):
 
         while True:
             event = self._api_helper.receive_event_data(sub_id)
-            for job, runtime, platform in self._sched.get_schedule(event):
+            for job, runtime, platform, rules in self._sched.get_schedule(event):
                 input_node = self._api.node.get(event['id'])
-                self._run_job(job, runtime, platform, input_node)
+                if self._api_helper.should_create_node(rules, input_node):
+                    self._run_job(job, runtime, platform, input_node)
 
         return True
 


### PR DESCRIPTION
Scheduler config entries can now contain rules to ensure jobs are only executed when certain conditions are met. This change ensures this check is properly conducted before actually attempting to run a job.

Depends on https://github.com/kernelci/kernelci-core/pull/2439