### PR TITLE
Handle incomplete/failed checkout

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -71,16 +71,15 @@ class TimeoutService(Service):
             node_update['state'] = state
             self.log.debug(f"{node_id} {mode}")
             if mode == 'TIMEOUT':
-                if node['kind'] != 'checkout':
+                if node['kind'] == 'checkout' and node['state'] != 'running':
+                    node_update['result'] = 'pass'
+                else:
                     if 'data' not in node_update:
                         node_update['data'] = {}
                     node_update['result'] = 'incomplete'
                     node_update['data']['error_code'] = 'node_timeout'
-                else:
-                    if node_update['state'] == 'running':
-                        node_update['result'] = 'fail'
-                    else:
-                        node_update['result'] = 'pass'
+                    node_update['data']['error_msg'] = 'Node timed-out'
+
             if node['kind'] == 'checkout' and mode == 'DONE':
                 node_update['result'] = 'pass'
 


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/554
Depends on https://github.com/kernelci/kernelci-core/pull/2507

- Tarball updates source code repo and creates tarball. If update repo operation fails even with the second attempt, it means it failed to checkout souce code. Hence, update `checkout` node with state `done` state and result `fail`.
- Set timed-out `checkout` node result to `incomplete` while in `running` state. As it denotes that the node timed-out while checkout was still going on.