### PR TITLE
Enable baseline test on all the Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -361,10 +361,8 @@ jobs:
   baseline-arm64-mediatek: *baseline-job
   baseline-arm64-qualcomm: *baseline-job
   baseline-x86-amd: *baseline-job
+  baseline-x86-amd-staging: *baseline-job
   baseline-x86-intel: *baseline-job
-  baseline-x86-pineview: *baseline-job
-  baseline-x86-stoneyridge: *baseline-job
-  baseline-x86-stoneyridge-staging: *baseline-job
 
   kbuild-gcc-10-arm64-chromebook:
     <<: *kbuild-gcc-10-arm64-chromeos-job
@@ -385,13 +383,13 @@ jobs:
       <<: *kbuild-gcc-10-arm64-chromeos-params
       flavour: qualcomm
 
-  kbuild-gcc-10-x86-chromeos-pineview:
+  kbuild-gcc-10-x86-chromeos-intel:
     <<: *kbuild-gcc-10-x86-chromeos-job
     params:
       <<: *kbuild-gcc-10-x86-chromeos-params
       flavour: intel-pineview
 
-  kbuild-gcc-10-x86-chromeos-stoneyridge:
+  kbuild-gcc-10-x86-chromeos-amd:
     <<: *kbuild-gcc-10-x86-chromeos-job
     params:
       <<: *kbuild-gcc-10-x86-chromeos-params
@@ -399,8 +397,8 @@ jobs:
 
   tast-basic-arm64-mediatek: *tast-basic-job
   tast-basic-arm64-qualcomm: *tast-basic-job
-  tast-basic-x86-pineview: *tast-basic-job
-  tast-basic-x86-stoneyridge: *tast-basic-job
+  tast-basic-x86-intel: *tast-basic-job
+  tast-basic-x86-amd: *tast-basic-job
 
   tast-decoder-chromestack-arm64-mediatek: *tast-decoder-chromestack-job
 
@@ -421,8 +419,8 @@ jobs:
         - video.ChromeStackDecoderVerification.vp9_0_group1_sub8x8_sf
     rules: *max-6_6-rules
 
-  tast-decoder-chromestack-x86-pineview: *tast-decoder-chromestack-job
-  tast-decoder-chromestack-x86-stoneyridge: *tast-decoder-chromestack-job
+  tast-decoder-chromestack-x86-intel: *tast-decoder-chromestack-job
+  tast-decoder-chromestack-x86-amd: *tast-decoder-chromestack-job
 
   tast-decoder-v4l2-sl-av1-arm64-mediatek: *tast-decoder-v4l2-sl-av1-job
   tast-decoder-v4l2-sl-h264-arm64-mediatek: *tast-decoder-v4l2-sl-h264-job
@@ -468,48 +466,48 @@ jobs:
 
   tast-hardware-arm64-mediatek: *tast-hardware-job
   tast-hardware-arm64-qualcomm: *tast-hardware-job
-  tast-hardware-x86-pineview: *tast-hardware-job
-  tast-hardware-x86-stoneyridge: *tast-hardware-job
+  tast-hardware-x86-intel: *tast-hardware-job
+  tast-hardware-x86-amd: *tast-hardware-job
 
   tast-kernel-arm64-mediatek: *tast-kernel-job
   tast-kernel-arm64-qualcomm: *tast-kernel-job
-  tast-kernel-x86-pineview: *tast-kernel-job
-  tast-kernel-x86-stoneyridge: *tast-kernel-job
+  tast-kernel-x86-intel: *tast-kernel-job
+  tast-kernel-x86-amd: *tast-kernel-job
 
   tast-mm-decode-arm64-mediatek: *tast-mm-decode-job
   tast-mm-decode-arm64-qualcomm: *tast-mm-decode-job
 
   tast-mm-misc-arm64-mediatek: *tast-mm-misc-job
   tast-mm-misc-arm64-qualcomm: *tast-mm-misc-job
