### PR TITLE
 Enable baseline-nfs test on all the Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -357,6 +357,22 @@ jobs:
     template: baseline.jinja2
     kind: test
 
+  baseline-nfs-arm64-mediatek: &baseline-nfs-arm64-job
+    template: baseline.jinja2
+    kind: test
+    params: &baseline-nfs-arm64-job-params
+      boot_commands: nfs
+      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/arm64
+
+  baseline-nfs-arm64-qualcomm: *baseline-nfs-arm64-job
+
+  baseline-nfs-x86-amd: &baseline-nfs-x86-job
+    <<: *baseline-nfs-arm64-job
+    params: &baseline-nfs-x86-job-params
+      <<: *baseline-nfs-arm64-job-params
+      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/amd64
+
+  baseline-nfs-x86-intel: *baseline-nfs-x86-job
   baseline-arm64-qualcomm: *baseline-job
   baseline-x86-amd: *baseline-job
   baseline-x86-amd-staging: *baseline-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -118,6 +118,30 @@ scheduler:
   - job: baseline-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
+  - job: baseline-nfs-arm64-mediatek
+    <<: *test-job-arm64-mediatek
+
+  - job: baseline-nfs-arm64-mediatek
+    <<: *test-job-chromeos-mediatek
+
+  - job: baseline-nfs-arm64-qualcomm
+    <<: *test-job-arm64-qualcomm
+
+  - job: baseline-nfs-arm64-qualcomm
+    <<: *test-job-chromeos-qualcomm
+
+  - job: baseline-nfs-x86-amd
+    <<: *test-job-chromeos-amd
+
+  - job: baseline-nfs-x86-amd
+    <<: *test-job-x86-amd
+
+  - job: baseline-nfs-x86-intel
+    <<: *test-job-chromeos-intel
+
+  - job: baseline-nfs-x86-intel
+    <<: *test-job-x86-intel
+
   - job: baseline-x86-amd
     <<: *test-job-chromeos-amd
 


### PR DESCRIPTION
Enable the baseline-nfs test on all the supported Chromebooks, with both the default and the chromeos kernel configurations.