### PR TITLE
result_summary: allow to define `null` search parameters in the yaml presets

### DIFF
--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -57,9 +57,20 @@ tast-failures:
       name__ne: tast
       result: fail
 
-# tast test regression
+# tast tests regressions for x86_64 targets
+# Collect only regressions that aren't caused by runtime errors
 tast-regressions-x86_64:
   regression:
     - group__re: tast
       name__ne: tast
       data.arch: x86_64
+      # Get only the regressions from results with no runtime errors
+      data.error_code: null
+
+# tast tests regressions for x86_64 targets caused by runtime errors
+tast-regressions-x86_64__runtime_errors:
+  regression:
+    - group__re: tast
+      name__ne: tast
+      data.arch: x86_64
+      data.error_code__ne: null

--- a/config/result_summary_templates/generic-regression.jinja2
+++ b/config/result_summary_templates/generic-regression.jinja2
@@ -43,8 +43,12 @@ No regressions found.
     Arch : {{ regression['data']['arch'] }}
     Config: {{ regression['data']['config_full'] }}
     Compiler: {{ regression['data']['compiler'] }}
-    Error code: {{ regression['data']['error_code'] }}
-    Error message: {{ regression['data']['error_msg'] }}
+    {% if regression['data']['error_code'] -%}
+        Error code: {{ regression['data']['error_code'] }}
+    {% endif -%}
+    {% if regression['data']['error_msg'] -%}
+        Error message: {{ regression['data']['error_msg'] }}
+    {% endif -%}
     {% if regression['logs'] | count > 0 -%}
     Logs:
       {% for log in regression['logs'] -%}

--- a/config/result_summary_templates/tast-regressions-x86_64__runtime_errors.jinja2
+++ b/config/result_summary_templates/tast-regressions-x86_64__runtime_errors.jinja2
@@ -1,0 +1,1 @@
+generic-regression.jinja2

--- a/src/result_summary.py
+++ b/src/result_summary.py
@@ -119,7 +119,7 @@ class ResultSummary(Service):
                         new_repo[f'data.kernel_revision.{key}'] = value
                     repos.append(new_repo)
             for key, value in item.items():
-                item_base_params[key] = value
+                item_base_params[key] = value if value else 'null'
             if repos:
                 for repo in repos:
                     query_params.append({**item_base_params, **repo})


### PR DESCRIPTION
Allow to use `null` search parameters in yaml presets.
Make the existing example preset `tast-regressions-x86_64` get only the regressions not linked to a runtime error and create a new example preset `tast-regressions-x86_64__runtime_errors` to show only the regressions linked to runtime errors.