-  tast-mm-misc-x86-pineview: *tast-mm-misc-job
-  tast-mm-misc-x86-stoneyridge: *tast-mm-misc-job
+  tast-mm-misc-x86-intel: *tast-mm-misc-job
+  tast-mm-misc-x86-amd: *tast-mm-misc-job
 
   tast-perf-arm64-mediatek: *tast-perf-job
   tast-perf-arm64-qualcomm: *tast-perf-job
-  tast-perf-x86-pineview: *tast-perf-job
-  tast-perf-x86-stoneyridge: *tast-perf-job
+  tast-perf-x86-intel: *tast-perf-job
+  tast-perf-x86-amd: *tast-perf-job
 
   tast-perf-long-duration-arm64-mediatek: *tast-perf-long-duration-job
   tast-perf-long-duration-arm64-qualcomm: *tast-perf-long-duration-job
-  tast-perf-long-duration-x86-pineview: *tast-perf-long-duration-job
-  tast-perf-long-duration-x86-stoneyridge: *tast-perf-long-duration-job
+  tast-perf-long-duration-x86-intel: *tast-perf-long-duration-job
+  tast-perf-long-duration-x86-amd: *tast-perf-long-duration-job
 
   tast-platform-arm64-mediatek: *tast-platform-job
   tast-platform-arm64-qualcomm: *tast-platform-job
-  tast-platform-x86-pineview: *tast-platform-job
-  tast-platform-x86-stoneyridge: *tast-platform-job
+  tast-platform-x86-intel: *tast-platform-job
+  tast-platform-x86-amd: *tast-platform-job
 
   tast-power-arm64-mediatek: *tast-power-job
   tast-power-arm64-qualcomm: *tast-power-job
-  tast-power-x86-pineview: *tast-power-job
-  tast-power-x86-stoneyridge: *tast-power-job
+  tast-power-x86-intel: *tast-power-job
+  tast-power-x86-amd: *tast-power-job
 
   tast-sound-arm64-mediatek: *tast-sound-job
   tast-sound-arm64-qualcomm: *tast-sound-job
-  tast-sound-x86-pineview: *tast-sound-job
-  tast-sound-x86-stoneyridge: *tast-sound-job
+  tast-sound-x86-intel: *tast-sound-job
+  tast-sound-x86-amd: *tast-sound-job
 
   tast-ui-arm64-mediatek: *tast-ui-job
   tast-ui-arm64-qualcomm: *tast-ui-job
-  tast-ui-x86-pineview: *tast-ui-job
-  tast-ui-x86-stoneyridge: *tast-ui-job
+  tast-ui-x86-intel: *tast-ui-job
+  tast-ui-x86-amd: *tast-ui-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -358,6 +358,10 @@ jobs:
     kind: test
 
   baseline-arm64-chromeos-qualcomm: *baseline-job
+  baseline-arm64-mediatek: *baseline-job
+  baseline-arm64-qualcomm: *baseline-job
+  baseline-x86-amd: *baseline-job
+  baseline-x86-intel: *baseline-job
   baseline-x86-pineview: *baseline-job
   baseline-x86-stoneyridge: *baseline-job
   baseline-x86-stoneyridge-staging: *baseline-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -353,12 +353,10 @@ _anchors:
 
 jobs:
 
-  baseline-arm64-chromeos-mediatek: &baseline-job
+  baseline-arm64-mediatek: &baseline-job
     template: baseline.jinja2
     kind: test
 
-  baseline-arm64-chromeos-qualcomm: *baseline-job
-  baseline-arm64-mediatek: *baseline-job
   baseline-arm64-qualcomm: *baseline-job
   baseline-x86-amd: *baseline-job
   baseline-x86-amd-staging: *baseline-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -50,7 +50,7 @@ _anchors:
       type: lava
       name: lava-collabora
 
-  test-job-mediatek: &test-job-mediatek
+  test-job-chromeos-mediatek: &test-job-chromeos-mediatek
     <<: *lava-job-collabora
     event:
       channel: node
@@ -58,7 +58,7 @@ _anchors:
       result: pass
     platforms: *mediatek-platforms
 
