### PR TITLE
pipeline: Add android-mainline

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -286,6 +286,9 @@ trees:
   mediatek:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
 
+  android:
+    url: 'https://android.googlesource.com/kernel/common'
+
 platforms:
 
   docker:
@@ -592,4 +595,9 @@ build_configs:
   mediatek_for_next:
     tree: mediatek
     branch: 'for-next'
+    variants: *build-variants
+
+  android_mainline:
+    tree: android
+    branch: 'android-mainline'
     variants: *build-variants

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -198,14 +198,26 @@ jobs:
       <<: *kbuild-gcc-10-arm64-params
       dtbs_check: true
 
-  kbuild-gcc-10-armel:
+  kbuild-gcc-10-armel: &kbuild-gcc-10-armel-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-10:arm64-kselftest-kernelci
-    params:
+    params: &kbuild-gcc-10-armel-params
       arch: arm
       compiler: gcc-10
       cross_compile: 'arm-linux-gnueabihf-'
       defconfig: multi_v7_defconfig
+
+  kbuild-gcc-10-armel-android-mainline: &kbuild-gcc-10-armel-android-mainline-job
+    <<: *kbuild-gcc-10-armel-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-gcc-10-armel-android-mainline-imx: &kbuild-gcc-10-armel-android-mainline-imx-job
+    <<: *kbuild-gcc-10-armel-android-mainline-job
+    params:
+      <<: *kbuild-gcc-10-armel-params
+      defconfig: imx_v6_v7_defconfig
 
   kbuild-gcc-10-i386:
     <<: *kbuild-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -467,6 +467,12 @@ scheduler:
   - job: kbuild-gcc-10-armel
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-10-armel-android-mainline
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-10-armel-android-mainline-imx
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-10-i386
     <<: *build-k8s-all
 


### PR DESCRIPTION
Add definitions of android-mainline from legacy system to the new system.
Add android-mainline tree
~~Add lab-kontron and lab-pengutronix definitions~~
~~Add respective platforms~~


NOTE: please review this, I didn't test and I wrote based on what I saw from current code and legacy code, so I'm very unsure about this. Please let me know if there is any better way to check/test it.

Reference: https://github.com/kernelci/kernelci-pipeline/issues/483