### PR TITLE
send_kcidb: submit build and test nodes

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -75,37 +75,42 @@ class KCIDBBridge(Service):
             parsed_build_nodes.append(parsed_node)
         return parsed_build_nodes
 
+    def _parse_checkout_node(self, origin, checkout_node):
+        return {
+            'id': f"{origin}:{checkout_node['id']}",
+            'origin': origin,
+            'tree_name': checkout_node['data']['kernel_revision']['tree'],
+            'git_repository_url':
+                checkout_node['data']['kernel_revision']['url'],
+            'git_commit_hash':
+                checkout_node['data']['kernel_revision']['commit'],
+            'git_commit_name':
+                checkout_node['data']['kernel_revision'].get('describe'),
+            'git_repository_branch':
+                checkout_node['data']['kernel_revision']['branch'],
+            'start_time': self._set_timezone(checkout_node['created']),
+            'patchset_hash': '',
+            'misc': {
+                'submitted_by': 'kernelci-pipeline'
+            },
+        }
+
     def _run(self, context):
         self.log.info("Listening for events... ")
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            node = self._api_helper.receive_event_node(context['sub_id'])
-            self.log.info(f"Submitting node to KCIDB: {node['id']}")
+            checkout_node = self._api_helper.receive_event_node(context['sub_id'])
+            self.log.info(f"Submitting node to KCIDB: {checkout_node['id']}")
 
             build_nodes = self._api.node.find({
-                'parent': node['id'],
+                'parent': checkout_node['id'],
                 'kind': 'kbuild'
             })
 
             revision = {
                 'checkouts': [
-                    {
-                        'id': f"{context['origin']}:{node['id']}",
-                        'origin': context['origin'],
-                        'tree_name': node['data']['kernel_revision']['tree'],
-                        'git_repository_url':
-                            node['data']['kernel_revision']['url'],
-                        'git_commit_hash':
-                            node['data']['kernel_revision']['commit'],
-                        'git_repository_branch':
-                            node['data']['kernel_revision']['branch'],
-                        'start_time': self._set_timezone(node['created']),
-                        'patchset_hash': '',
-                        'misc': {
-                            'submitted_by': 'kernelci-pipeline'
-                        },
-                    }
+                    self._parse_checkout_node(context['origin'], checkout_node)
                 ],
                 'builds': self._parse_build_nodes(context['origin'], build_nodes),
                 'tests': [],

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -205,7 +205,7 @@ in {test_node['data'].get('runtime')}",
                 'tests': parsed_test_nodes,
                 'version': {
                     'major': 4,
-                    'minor': 0
+                    'minor': 3
                 }
             }
             self._send_revision(context['client'], revision)

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -43,7 +43,17 @@ class KCIDBBridge(Service):
         if context['sub_id']:
             self._api_helper.unsubscribe_filters(context['sub_id'])
 
+    def _remove_none_fields(self, data):
+        """Remove all keys with `None` values as KCIDB doesn't allow it"""
+        if isinstance(data, dict):
+            return {key: self._remove_none_fields(val)
+                    for key, val in data.items() if val is not None}
+        if isinstance(data, list):
+            return [self._remove_none_fields(item) for item in data]
+        return data
+
     def _send_revision(self, client, revision):
+        revision = self._remove_none_fields(revision)
         self.log.debug(f"DEBUG: sending revision: {revision}")
         if kcidb.io.SCHEMA.is_valid(revision):
             return client.submit(revision)

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -58,6 +58,10 @@ class KCIDBBridge(Service):
         if kcidb.io.SCHEMA.is_valid(revision):
             return client.submit(revision)
         self.log.error("Aborting, invalid data")
+        try:
+            kcidb.io.SCHEMA.validate(revision)
+        except Exception as exc:
+            self.log.error(f"Validation error: {str(exc)}")
 
     @staticmethod
     def _set_timezone(created_timestamp):

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -16,7 +16,6 @@ import sys
 import kernelci
 import kernelci.config
 from kernelci.legacy.cli import Args, Command, parse_opts
-from kcidb import Client
 import kcidb
 
 from base import Service
@@ -28,7 +27,7 @@ class KCIDBBridge(Service):
 
     def _setup(self, args):
         return {
-            'client': Client(
+            'client': kcidb.Client(
                 project_id=args.kcidb_project_id,
                 topic_name=args.kcidb_topic_name
             ),


### PR DESCRIPTION
Related to https://github.com/kernelci/kcidb/issues/338

Fetch build and test nodes for the current checkout node. Create KCIDB schema compatible nodes from it and
send them along with checkout node.