-  test-job-pineview: &test-job-pineview
+  test-job-chromeos-pineview: &test-job-chromeos-pineview
     <<: *lava-job-collabora
     event:
       channel: node
@@ -66,7 +66,7 @@ _anchors:
       result: pass
     platforms: *intel-platforms
 
-  test-job-qualcomm: &test-job-qualcomm
+  test-job-chromeos-qualcomm: &test-job-chromeos-qualcomm
     <<: *lava-job-collabora
     event:
       channel: node
@@ -74,7 +74,7 @@ _anchors:
       result: pass
     platforms: *qualcomm-platforms
 
-  test-job-stoneyridge: &test-job-stoneyridge
+  test-job-chromeos-stoneyridge: &test-job-chromeos-stoneyridge
     <<: *lava-job-collabora
     event:
       channel: node
@@ -85,19 +85,19 @@ _anchors:
 scheduler:
 
   - job: baseline-arm64-chromeos-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: baseline-arm64-chromeos-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: baseline-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: baseline-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: baseline-x86-stoneyridge-staging
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
     runtime:
       type: lava
       name: lava-collabora-staging
@@ -128,187 +128,187 @@ scheduler:
     platforms: *mediatek-platforms
 
   - job: tast-basic-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-basic-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-basic-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-basic-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-decoder-chromestack-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-decoder-chromestack-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-chromestack-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-decoder-chromestack-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-decoder-v4l2-sl-av1-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
     platforms:
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sl-h264-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
     platforms:
       - mt8183-kukui-jacuzzi-juniper-sku16
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sl-vp8-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
     platforms:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sl-vp9-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
     platforms:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sf-h264-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp8-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp9-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-hardware-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-hardware-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-hardware-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-hardware-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-kernel-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-kernel-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-kernel-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-kernel-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-mm-decode-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
     platforms:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
   - job: tast-mm-decode-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-mm-misc-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-mm-misc-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-mm-misc-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-mm-misc-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-perf-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-perf-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-perf-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-perf-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-perf-long-duration-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-perf-long-duration-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-perf-long-duration-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-perf-long-duration-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-platform-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-platform-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-platform-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-platform-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-power-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-power-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-power-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-power-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-sound-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-sound-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-sound-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-sound-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge
 
   - job: tast-ui-arm64-mediatek
-    <<: *test-job-mediatek
+    <<: *test-job-chromeos-mediatek
 
   - job: tast-ui-arm64-qualcomm
-    <<: *test-job-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: tast-ui-x86-pineview
-    <<: *test-job-pineview
+    <<: *test-job-chromeos-pineview
 
   - job: tast-ui-x86-stoneyridge
-    <<: *test-job-stoneyridge
+    <<: *test-job-chromeos-stoneyridge

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -106,17 +106,17 @@ _anchors:
 
 scheduler:
 
-  - job: baseline-arm64-chromeos-mediatek
-    <<: *test-job-chromeos-mediatek
-
-  - job: baseline-arm64-chromeos-qualcomm
-    <<: *test-job-chromeos-qualcomm
-
   - job: baseline-arm64-mediatek
     <<: *test-job-arm64-mediatek
 
   - job: baseline-arm64-qualcomm
     <<: *test-job-arm64-qualcomm
+
+  - job: baseline-arm64-mediatek
+    <<: *test-job-chromeos-mediatek
+
+  - job: baseline-arm64-qualcomm
+    <<: *test-job-chromeos-qualcomm
 
   - job: baseline-x86-amd
     <<: *test-job-chromeos-amd

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -1,6 +1,6 @@
 _anchors:
 
-  amd-stoneyridge-platforms: &amd-stoneyridge-platforms
+  amd-platforms: &amd-platforms
     - acer-R721T-grunt
     - acer-cp514-3wh-r0qs-guybrush
     - asus-CM1400CXA-dalboz_chromeos
@@ -11,7 +11,7 @@ _anchors:
     - hp-x360-14a-cb0001xx-zork
     - lenovo-TPad-C13-Yoga-zork
 
