### PR TITLE
Add Android build preset

### DIFF
--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -387,7 +387,7 @@ monitor-all-kunit-failures:
   metadata:
     action: monitor
     title: "All kunit test failures not caused by runtime errors"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "kunit-failures.html"
     #template: "generic-test-failure-report.jinja2"
     #output_file: "kunit-failures.txt"
@@ -433,7 +433,7 @@ stable-rc-build-failures:
   metadata:
     action: summary
     title: "<strong>stable-rc</strong> kernel build failures"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "stable-rc-build-failures.html"
   preset:
     kbuild:
@@ -474,7 +474,7 @@ stable-rc-boot-failures:
   metadata:
     action: summary
     title: "<strong>stable-rc</strong> kernel boot failures"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "stable-rc-boot-failures.html"
   preset:
     test:
@@ -488,7 +488,7 @@ tast-failures:
   metadata:
     action: summary
     title: "General Tast test failures"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "tast-failures.html"
   preset:
     test:
@@ -502,7 +502,7 @@ tast-failures__runtime-errors:
   metadata:
     action: summary
     title: "General Tast test failures"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "tast-failures.html"
   preset:
     test:
@@ -530,7 +530,7 @@ mainline-next-test-failures:
   metadata:
     action: summary
     title: "Test failures found in mainline and next"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "mainline-next-failures.html"
   preset:
     test:
@@ -620,7 +620,7 @@ all-kunit-failures:
   metadata:
     action: summary
     title: "All kunit test failures"
-    template: "generic-test-failures.html.jinja2"
+    template: "generic-test-results.html.jinja2"
     output_file: "kunit-failures.html"
   preset:
     test:

--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -627,3 +627,16 @@ all-kunit-failures:
       - group__re: kunit
         result: fail
         data.error_code: null
+
+# All android build results
+all-android-builds:
+  metadata:
+    action: summary
+    title: "Test results for Android branches"
+    template: "generic-test-results.html.jinja2"
+    output_file: "all-android-builds.html"
+  preset:
+    kbuild:
+      - data.error_code: null
+        repos:
+          - tree: android

--- a/config/result_summary_templates/generic-test-results.html.jinja2
+++ b/config/result_summary_templates/generic-test-results.html.jinja2
@@ -1,7 +1,7 @@
 {# SPDX-License-Identifier: LGPL-2.1-or-later -#}
 
 {#
-Template to generate a generic html test failure summary. It
+Template to generate a generic html test summary. It
 expects the following input parameters:
   - metadata: summary preset metadata
   - from_date: start date of the results query
@@ -25,7 +25,7 @@ expects the following input parameters:
 #}
 
 {% extends "base.html" %}
-{% set title = metadata['title'] if 'title' in metadata else 'Test failures: ' %}
+{% set title = metadata['title'] if 'title' in metadata else 'Test results: ' %}
 
 {% block title %}
   {{ title | striptags }}
@@ -59,7 +59,7 @@ expects the following input parameters:
   </h1>
 
   {% if results_per_branch | count == 0 %}
-    No failures found.
+    No results found.
   {% else -%}
     <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
             data-bs-target="#logSnippet" aria-expanded="false"
@@ -74,7 +74,7 @@ expects the following input parameters:
     {% for tree in results_per_branch %}
       {% for branch in results_per_branch[tree] %}
         <h2 class="text-bg-light p-3 rounded">
-          Test failures found in {{ tree }}/{{ branch }}:
+          Test results found in {{ tree }}/{{ branch }}:
         </h2>
         <div id="result-list">
           {% for test in results_per_branch[tree][branch] -%}

--- a/config/result_summary_templates/generic-test-results.jinja2
+++ b/config/result_summary_templates/generic-test-results.jinja2
@@ -1,7 +1,7 @@
 {# SPDX-License-Identifier: LGPL-2.1-or-later -#}
 
 {#
-Template to generate a generic text-based test failure summary. It
+Template to generate a generic text-based test results summary. It
 expects the following input parameters:
   - metadata: summary preset metadata
   - from_date: start date of the results query
@@ -38,7 +38,7 @@ expects the following input parameters:
 {% elif last_updated_to -%}
   {% set last_updated_string = 'Last updated before ' + last_updated_to -%}
 {% endif -%}
-{{ metadata['title'] if 'title' in metadata else 'Test failures: ' }}
+{{ metadata['title'] if 'title' in metadata else 'Test results: ' }}
 {% if created_string -%}
   - {{ created_string }}
 {% endif -%}
@@ -46,11 +46,11 @@ expects the following input parameters:
   - {{ last_updated_string }}
 {% endif -%}
 {% if results_per_branch | count == 0 %}
-No failures found.
+No results found.
 {% else -%}
   {% for tree in results_per_branch %}
     {% for branch in results_per_branch[tree] %}
-## Failures found in {{ tree }}/{{ branch }}:
+## Results found in {{ tree }}/{{ branch }}:
       {% for test in results_per_branch[tree][branch] -%}
         {% set kernel_version = test['data']['kernel_revision'] %}
     KernelCI node id: {{ test['id'] }}


### PR DESCRIPTION
result-summary.yaml: add preset to list android build tests
    
Since we now build android, add a preset to allow result-summary.yaml to
list all build results from Android tree.

also:

result_summary_templates: make generic-test-failures generic to all
    results

The generic-test-failures templates can be used to show general results
just replacing the name "failures" by "results". Makeing it easier to be
re-used by communities that want to have pre-sets to list all results of
the tests, so:

            s/generic-test-failures/generic-test-results

To properly work, this change requires https://github.com/kernelci/kernelci-pipeline/pull/580 