### PR TITLE
result_summary: restore missing split_query_params function

### DIFF
--- a/src/result_summary.py
+++ b/src/result_summary.py
@@ -80,7 +80,7 @@ class ResultSummary(Service):
         # Additional query parameters
         extra_query_params = {}
         if args.query_params:
-            extra_query_params = split_query_params(args.query_params)
+            extra_query_params = utils.split_query_params(args.query_params)
         output_dir = None
         if args.output_dir:
             output_dir = args.output_dir

--- a/src/result_summary/utils.py
+++ b/src/result_summary/utils.py
@@ -6,9 +6,28 @@
 # Common utils for result-summary.
 
 import gzip
+import re
 import requests
 
 import result_summary
+
+
+def split_query_params(query_string):
+    """Given a string input formatted like this:
+           parameter1=value1,parameter2=value2,...,parameterN=valueN
+       return a dict containing the string information where the
+       parameters are the dict keys:
+           {'parameter1': 'value1',
+            'parameter2': 'value2',
+            ...,
+            'parameterN': 'valueN'
+           }
+    """
+    query_dict = {}
+    matches = re.findall('([^ =,]+)\s*=\s*([^ =,]+)', query_string)  # noqa: W605
+    for operator, value in matches:
+        query_dict[operator] = value
+    return query_dict
 
 
 def parse_block_config(block, kind, state):


### PR DESCRIPTION
Restore this function that was accidentally removed during the last refactoring.