### PR TITLE
src/timeout: set `checkout` result

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -77,7 +77,12 @@ class TimeoutService(Service):
                     node_update['result'] = 'incomplete'
                     node_update['data']['error_code'] = 'node_timeout'
                 else:
-                    node_update['result'] = 'pass'
+                    if node_update['state'] == 'running':
+                        node_update['result'] = 'fail'
+                    else:
+                        node_update['result'] = 'pass'
+            if node_id['kind'] == 'checkout' and mode == 'DONE':
+                node_update['result'] = 'pass'
 
             try:
                 self._api.node.update(node_update)


### PR DESCRIPTION
For `TIMEOUT` mode, set `checkout` node result to `fail` if its state is `running` as it means code checkout is still going on and node timed-out. Set it to `pass` if its state is any other than `running`.
Set `checkout` node result to `pass` if mode is `DONE` as it means once `checkout` has been in `available` or `closing` state and it could successfully complete source code checkout.