### PR TITLE
config: platforms-chromeos: fix dalboz device type

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -70,11 +70,9 @@ platforms:
     <<: *x86-chromebook-device
     base_name: coral
 
-  asus-CM1400CXA-dalboz_chromeos: &chromebook-zork-device
+  asus-CM1400CXA-dalboz: &chromebook-zork-device
     <<: *x86-chromebook-device
     base_name: zork
-
-
 
   dell-latitude-3445-7520c-skyrim:
     <<: *x86-chromebook-device

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -3,7 +3,7 @@ _anchors:
   amd-platforms: &amd-platforms
     - acer-R721T-grunt
     - acer-cp514-3wh-r0qs-guybrush
-    - asus-CM1400CXA-dalboz_chromeos
+    - asus-CM1400CXA-dalboz
     - dell-latitude-3445-7520c-skyrim
     - hp-14-db0003na-grunt
     - hp-11A-G6-EE-grunt


### PR DESCRIPTION
Due due to a copy/paste mishap, the device type for `asus-CM1400CXA-dalboz` had a trailing `_chromeos`, leading LAVA to fail finding the correct device type, and no job from the new system running on this platform.