### PR TITLE
kernelci.toml: set `checkout` node timeout to `180 min`

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -6,7 +6,7 @@ verbose = true
 [trigger]
 poll_period = 0
 startup_delay = 3
-timeout = 60
+timeout = 180
 
 [tarball]
 kdir = "/home/kernelci/data/src/linux"


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/538

Currently set `60 min` timeout is not enough as some `kbuild` jobs and its sub-tests take around 2 hrs to complete after getting submitted to runtime.

Here is an example from staging. See the information for a `checkout` and its child nodes:

| id                       | name                | created                    | updated                    | timeout                    |
|--------------------------|---------------------|----------------------------|----------------------------|----------------------------|
| 661c9d59b60b785eb9fc42b0 | checkout            | 2024-04-15T03:22:01.317000 | 2024-04-15T03:51:03.870000 | 2024-04-15T04:22:01.284000 |
| 661c9d97b60b785eb9fc42b4 | kbuild-gcc-10-arm64 | 2024-04-15T03:23:03.399000 | 2024-04-15T03:50:15.031000 | 2024-04-15T09:23:03.399000 |
| 661ca3f7b60b785eb9fc4ead | baseline-arm64      | 2024-04-15T03:50:15.304000 | 2024-04-15T05:09:45.247000 | 2024-04-15T09:50:15.304000 |