### PR TITLE
T40464 src/scheduler: store error message when job fails with "submit_error"

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -150,6 +150,7 @@ class Scheduler(Service):
             node['state'] = 'done'
             node['result'] = 'incomplete'
             node['data']['error_code'] = 'submit_error'
+            node['data']['error_msg'] = str(e)
             try:
                 self._api.node.update(node)
             except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/508

It is helpful for debugging to catch error message when scheduler fails to submit job to runtime.
Store the error message in `data.error_msg` field.