### PR TITLE
config: chromeos: remove/disable more failing Tast tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -44,6 +44,10 @@ _anchors:
       tests:
         - video.ChromeStackDecoder.*
         - video.ChromeStackDecoderVerification.*
+      excluded_tests:
+        # Those always fail on all platforms
+        - video.ChromeStackDecoderVerification.hevc_main
+        - video.ChromeStackDecoderVerification.vp9_0_svc
 
   tast-decoder-v4l2-sf-h264: &tast-decoder-v4l2-sf-h264-job
     <<: *tast-job
@@ -71,6 +75,9 @@ _anchors:
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group2_*
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group3_*
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_*
+      excluded_tests:
+        # Regression in ChromeOS R120, to be re-evaluated on next CrOS upgrade
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_sub8x8_sf
 
   tast-decoder-v4l2-sf-vp9-extra: &tast-decoder-v4l2-sf-vp9-extra-job
     <<: *tast-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -27,6 +27,16 @@ _anchors:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
 
+  min-6_7-rules: &min-6_7-rules
+    min_version:
+      version: 6
+      patchlevel: 7
+
+  max-6_6-rules: &max-6_6-rules
+    max_version:
+      version: 6
+      patchlevel: 6
+
   tast: &tast-job
     template: tast.jinja2
     kind: test
@@ -40,7 +50,7 @@ _anchors:
 
   tast-decoder-chromestack: &tast-decoder-chromestack-job
     <<: *tast-job
-    params:
+    params: &tast-decoder-chromestack-params
       tests:
         - video.ChromeStackDecoder.*
         - video.ChromeStackDecoderVerification.*
@@ -69,7 +79,7 @@ _anchors:
 
   tast-decoder-v4l2-sf-vp9: &tast-decoder-v4l2-sf-vp9-job
     <<: *tast-job
-    params:
+    params: &tast-decoder-v4l2-sf-vp9-params
       tests:
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group1_*
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group2_*
@@ -81,7 +91,7 @@ _anchors:
 
   tast-decoder-v4l2-sf-vp9-extra: &tast-decoder-v4l2-sf-vp9-extra-job
     <<: *tast-job
-    params:
+    params: &tast-decoder-v4l2-sf-vp9-extra-params
       tests:
         - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_*
         - video.PlatformDecoding.v4l2_stateful_vp9_0_svc
@@ -396,7 +406,24 @@ jobs:
   tast-basic-x86-stoneyridge: *tast-basic-job
 
   tast-decoder-chromestack-arm64-mediatek: *tast-decoder-chromestack-job
-  tast-decoder-chromestack-arm64-qualcomm: *tast-decoder-chromestack-job
+
+  tast-decoder-chromestack-arm64-qualcomm:
+    <<: *tast-decoder-chromestack-job
+    rules: *min-6_7-rules
+
+  tast-decoder-chromestack-arm64-qualcomm-pre6_7:
+    <<: *tast-decoder-chromestack-job
+    params:
+      <<: *tast-decoder-chromestack-params
+      excluded_tests:
+        # Platform-independent excluded tests
+        - video.ChromeStackDecoderVerification.hevc_main
+        - video.ChromeStackDecoderVerification.vp9_0_svc
+        # Qualcomm-specific: those always fail with pre-6.7 kernels
+        - video.ChromeStackDecoderVerification.vp9_0_group1_frm_resize
+        - video.ChromeStackDecoderVerification.vp9_0_group1_sub8x8_sf
+    rules: *max-6_6-rules
+
   tast-decoder-chromestack-x86-pineview: *tast-decoder-chromestack-job
   tast-decoder-chromestack-x86-stoneyridge: *tast-decoder-chromestack-job
 
@@ -409,8 +436,38 @@ jobs:
   tast-decoder-v4l2-sf-h264-arm64-qualcomm: *tast-decoder-v4l2-sf-h264-job
   tast-decoder-v4l2-sf-hevc-arm64-qualcomm: *tast-decoder-v4l2-sf-hevc-job
   tast-decoder-v4l2-sf-vp8-arm64-qualcomm: *tast-decoder-v4l2-sf-vp8-job
-  tast-decoder-v4l2-sf-vp9-arm64-qualcomm: *tast-decoder-v4l2-sf-vp9-job
-  tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm: *tast-decoder-v4l2-sf-vp9-extra-job
+
+  tast-decoder-v4l2-sf-vp9-arm64-qualcomm:
+    <<: *tast-decoder-v4l2-sf-vp9-job
+    rules: *min-6_7-rules
+
+  tast-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7:
+    <<: *tast-decoder-v4l2-sf-vp9-job
+    params:
+      <<: *tast-decoder-v4l2-sf-vp9-params
+      excluded_tests:
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group1_frm_resize
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group1_sub8x8_sf
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group2_frm_resize
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group2_sub8x8_sf
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group3_frm_resize
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group3_sub8x8_sf
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_frm_resize
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_sub8x8_sf
+    rules: *max-6_6-rules
+
+  tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm:
+    <<: *tast-decoder-v4l2-sf-vp9-extra-job
+    rules: *min-6_7-rules
+
+  tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7:
+    <<: *tast-decoder-v4l2-sf-vp9-extra-job
+    params:
+      <<: *tast-decoder-v4l2-sf-vp9-extra-params
+      excluded_tests:
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_0_frm_resize
+        - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_0_sub8x8_sf
+    rules: *max-6_6-rules
 
   tast-hardware-arm64-mediatek: *tast-hardware-job
   tast-hardware-arm64-qualcomm: *tast-hardware-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -145,6 +145,9 @@ scheduler:
   - job: tast-decoder-chromestack-arm64-qualcomm
     <<: *test-job-qualcomm
 
+  - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
+    <<: *test-job-qualcomm
+
   - job: tast-decoder-chromestack-x86-pineview
     <<: *test-job-pineview
 
@@ -192,7 +195,13 @@ scheduler:
   - job: tast-decoder-v4l2-sf-vp9-arm64-qualcomm
     <<: *test-job-qualcomm
 
+  - job: tast-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7
+    <<: *test-job-qualcomm
+
   - job: tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm
+    <<: *test-job-qualcomm
+
+  - job: tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7
     <<: *test-job-qualcomm
 
   - job: tast-hardware-arm64-mediatek


### PR DESCRIPTION
As a follow-up to #520 this PR ensures more always-failing tests are disabled. This is a separate PR as this part requires https://github.com/kernelci/kernelci-core/pull/2490 to actually give the expected results.

It contains 2 parts/commits:
* exclude tests failing on all platforms and all kernel versions
* exclude *some* tests when testing kernels < 6.7 on qcom/trogdor devices (those tests pass with 6.7+)

The 2nd part is a bit more involved as it required duplicating test jobs and setting the proper rules on each variant so only the appropriate one is executed depending on the version of the kernel being tested.

Depends on https://github.com/kernelci/kernelci-core/pull/2490 (without it `excluded_tests` will only be ignored, but otherwise that should be "mostly harmless").