### PR TITLE
scheduler: mark jobs that we failed to submit as incomplete

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -101,7 +101,7 @@ class Scheduler(Service):
                 "Invalid job parameters, aborting...",
             ]))
             node['state'] = 'done'
-            node['result'] = 'fail'
+            node['result'] = 'incomplete'
             node['data']['error_code'] = 'invalid_job_params'
             try:
                 self._api.node.update(node)
@@ -131,7 +131,7 @@ class Scheduler(Service):
                 str(e),
             ]))
             node['state'] = 'done'
-            node['result'] = 'fail'
+            node['result'] = 'incomplete'
             node['data']['error_code'] = 'submit_error'
             try:
                 self._api.node.update(node)


### PR DESCRIPTION
We need to mark jobs that failed to run due infrastructure or configuration issues as incomplete and such issues usually need admins attentions and more permanent fixes.