### PR TITLE
Improve architecture naming and format strings

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -9,8 +9,8 @@ _anchors:
       compiler: gcc-10
       cross_compile: 'aarch64-linux-gnu-'
       cross_compile_compat: 'arm-linux-gnueabihf-'
-      defconfig: 'cros://chromeos-{krev}/{arch}/chromiumos-{flavour}.flavour.config'
-      flavour: '{arch}-generic'
+      defconfig: 'cros://chromeos-{krev}/{crosarch}/chromiumos-{flavour}.flavour.config'
+      flavour: '{crosarch}-generic'
       fragments:
         - arm64-chromebook
         - CONFIG_MODULE_COMPRESS=n
@@ -21,8 +21,8 @@ _anchors:
     params: &kbuild-gcc-10-x86-chromeos-params
       arch: x86_64
       compiler: gcc-10
-      defconfig: 'cros://chromeos-{krev}/{arch}/chromeos-{flavour}.flavour.config'
-      flavour: '{arch}-generic'
+      defconfig: 'cros://chromeos-{krev}/{crosarch}/chromeos-{flavour}.flavour.config'
+      flavour: '{crosarch}-generic'
       fragments:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
@@ -357,23 +357,18 @@ jobs:
     template: baseline.jinja2
     kind: test
 
-  baseline-nfs-arm64-mediatek: &baseline-nfs-arm64-job
+  baseline-arm64-qualcomm: *baseline-job
+
+  baseline-nfs-arm64-mediatek: &baseline-nfs-job
     template: baseline.jinja2
     kind: test
-    params: &baseline-nfs-arm64-job-params
+    params:
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/arm64
+      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
 
-  baseline-nfs-arm64-qualcomm: *baseline-nfs-arm64-job
-
-  baseline-nfs-x86-amd: &baseline-nfs-x86-job
-    <<: *baseline-nfs-arm64-job
-    params: &baseline-nfs-x86-job-params
-      <<: *baseline-nfs-arm64-job-params
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/amd64
-
-  baseline-nfs-x86-intel: *baseline-nfs-x86-job
-  baseline-arm64-qualcomm: *baseline-job
+  baseline-nfs-arm64-qualcomm: *baseline-nfs-job
+  baseline-nfs-x86-amd: *baseline-nfs-job
+  baseline-nfs-x86-intel: *baseline-nfs-job
   baseline-x86-amd: *baseline-job
   baseline-x86-amd-staging: *baseline-job
   baseline-x86-intel: *baseline-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -280,7 +280,7 @@ jobs:
     template: kselftest.jinja2
     kind: test
     params:
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{arch}'
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{debarch}'
       collections: dt
       job_timeout: 10
     rules:
@@ -293,7 +293,7 @@ jobs:
     template: sleep.jinja2
     kind: test
     params:
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bullseye/20240129.0/{arch}
+      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bullseye/20240129.0/{debarch}
       sleep_params: mem freeze
 
 trees:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -10,9 +10,9 @@ _anchors:
     arch: arm64
     boot_method: u-boot
 
-  armel-device: &armel-device
+  arm-device: &arm-device
     <<: *arm64-device
-    arch: armel
+    arch: arm
 
   baseline: &baseline-job
     template: baseline.jinja2
@@ -198,8 +198,8 @@ jobs:
 
   baseline-arm64: *baseline-job
   baseline-arm64-broonie: *baseline-job
-  baseline-armel: *baseline-job
-  baseline-armel-baylibre: *baseline-job
+  baseline-arm: *baseline-job
+  baseline-arm-baylibre: *baseline-job
   baseline-x86: *baseline-job
   baseline-x86-baylibre: *baseline-job
 
@@ -213,25 +213,25 @@ jobs:
       <<: *kbuild-gcc-10-arm64-params
       dtbs_check: true
 
-  kbuild-gcc-10-armel: &kbuild-gcc-10-armel-job
+  kbuild-gcc-10-arm: &kbuild-gcc-10-arm-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-10:arm64-kselftest-kernelci
-    params: &kbuild-gcc-10-armel-params
+    params: &kbuild-gcc-10-arm-params
       arch: arm
       compiler: gcc-10
       cross_compile: 'arm-linux-gnueabihf-'
       defconfig: multi_v7_defconfig
 
-  kbuild-gcc-10-armel-android-mainline: &kbuild-gcc-10-armel-android-mainline-job
-    <<: *kbuild-gcc-10-armel-job
+  kbuild-gcc-10-arm-android-mainline: &kbuild-gcc-10-arm-android-mainline-job
+    <<: *kbuild-gcc-10-arm-job
     rules:
       tree:
       - 'android'
 
-  kbuild-gcc-10-armel-android-mainline-imx: &kbuild-gcc-10-armel-android-mainline-imx-job
-    <<: *kbuild-gcc-10-armel-android-mainline-job
+  kbuild-gcc-10-arm-android-mainline-imx: &kbuild-gcc-10-arm-android-mainline-imx-job
+    <<: *kbuild-gcc-10-arm-android-mainline-job
     params:
