### PR TITLE
config: exclude android tree from kbuild jobs

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -14,6 +14,9 @@ _anchors:
       fragments:
         - arm64-chromebook
         - CONFIG_MODULE_COMPRESS=n
+    rules: &kbuild-gcc-10-arm64-chromeos-rules
+      tree:
+      - '!android'
 
   kbuild-gcc-10-x86-chromeos: &kbuild-gcc-10-x86-chromeos-job
     <<: *kbuild-gcc-10-arm64-chromeos-job
@@ -26,6 +29,9 @@ _anchors:
       fragments:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
+    rules:
+      tree:
+      - '!android'
 
   tast: &tast-job
     template: tast.jinja2
@@ -364,6 +370,11 @@ jobs:
     params:
       <<: *kbuild-gcc-10-arm64-chromeos-params
       flavour: mediatek
+    rules:
+      <<: *kbuild-gcc-10-arm64-chromeos-rules
+      min_version:
+        version: 6
+        patchlevel: 1
 
   kbuild-gcc-10-arm64-chromeos-qualcomm:
     <<: *kbuild-gcc-10-arm64-chromeos-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -31,6 +31,9 @@ _anchors:
   kbuild: &kbuild-job
     template: kbuild.jinja2
     kind: kbuild
+    rules:
+      tree:
+      - '!android'
 
   kbuild-clang-17-x86: &kbuild-clang-17-x86-job
     <<: *kbuild-job


### PR DESCRIPTION
Only Android-specific kbuild jobs should run for this tree, let's not overload our system with unneeded builds.

Take this opportunity to limit mediatek kbuilds to 6.1+ as that's the earliest version that has upstream support for at least one of our devices.