### PR TITLE
config: chromeos: update volteer device types

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -48,9 +48,11 @@ platforms:
     <<: *x86-chromebook-device
     base_name: puff
 
-  acer-cp514-2h-1160g7-volteer: &chromebook-volteer-device
+  acer-cp514-2h-1130g7-volteer: &chromebook-volteer-device
     <<: *x86-chromebook-device
     base_name: volteer
+
+  acer-cp514-2h-1160g7-volteer: *chromebook-volteer-device
 
   acer-cp514-3wh-r0qs-guybrush:
     <<: *x86-chromebook-device
@@ -71,8 +73,6 @@ platforms:
   asus-CM1400CXA-dalboz_chromeos: &chromebook-zork-device
     <<: *x86-chromebook-device
     base_name: zork
-
-  asus-cx9400-volteer: *chromebook-volteer-device
 
   dell-latitude-3445-7520c-skyrim:
     <<: *x86-chromebook-device

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -15,8 +15,8 @@ _anchors:
     - acer-cb317-1h-c3z6-dedede
     - acer-cbv514-1h-34uz-brya
     - acer-chromebox-cxi4-puff
+    - acer-cp514-2h-1130g7-volteer
     - acer-cp514-2h-1160g7-volteer
-    - asus-cx9400-volteer
     - asus-C433TA-AJ0005-rammus
     - asus-C436FA-Flip-hatch
     - asus-C523NA-A20057-coral


### PR DESCRIPTION
The `asus-cx9400-volteer` is no longer available in LAVA, all `volteer` devices being of the `acer-cp514-*-volteer` types now. As we were missing one variant, add it while removing the old, unused one.