-      <<: *kbuild-gcc-10-armel-params
+      <<: *kbuild-gcc-10-arm-params
       defconfig: imx_v6_v7_defconfig
 
   kbuild-gcc-10-i386:
@@ -341,12 +341,12 @@ platforms:
     dtb: dtbs/broadcom/bcm2711-rpi-4-b.dtb
 
   bcm2836-rpi-2-b:
-    <<: *armel-device
+    <<: *arm-device
     mach: broadcom
     dtb: dtbs/bcm2836-rpi-2-b.dtb
 
   imx6q-sabrelite:
-    <<: *armel-device
+    <<: *arm-device
     mach: imx
     dtb: dtbs/imx6q-sabrelite.dtb
 
@@ -356,7 +356,7 @@ platforms:
     dtb: dtbs/allwinner/sun50i-h5-libretech-all-h3-cc.dtb
 
   sun7i-a20-cubieboard2:
-    <<: *armel-device
+    <<: *arm-device
     mach: allwinner
     dtb: dtbs/sun7i-a20-cubieboard2.dtb
 
@@ -366,17 +366,17 @@ platforms:
     dtb: dtbs/amlogic/meson-g12b-a311d-khadas-vim3.dtb
 
   odroid-xu3:
-    <<: *armel-device
+    <<: *arm-device
     mach: samsung
     dtb: dtbs/exynos5422-odroidxu3.dtb
 
   rk3288-rock2-square:
-    <<: *armel-device
+    <<: *arm-device
     mach: rockchip
     dtb: dtbs/rk3288-rock2-square.dtb
 
   rk3288-veyron-jaq:
-    <<: *armel-device
+    <<: *arm-device
     boot_method: depthcharge
     mach: rockchip
     dtb: dtbs/rk3288-veyron-jaq.dtb
@@ -436,10 +436,10 @@ scheduler:
     platforms:
       - sun50i-h5-libretech-all-h3-cc
 
-  - job: baseline-armel
+  - job: baseline-arm
     event:
       channel: node
-      name: kbuild-gcc-10-armel
+      name: kbuild-gcc-10-arm
       result: pass
     runtime:
       type: lava
@@ -451,10 +451,10 @@ scheduler:
       - rk3288-rock2-square
       - rk3288-veyron-jaq
 
-  - job: baseline-armel-baylibre
+  - job: baseline-arm-baylibre
     event:
       channel: node
-      name: kbuild-gcc-10-armel
+      name: kbuild-gcc-10-arm
       result: pass
     runtime:
       type: lava
@@ -508,13 +508,13 @@ scheduler:
 #      branch: 
 #        - staging-next
 
-  - job: kbuild-gcc-10-armel
+  - job: kbuild-gcc-10-arm
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-10-armel-android-mainline
+  - job: kbuild-gcc-10-arm-android-mainline
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-10-armel-android-mainline-imx
+  - job: kbuild-gcc-10-arm-android-mainline-imx
     <<: *build-k8s-all
 
   - job: kbuild-gcc-10-i386
@@ -573,8 +573,6 @@ build_environments:
     cc: gcc
     cc_version: 10
     arch_params:
-      armel:
-        name: 'arm'
       x86_64:
         name: 'x86'
 
@@ -592,7 +590,7 @@ build_variants:
           base_defconfig: 'defconfig'
           filters:
             - regex: { defconfig: 'defconfig' }
-        armel:
+        arm:
           base_defconfig: 'multi_v7_defconfig'
           filters:
             - regex: { defconfig: 'multi_v7_defconfig' }

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -7,8 +7,8 @@ _anchors:
       flash_kernel:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-{mach}
         image: 'kernel/Image'
-      nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/arm64
-      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240129.0/arm64/tast.tgz
+      nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/{debarch}
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240129.0/{debarch}/tast.tgz
     rules: &arm64-chromebook-device-rules
       defconfig:
         - '!allnoconfig'
@@ -21,11 +21,10 @@ _anchors:
     boot_method: depthcharge
     mach: x86
     params:
+      <<: *arm64-chromebook-device-params
       flash_kernel:
         url: https://storage.chromeos.kernelci.org/images/kernel/cros-20230815-amd64/clang-14
         image: 'kernel/bzImage'
-      nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240215.0/amd64
-      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240129.0/amd64/tast.tgz
     rules:
       <<: *arm64-chromebook-device-rules
       fragments:


### PR DESCRIPTION
This PR addresses 2 issues:
* the naming of 32-bits ARM architecture (`armel`) can be confusing to some and has different meanings for different systems; rename to `arm` so it makes more sense
* replace hardcoded system-dependent architecture strings with the corresponding properties (`crosarch`, `debarch`, `karch`)

Depends on https://github.com/kernelci/kernelci-core/pull/2504