### PR TITLE
src: lava_callback: add device ID to node data

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -115,7 +115,10 @@ def async_job_submit(api_helper, node_id, job_callback):
     job_node['result'] = job_result
     job_node['state'] = 'done'
     if device_id:
+        print(f"DEBUG: Habemus device: {device_id}")
         job_node['data']['device'] = device_id
+    else:
+        print(f"DEBUG: Device ID: {callback_data.get('actual_device_id')} => {device_id}")
     hierarchy = job_callback.get_hierarchy(results, job_node)
     api_helper.submit_results(hierarchy, job_node)
 

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -81,6 +81,7 @@ def async_job_submit(api_helper, node_id, job_callback):
 
     log_parser = job_callback.get_log_parser()
     job_result = job_callback.get_job_status()
+    device_id = job_callback.get_device_id()
     storage_config_name = job_callback.get_meta('storage_config_name')
     storage = _get_storage(storage_config_name)
     log_txt_url = _upload_log(log_parser, job_node, storage)
@@ -90,6 +91,8 @@ def async_job_submit(api_helper, node_id, job_callback):
     # failed LAVA job should have result set to 'incomplete'
     job_node['result'] = job_result
     job_node['state'] = 'done'
+    if device_id:
+        job_node['data']['device'] = device_id
     hierarchy = job_callback.get_hierarchy(results, job_node)
     api_helper.submit_results(hierarchy, job_node)
 


### PR DESCRIPTION
It can be useful to know the exact device on which a job ran, without having to open the LAVA job page. This is done by querying the device ID from the callback data and appending it to the node data.

Depends on https://github.com/kernelci/kernelci-core/pull/2519
Fixes https://github.com/kernelci/kernelci-core/issues/2502