### PR TITLE
Set architecture info for `kunit` test nodes

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -125,6 +125,7 @@ cd {src_path}
             'node': {
                 'result': step_results['exec'][0] or 'fail',
                 'artifacts': artifacts,
+                'data': {'arch': ARCH if ARCH else 'um'}
             },
             'child_nodes': [
                 {


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2517
Fixes https://github.com/kernelci/kernelci-pipeline/issues/567

Set `node.data.arch` field for `kunit` test nodes.