### PR TITLE
Track collabora-next tree and enable ACPI kselftest

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -422,6 +422,19 @@ jobs:
       <<: *kbuild-gcc-10-x86-chromeos-params
       flavour: amd-stoneyridge
 
+  kselftest-acpi:
+    template: kselftest.jinja2
+    kind: test
+    params:
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      collections: acpi
+      job_timeout: 10
+    rules:
+      tree:
+        - collabora-next
+      branch:
+        - for-kernelci
+
   tast-basic-arm64-mediatek: *tast-basic-job
   tast-basic-arm64-qualcomm: *tast-basic-job
   tast-basic-x86-intel: *tast-basic-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -319,6 +319,9 @@ trees:
   android:
     url: 'https://android.googlesource.com/kernel/common'
 
+  collabora-next:
+    url: 'https://gitlab.collabora.com/kernel/collabora-next.git'
+
 platforms:
 
   docker:
@@ -663,4 +666,9 @@ build_configs:
   android_mainline:
     tree: android
     branch: 'android-mainline'
+    variants: *build-variants
+
+  collabora-next_for-kernelci:
+    tree: collabora-next
+    branch: 'for-kernelci'
     variants: *build-variants

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -176,6 +176,9 @@ scheduler:
   - job: kbuild-gcc-10-x86-chromeos-intel
     <<: *build-k8s-all
 
+  - job: kselftest-acpi
+    <<: *test-job-x86-intel
+
   - job: kselftest-dt
     <<: *lava-job-collabora
     event:


### PR DESCRIPTION
Start tracking the [collabora-next](https://gitlab.collabora.com/kernel/collabora-next) tree, a linux-next based tree maintained by Collabora and used to track patches on the way to upstream.

Enable the [ACPI kselftest](https://github.com/kernelci/kernelci-pipeline/commit/050ccd051d38c5b1d05750cdc6c8f1686fc66ab1) on the collabora-next tree for the Intel Chromebooks in the Collabora LAVA lab, to perform some preliminary testing and verify the test is working as expected.