### PR TITLE
config: chromeos: remove/disable meaningless Tast tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -77,7 +77,6 @@ _anchors:
     params:
       tests:
         - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_*
-        - video.PlatformDecoding.v4l2_stateful_vp9_0_svc
 
   tast-decoder-v4l2-sl-av1: &tast-decoder-v4l2-sl-av1-job
     <<: *tast-job
@@ -117,7 +116,6 @@ _anchors:
     params:
       tests:
         - video.PlatformDecoding.v4l2_stateless_vp9_0_level5_*
-        - video.PlatformDecoding.v4l2_stateless_vp9_0_svc
 
   tast-hardware: &tast-hardware-job
     <<: *tast-job
@@ -148,7 +146,6 @@ _anchors:
       tests:
         - kernel.Bloat
         - kernel.ConfigVerify.chromeos_kernelci
-        - kernel.ConfigVerify.chromeos
         - kernel.CPUCgroup
         - kernel.Cpuidle
         - kernel.CryptoAPI
@@ -276,14 +273,10 @@ _anchors:
         - platform.CrosDisksSSHFS
         - platform.CrosID
         - platform.DeviceHwid
-        - platform.DLCService
-        - platform.DLCServiceCrosDeploy
-        - platform.DLCServicePreloading
         - platform.DMVerity
         - platform.DumpVPDLog
         - platform.Firewall
         - platform.LocalPerfettoTBMTracedProbes
-        - platform.Memd
         - platform.Mtpd
         - platform.SerialNumber
         - platform.TPMResponsive

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -163,11 +163,6 @@ scheduler:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
-  - job: tast-decoder-v4l2-sl-hevc-arm64-mediatek
-    <<: *test-job-mediatek
-    platforms:
-      - mt8195-cherry-tomato-r2
-
   - job: tast-decoder-v4l2-sl-vp8-arm64-mediatek
     <<: *test-job-mediatek
     platforms:
@@ -181,9 +176,6 @@ scheduler:
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sf-h264-arm64-qualcomm
-    <<: *test-job-qualcomm
-
-  - job: tast-decoder-v4l2-sf-hevc-arm64-qualcomm
     <<: *test-job-qualcomm
 
   - job: tast-decoder-v4l2-sf-vp8-arm64-qualcomm


### PR DESCRIPTION
Several Tast tests can only fail in the context of KernelCI:
* `video.PlatformDecoding.v4l2_state*_vp9_0_svc` do not actually exist, causing the whole test job to fail
* `platform.DLCService*` and `platform.Memd` rely on features only present in the downstream Chrom{e,ium}OS kernel (see b/247467814 and b/244479619 for those having access to Google's issue tracker)
* `kernel.ConfigVerify.chromeos` relies on downstream-only config options such as `CONFIG_SECURITY_CHROMIUMOS` and other similar ones, and therefore can only fail when testing upstream kernels

HEVC tests are also expected to either fail or be skipped as ChromeOS [doesn't handle hardware decoding](https://chromium.googlesource.com/chromiumos/overlays/board-overlays/+/accf64c6d3df95945c42ab6740dedddea556f218) for this codec. This might change in the future, though, so we only drop the scheduler entries for those tests in order to easily reinstate them in the future.