### PR TITLE
config: pipeline: Set minimum kernel version for DT kselftest to 6.7

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -256,6 +256,10 @@ jobs:
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{arch}'
       collections: dt
       job_timeout: 10
+    rules:
+      min_version:
+        version: 6
+        patchlevel: 7
 
   # amd64-only temporary
   sleep:


### PR DESCRIPTION
The test was introduced upstream in version 6.7, so no point in trying to run it on earlier versions.