### PR TITLE
src/tarball: fix `_kdir` in `update_repo`

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -76,7 +76,7 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
                 self.log.error(err_msg)
                 raise Exception(err_msg)
             # cleanup the repo and return True, so we try again
-            kernelci.shell_cmd(f"rm -rf {self._kdir}")
+            kernelci.shell_cmd(f"rm -rf {self._service_config.kdir}")
             return True
 
         self.log.info("Repo updated")


### PR DESCRIPTION
Fix the below error:
```
kernelci-pipeline-tarball |   File "/home/kernelci/./pipeline/tarball.py", line 79, in _update_repo
kernelci-pipeline-tarball |     kernelci.shell_cmd(f"rm -rf {self._kdir}")
kernelci-pipeline-tarball |                                  ^^^^^^^^^^
kernelci-pipeline-tarball | AttributeError: 'Tarball' object has no attribute '_kdir'
```

Fixes: 0a2fe9c ("src/patchset.py: Implement Patchset service)