### PR TITLE
Use "device" field in regression tracker/results summary

### DIFF
--- a/config/result_summary_templates/generic-regression-report.html.jinja2
+++ b/config/result_summary_templates/generic-regression-report.html.jinja2
@@ -71,6 +71,9 @@ the following input parameters:
     {% if node['data']['platform'] %}
       <li>Platform : {{ node['data']['platform'] }}</li>
     {% endif %}
+    {% if node['data']['device'] %}
+      <li>Device : {{ node['data']['device'] }}</li>
+    {% endif %}
     {% if node['data']['config_full'] %}
       <li>Config: {{ node['data']['config_full'] }}</li>
     {% endif %}

--- a/config/result_summary_templates/generic-regression-report.jinja2
+++ b/config/result_summary_templates/generic-regression-report.jinja2
@@ -35,6 +35,9 @@ Arch : {{ node['data']['arch'] }}
 {% if node['data']['platform'] -%}
 Platform : {{ node['data']['platform'] }}
 {% endif -%}
+{% if node['data']['device'] -%}
+Device : {{ node['data']['device'] }}
+{% endif -%}
 {% if node['data']['config_full'] -%}
 Config: {{ node['data']['config_full'] }}
 {% endif -%}

--- a/config/result_summary_templates/generic-regressions.html.jinja2
+++ b/config/result_summary_templates/generic-regressions.html.jinja2
@@ -122,6 +122,9 @@ expects the following input parameters:
               {% if regression['data']['platform'] %}
                 <li>Platform: {{ regression['data']['platform'] }}</li>
               {% endif %}
+              {% if regression['data']['device'] %}
+                <li>Device : {{ regression['data']['device'] }}</li>
+              {% endif %}
               {% if regression['data']['config_full'] %}
                 <li>Config: {{ regression['data']['config_full'] }}</li>
               {% endif %}

--- a/config/result_summary_templates/generic-test-failure-report.html.jinja2
+++ b/config/result_summary_templates/generic-test-failure-report.html.jinja2
@@ -57,6 +57,9 @@ the following input parameters:
     {% if node['data']['platform'] %}
       <li>Platform : {{ node['data']['platform'] }}</li>
     {% endif %}
+    {% if node['data']['device'] %}
+      <li>Device : {{ node['data']['device'] }}</li>
+    {% endif %}
     {% if node['data']['config_full'] %}
       <li>Config: {{ node['data']['config_full'] }}</li>
     {% endif %}

--- a/config/result_summary_templates/generic-test-failure-report.jinja2
+++ b/config/result_summary_templates/generic-test-failure-report.jinja2
@@ -21,6 +21,9 @@ Arch : {{ node['data']['arch'] }}
 {% if node['data']['platform'] -%}
 Platform : {{ node['data']['platform'] }}
 {% endif -%}
+{% if node['data']['device'] -%}
+Device : {{ node['data']['device'] }}
+{% endif -%}
 {% if node['data']['config_full'] -%}
 Config: {{ node['data']['config_full'] }}
 {% endif -%}

--- a/config/result_summary_templates/generic-test-results.html.jinja2
+++ b/config/result_summary_templates/generic-test-results.html.jinja2
@@ -108,6 +108,9 @@ expects the following input parameters:
               {% if test['data']['platform'] %}
                 <li>Platform : {{ test['data']['platform'] }}</li>
               {% endif %}
+              {% if test['data']['device'] %}
+                <li>Device : {{ test['data']['device'] }}</li>
+              {% endif %}
               {% if test['data']['config_full'] %}
                 <li>Config: {{ test['data']['config_full'] }}</li>
               {% endif %}

--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -90,6 +90,7 @@ class RegressionTracker(Service):
             'config_full': failed_node['data'].get('config_full'),
             'compiler': failed_node['data'].get('compiler'),
             'platform': failed_node['data'].get('platform'),
+            'device': failed_node['data'].get('device'),
             'failed_kernel_version': failed_node['data'].get('kernel_revision'),   # noqa
             'error_code': error['error_code'],
             'error_msg': error['error_msg'],


### PR DESCRIPTION
With the `device` field now being available, it can be interesting to add this information to both regression nodes and results summary reports.

Depends on https://github.com/kernelci/kernelci-core/pull/2519