### PR TITLE
regression_tracker: sync to latest model changes

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -85,7 +85,7 @@ class RegressionTracker(Service):
             'config_full': failed_node['data'].get('config_full'),
             'compiler': failed_node['data'].get('compiler'),
             'platform': failed_node['data'].get('platform'),
-            'failed_kernel_version': failed_node['data'].get('kernel_revision'),   # noqa
+            'kernel_revision': failed_node['data'].get('kernel_revision'),   # noqa
             'error_code': error['error_code'],
             'error_msg': error['error_msg'],
         }


### PR DESCRIPTION
See https://github.com/kernelci/kernelci-core/pull/2474

To be applied after kernelci-core commit

models: rename regression.data.failed_kernel_revision to kernel_revision