### PR TITLE
Small improvements to ChromeOS configs

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -27,12 +27,18 @@ _anchors:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
 
+  min-5_4-rules: &min-5_4-rules
+    min_version:
+      version: 5
+      patchlevel: 4
+
   min-6_7-rules: &min-6_7-rules
     min_version:
       version: 6
       patchlevel: 7
 
   max-6_6-rules: &max-6_6-rules
+    <<: *min-5_4-rules
     max_version:
       version: 6
       patchlevel: 6
@@ -40,6 +46,7 @@ _anchors:
   tast: &tast-job
     template: tast.jinja2
     kind: test
+    rules: *min-5_4-rules
 
   tast-basic: &tast-basic-job
     <<: *tast-job

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -92,11 +92,10 @@ platforms:
     <<: *x86-chromebook-device
     base_name: nami
 
-  hp-x360-12b-ca0010nr-n4020-octopus: &chromebook-octopus-device
+  hp-x360-12b-ca0010nr-n4020-octopus:
     <<: *x86-chromebook-device
     base_name: octopus
 
-  hp-x360-12b-ca0500na-n4000-octopus: *chromebook-octopus-device
   hp-x360-14a-cb0001xx-zork: *chromebook-zork-device
   lenovo-TPad-C13-Yoga-zork: *chromebook-zork-device
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -25,7 +25,6 @@ _anchors:
     - dell-latitude-5400-8665U-sarien
     - hp-x360-14-G1-sona
     - hp-x360-12b-ca0010nr-n4020-octopus
-    - hp-x360-12b-ca0500na-n4000-octopus
 
   mediatek-platforms: &mediatek-platforms
     - mt8183-kukui-jacuzzi-juniper-sku16


### PR DESCRIPTION
Drop non-existent platform and limit Tast tests to 5.4+: those can't run on earlier kernels due to missing filesystem features, and that causes false positives when trying to identify corrupt devices.