### PR TITLE
result_summary: post-process results for summary and monitor modes

### DIFF
--- a/src/result_summary/monitor.py
+++ b/src/result_summary/monitor.py
@@ -10,6 +10,7 @@ import os
 import re
 
 import result_summary
+import result_summary.utils as utils
 
 
 def setup(service, args, context):
@@ -89,6 +90,9 @@ def run(service, context):
                     'metadata': context['metadata'],
                     'node': node,
                 }
+                # Post-process node
+                utils.post_process_node(node, service._api)
+
                 output_text = context['template'].render(template_params)
                 # Setup output dir from base path and user-specified
                 # parameter (in preset metadata or cmdline)

--- a/src/result_summary/summary.py
+++ b/src/result_summary/summary.py
@@ -67,14 +67,15 @@ def run(service, context):
         nodes.extend(query_results)
     result_summary.logger.info(f"Total nodes found: {len(nodes)}")
 
+    # Post-process nodes
     # Filter log files
     # - remove empty files
     # - collect log files in a 'logs' field
-    result_summary.logger.info(f"Checking logs ...")
+    result_summary.logger.info(f"Post-processing nodes ...")
     progress_total = len(nodes)
     progress = 0
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures = {executor.submit(utils.get_logs, node) for node in nodes}
+        futures = {executor.submit(utils.post_process_node, node, service._api) for node in nodes}
         for future in concurrent.futures.as_completed(futures):
             result = future.result()
             progress += 1


### PR DESCRIPTION
Split the post-processing of nodes to a common function that can be used for both summary and monitor modes. Currently, post-processing involves only the collection of logs.