### PR TITLE
src/timeout: set timed-out `checkout` result

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -77,8 +77,8 @@ class TimeoutService(Service):
                     node_update['result'] = 'incomplete'
                     node_update['data']['error_code'] = 'node_timeout'
                 else:
-                    if node_update['state'] == 'running':
-                        node_update['result'] = 'fail'
+                    if node['state'] == 'running':
+                        node_update['result'] = 'incomplete'
                     else:
                         node_update['result'] = 'pass'
             if node['kind'] == 'checkout' and mode == 'DONE':


### PR DESCRIPTION
Set timed-out `checkout` node result to `incomplete` while in `running` state. As it denotes that the node timed-out while checkout was still going on.