### PR TITLE
Fix Tast tests on `trogdor-kingoftown` with kernels >= 6.4

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -150,12 +150,15 @@ platforms:
     <<: *arm64-chromebook-device
     base_name: trogdor
     mach: qcom
-    dtb: dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb
+    dtb:
+      - dtbs/qcom/sc7180-trogdor-kingoftown.dtb
+      - dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb
     params:
       <<: *arm64-chromebook-device-params
       flash_kernel:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-qualcomm
         image: 'kernel/Image'
+        dtb: 'dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb'
 
   sc7180-trogdor-lazor-limozeen:
     <<: *trogdor-chromebook-device

--- a/config/runtime/tast.jinja2
+++ b/config/runtime/tast.jinja2
@@ -8,8 +8,8 @@
 
 {%- set kernel_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.image %}
 {%- set modules_url = base_kurl ~ '/' ~ flash_modules %}
-{%- if platform_config.dtb %}
-{%-   set dtb_url = base_kurl ~ '/' ~ platform_config.dtb %}
+{%- if device_dtb %}
+{%-   set dtb_url = base_kurl ~ '/' ~ device_dtb %}
 {%- endif %}
 {%- set nfsroot = platform_config.params.nfsroot %}
 

--- a/config/runtime/tast.jinja2
+++ b/config/runtime/tast.jinja2
@@ -8,7 +8,9 @@
 
 {%- set kernel_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.image %}
 {%- set modules_url = base_kurl ~ '/' ~ flash_modules %}
-{%- if device_dtb %}
+{%- if platform_config.params.flash_kernel.dtb %}
+{%-   set dtb_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.dtb %}
+{%- elif device_dtb %}
 {%-   set dtb_url = base_kurl ~ '/' ~ device_dtb %}
 {%- endif %}
 {%- set nfsroot = platform_config.params.nfsroot %}


### PR DESCRIPTION
This PR reworks the `tast` template so it uses the new `device_dtb` parameter instead of the old `platform_config.dtb`. It also honors `platform_config.params.flash_kernel.dtb` if present, falling back to `device_dtb` otherwise.

The config for `trogdor-kingoftown` is updated so it can use either the old DTB file name (up until 6.3.x) or the new one (renamed starting with 6.4-rc1), while still using the correct file name for the "flash kernel" (which is based on 6.1).

Depends on https://github.com/kernelci/kernelci-core/pull/2471