### PR TITLE
src/regression_tracker: rework regression detection

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -187,6 +187,9 @@ class RegressionTracker(Service):
                     resp = self._api_helper.submit_regression(regression)
                     reg = json.loads(resp.text)
                     self.log.info(f"Regression submitted: {reg['id']}")
+                    # Update node
+                    node['data']['regression'] = reg['id']
+                    self._api.node.update(node)
                 else:
                     self.log.info(f"Skipping regression: already exists")
             elif previous['result'] == 'fail':
@@ -203,6 +206,9 @@ class RegressionTracker(Service):
                     # Update active regression
                     regression['data']['node_sequence'].append(node['id'])
                     self._api.node.update(regression)
+                    # Update node
+                    node['data']['regression'] = regression['id']
+                    self._api.node.update(node)
         # Process children recursively:
         # When a node hierarchy is submitted on a single operation,
         # an event is generated only for the root node. Walk the


### PR DESCRIPTION
**DEPENDS ON**: https://github.com/kernelci/kernelci-core/pull/2476

Take into account "active" and "inactive" regressions when creating them and when processing new passed or failed nodes.

When a node passes, it checks if it "inactivates" an existing "active" regression. When a node fails, it checks if it needs to create a new regression or update an existing "active" one.