### PR TITLE
Enable DT kselftest for MediaTek Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -350,6 +350,13 @@ jobs:
   baseline-x86-stoneyridge: *baseline-job
   baseline-x86-stoneyridge-staging: *baseline-job
 
+  kbuild-gcc-10-arm64-chromebook:
+    <<: *kbuild-gcc-10-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-10-arm64-chromeos-params
+      cross_compile_compat:
+      defconfig: defconfig
+
   kbuild-gcc-10-arm64-chromeos-mediatek:
     <<: *kbuild-gcc-10-arm64-chromeos-job
     params:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -241,6 +241,7 @@ jobs:
     template: kselftest.jinja2
     kind: test
     params:
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{arch}'
       collections: dt
       job_timeout: 10
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -104,6 +104,9 @@ scheduler:
     platforms:
     - dell-latitude-3445-7520c-skyrim
 
+  - job: kbuild-gcc-10-arm64-chromebook
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-10-arm64-chromeos-mediatek
     <<: *build-k8s-all
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -119,6 +119,14 @@ scheduler:
   - job: kbuild-gcc-10-x86-chromeos-stoneyridge
     <<: *build-k8s-all
 
+  - job: kselftest-dt
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-arm64-chromebook
+      result: pass
+    platforms: *mediatek-platforms
+
   - job: tast-basic-arm64-mediatek
     <<: *test-job-mediatek
 


### PR DESCRIPTION
Enable the DT kselftest for MediaTek Chromebooks.