### PR TITLE
Draft: Enable android tree and add kontron and pengutronix runtime

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -286,6 +286,9 @@ trees:
   mediatek:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
 
+  android:
+    url: 'https://android.googlesource.com/kernel/common'
+
 platforms:
 
   docker:
@@ -592,4 +595,9 @@ build_configs:
   mediatek_for_next:
     tree: mediatek
     branch: 'for-next'
+    variants: *build-variants
+
+  android_mainline:
+    tree: android
+    branch: 'android-mainline'
     variants: *build-variants

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -116,6 +116,13 @@ runtimes:
       tree:
       - 'android'
 
+  lava-pengutronix:
+    lab_type: lava
+    url: 'https://hekla.openlab.pengutronix.de/'
+    rules:
+      tree:
+      - 'android'
+
   docker:
     lab_type: docker
     env_file: '/home/kernelci/.docker-env'

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -109,6 +109,13 @@ storage:
 
 runtimes:
 
+  lava-kontron:
+    lab_type: lava
+    url: 'https://lavalab.kontron.com/'
+    rules:
+      tree:
+      - 'android'
+
   docker:
     lab_type: docker
     env_file: '/home/kernelci/.docker-env'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,7 @@ services:
       - 'lava-collabora-staging'
       - 'lava-broonie'
       - 'lava-kontron'
+      - 'lava-pengutronix'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,6 +88,7 @@ services:
       - 'lava-collabora'
       - 'lava-collabora-staging'
       - 'lava-broonie'
+      - 'lava-kontron'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
reference: https://github.com/kernelci/kernelci-pipeline/pull/502#discussion_r1540684977 https://github.com/kernelci/kernelci-pipeline/issues/483


Add runtime for kontron and pengutronix labs to be used by android trees