### PR TITLE
regression_tracker: bugfix, failed test with no prior runs

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -175,7 +175,10 @@ class RegressionTracker(Service):
                 self._api.node.update(regression)
         elif node['result'] == 'fail':
             previous = self._get_previous_job_instance(node)
-            if previous['result'] == 'pass':
+            if not previous:
+                # Not a regression, since there's no previous test run
+                pass
+            elif previous['result'] == 'pass':
                 self.log.info(f"Detected regression for node id: {node['id']}")
                 # Skip the regression generation if it was already in the
                 # DB. This may happen if a job was detected to generate a
@@ -220,8 +223,9 @@ class RegressionTracker(Service):
         # an event is generated only for the root node. Walk the
         # children node tree to check for event-less finished jobs
         child_nodes = self._api.node.find({'parent': node['id']})
-        for child_node in child_nodes:
-            self._process_node(child_node)
+        if child_nodes:
+            for child_node in child_nodes:
+                self._process_node(child_node)
 
     def _run(self, sub_id):
         """Method to run regression detection and generation"""


### PR DESCRIPTION
Handle the case of a failed test run when it's the first occurence of that test case. Consider it "not a regression" for now, since we're defining a regression as a "breaking point" between a success and a failure.

I suggest we leave this running on staging for a while to see if the issue happens again, although it may be hard to catch. ~I'll try to test it locally next Monday.~ -> Tested locally already: OK