### PR TITLE
pipeline.yaml: Update early access FQDN

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -71,7 +71,7 @@ api:
     url: https://staging.kernelci.org:9000
 
   early-access:
-    url: https://kernelci-api.eastus.cloudapp.azure.com
+    url: https://kernelci-api.westus3.cloudapp.azure.com
 
   k8s-host:
     url: http://kernelci-api:8001


### PR DESCRIPTION
We are moving k8s from eastus to westus3 as it is cheaper