### PR TITLE
regression_tracker: [trivial] set default empty node sequence

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -93,6 +93,7 @@ class RegressionTracker(Service):
             'failed_kernel_version': failed_node['data'].get('kernel_revision'),   # noqa
             'error_code': error['error_code'],
             'error_msg': error['error_msg'],
+            'node_sequence': [],
         }
         regression['artifacts'] = self._collect_logs(failed_node)
         return regression


### PR DESCRIPTION
Fixup for commit fcb29501663d78920bcd129bd57c36b9af624bc4 If the "node_sequence" field is ever made non-optional in the models we can probably remove this.