-  intel-pineview-platforms: &intel-pineview-platforms
+  intel-platforms: &intel-platforms
     - acer-cb317-1h-c3z6-dedede
     - acer-cbv514-1h-34uz-brya
     - acer-chromebox-cxi4-puff
@@ -64,7 +64,7 @@ _anchors:
       channel: node
       name: kbuild-gcc-10-x86-chromeos-pineview
       result: pass
-    platforms: *intel-pineview-platforms
+    platforms: *intel-platforms
 
   test-job-qualcomm: &test-job-qualcomm
     <<: *lava-job-collabora
@@ -80,7 +80,7 @@ _anchors:
       channel: node
       name: kbuild-gcc-10-x86-chromeos-stoneyridge
       result: pass
-    platforms: *amd-stoneyridge-platforms
+    platforms: *amd-platforms
 
 scheduler:
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -62,37 +62,35 @@ _anchors:
     <<: *test-job-arm64-mediatek
     platforms: *qualcomm-platforms
 
-  test-job-chromeos-mediatek: &test-job-chromeos-mediatek
+  test-job-chromeos-amd: &test-job-chromeos-amd
     <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-chromeos-amd
+      result: pass
+    platforms: *amd-platforms
+
+  test-job-chromeos-intel: &test-job-chromeos-intel
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86-chromeos-intel
+      result: pass
+    platforms: *intel-platforms
+
+  test-job-chromeos-mediatek: &test-job-chromeos-mediatek
+    <<: *test-job-arm64-mediatek
     event:
       channel: node
       name: kbuild-gcc-10-arm64-chromeos-mediatek
       result: pass
-    platforms: *mediatek-platforms
-
-  test-job-chromeos-pineview: &test-job-chromeos-pineview
-    <<: *lava-job-collabora
-    event:
-      channel: node
-      name: kbuild-gcc-10-x86-chromeos-pineview
-      result: pass
-    platforms: *intel-platforms
 
   test-job-chromeos-qualcomm: &test-job-chromeos-qualcomm
-    <<: *lava-job-collabora
+    <<: *test-job-arm64-qualcomm
     event:
       channel: node
       name: kbuild-gcc-10-arm64-chromeos-qualcomm
       result: pass
-    platforms: *qualcomm-platforms
-
-  test-job-chromeos-stoneyridge: &test-job-chromeos-stoneyridge
-    <<: *lava-job-collabora
-    event:
-      channel: node
-      name: kbuild-gcc-10-x86-chromeos-stoneyridge
-      result: pass
-    platforms: *amd-platforms
 
   test-job-x86-amd: &test-job-x86-amd
     <<: *lava-job-collabora
@@ -121,24 +119,24 @@ scheduler:
     <<: *test-job-arm64-qualcomm
 
   - job: baseline-x86-amd
-    <<: *test-job-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: baseline-x86-intel
-    <<: *test-job-x86-intel
-
-  - job: baseline-x86-pineview
-    <<: *test-job-chromeos-pineview
-
-  - job: baseline-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
-
-  - job: baseline-x86-stoneyridge-staging
-    <<: *test-job-chromeos-stoneyridge
+  - job: baseline-x86-amd-staging
+    <<: *test-job-chromeos-amd
     runtime:
       type: lava
       name: lava-collabora-staging
     platforms:
     - dell-latitude-3445-7520c-skyrim
+
+  - job: baseline-x86-amd
+    <<: *test-job-x86-amd
+
+  - job: baseline-x86-intel
+    <<: *test-job-chromeos-intel
+
+  - job: baseline-x86-intel
+    <<: *test-job-x86-intel
 
   - job: kbuild-gcc-10-arm64-chromebook
     <<: *build-k8s-all
@@ -149,10 +147,10 @@ scheduler:
   - job: kbuild-gcc-10-arm64-chromeos-qualcomm
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-10-x86-chromeos-pineview
+  - job: kbuild-gcc-10-x86-chromeos-amd
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-10-x86-chromeos-stoneyridge
+  - job: kbuild-gcc-10-x86-chromeos-intel
     <<: *build-k8s-all
 
   - job: kselftest-dt
