### PR TITLE
regression_tracker: [trivial] make regression active by default

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -72,6 +72,11 @@ class RegressionTracker(Service):
         """Method to create a regression"""
         regression = {}
         regression['kind'] = 'regression'
+        # Make regression "active" by default.
+        # TODO: 'result' is currently optional in the model, so we set
+        # it here. Remove this line if the field is set as mandatory in
+        # the future.
+        regression['result'] = 'fail'
         regression['name'] = failed_node['name']
         regression['path'] = failed_node['path']
         regression['group'] = failed_node['group']


### PR DESCRIPTION
Fixup for commit fcb29501663d78920bcd129bd57c36b9af624bc4 If the "result" field is ever made non-optional in the models we can probably remove this.