### PR TITLE
src/timeout: a bug fix in `_submit_lapsed_nodes`

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -81,7 +81,7 @@ class TimeoutService(Service):
                         node_update['result'] = 'fail'
                     else:
                         node_update['result'] = 'pass'
-            if node_id['kind'] == 'checkout' and mode == 'DONE':
+            if node['kind'] == 'checkout' and mode == 'DONE':
                 node_update['result'] = 'pass'
 
             try:


### PR DESCRIPTION
Fix a glitch in the code related to setting `checkout` node result.

Fixes: 361fc0d ("src/timeout: set `checkout` result")