### PR TITLE
jobs-chromeos.yaml: Disable module compression for every kernel version

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -14,6 +14,7 @@ _anchors:
       fragments:
         - arm64-chromebook
         - CONFIG_MODULE_COMPRESS=n
+        - CONFIG_MODULE_COMPRESS_NONE=y
     rules: &kbuild-gcc-10-arm64-chromeos-rules
       tree:
       - '!android'
@@ -29,6 +30,7 @@ _anchors:
       fragments:
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
+        - CONFIG_MODULE_COMPRESS_NONE=y
     rules:
       tree:
       - '!android'


### PR DESCRIPTION
Commit d4bbe942098b ("kbuild: remove CONFIG_MODULE_COMPRESS"), introduced in kernel v5.13, substituted CONFIG_MODULE_COMPRESS=n for CONFIG_MODULE_COMPRESS_NONE=y as the way to disable module compression. Since module compression causes "Invalid ELF header magic: != ELF" errors during boot on the ChromeOS base config, add the missing config to disable module compression on kernels > v5.13 as well.