@@ -169,11 +167,11 @@ scheduler:
   - job: tast-basic-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-basic-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-basic-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-basic-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-basic-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-decoder-chromestack-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -184,11 +182,11 @@ scheduler:
   - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-decoder-chromestack-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-decoder-chromestack-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-decoder-chromestack-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-decoder-chromestack-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-decoder-v4l2-sl-av1-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -238,11 +236,11 @@ scheduler:
   - job: tast-hardware-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-hardware-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-hardware-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-hardware-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-hardware-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-kernel-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -250,11 +248,11 @@ scheduler:
   - job: tast-kernel-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-kernel-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-kernel-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-kernel-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-kernel-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-mm-decode-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -271,11 +269,11 @@ scheduler:
   - job: tast-mm-misc-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-mm-misc-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-mm-misc-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-mm-misc-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-mm-misc-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-perf-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -283,11 +281,11 @@ scheduler:
   - job: tast-perf-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-perf-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-perf-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-perf-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-perf-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-perf-long-duration-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -295,11 +293,11 @@ scheduler:
   - job: tast-perf-long-duration-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-perf-long-duration-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-perf-long-duration-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-perf-long-duration-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-perf-long-duration-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-platform-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -307,11 +305,11 @@ scheduler:
   - job: tast-platform-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-platform-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-platform-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-platform-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-platform-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-power-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -319,11 +317,11 @@ scheduler:
   - job: tast-power-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-power-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-power-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-power-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-power-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-sound-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -331,11 +329,11 @@ scheduler:
   - job: tast-sound-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-sound-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-sound-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-sound-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-sound-x86-intel
+    <<: *test-job-chromeos-intel
 
   - job: tast-ui-arm64-mediatek
     <<: *test-job-chromeos-mediatek
@@ -343,8 +341,8 @@ scheduler:
   - job: tast-ui-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-ui-x86-pineview
-    <<: *test-job-chromeos-pineview
+  - job: tast-ui-x86-amd
+    <<: *test-job-chromeos-amd
 
-  - job: tast-ui-x86-stoneyridge
-    <<: *test-job-chromeos-stoneyridge
+  - job: tast-ui-x86-intel
+    <<: *test-job-chromeos-intel

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -50,6 +50,18 @@ _anchors:
       type: lava
       name: lava-collabora
 
+  test-job-arm64-mediatek: &test-job-arm64-mediatek
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-arm64-chromebook
+      result: pass
+    platforms: *mediatek-platforms
+
+  test-job-arm64-qualcomm: &test-job-arm64-qualcomm
+    <<: *test-job-arm64-mediatek
+    platforms: *qualcomm-platforms
+
   test-job-chromeos-mediatek: &test-job-chromeos-mediatek
     <<: *lava-job-collabora
     event:
@@ -82,6 +94,18 @@ _anchors:
       result: pass
     platforms: *amd-platforms
 
+  test-job-x86-amd: &test-job-x86-amd
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-x86
+      result: pass
+    platforms: *amd-platforms
+
+  test-job-x86-intel: &test-job-x86-intel
+    <<: *test-job-x86-amd
+    platforms: *intel-platforms
+
 scheduler:
 
   - job: baseline-arm64-chromeos-mediatek
@@ -89,6 +113,18 @@ scheduler:
 
   - job: baseline-arm64-chromeos-qualcomm
     <<: *test-job-chromeos-qualcomm
+
+  - job: baseline-arm64-mediatek
+    <<: *test-job-arm64-mediatek
+
+  - job: baseline-arm64-qualcomm
+    <<: *test-job-arm64-qualcomm
+
+  - job: baseline-x86-amd
+    <<: *test-job-x86-amd
+
+  - job: baseline-x86-intel
+    <<: *test-job-x86-intel
 
   - job: baseline-x86-pineview
     <<: *test-job-chromeos-pineview


### PR DESCRIPTION
Enable the baseline test on all the supported Chromebooks. Also, generalize the Chromebook platform anchors by dropping the "stoneyridge" and "pineview" naming.

This PR relies on https://github.com/kernelci/kernelci-core/pull/2459 to remove bootrr from the baseline template.