### PR TITLE
config: enable first fluster test for mt8195-cherry-tomato-r2

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -376,6 +376,7 @@ _anchors:
       tree:
         - mainline
         - next
+        - kernelci
 
 jobs:
 

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -364,6 +364,19 @@ _anchors:
         - ui.HotseatAnimation.shelf_with_navigation_widget_lacros
         - ui.WindowControl
 
+  v4l2-decoder-conformance: &v4l2-decoder-conformance-job
+    template: 'v4l2-decoder-conformance.jinja2'
+    kind: test
+    params: &v4l2-decoder-conformance-params
+      nfsroot: 'https://storage.staging.kernelci.org/rootfs/bookworm-gst-fluster/20240430.0/{debarch}/'
+      job_timeout: 30
+      videodec_parallel_jobs: 1
+      videodec_timeout: 90
+    rules:
+      tree:
+        - mainline
+        - next
+
 jobs:
 
   baseline-arm64-mediatek: &baseline-job
@@ -551,3 +564,11 @@ jobs:
   tast-ui-arm64-qualcomm: *tast-ui-job
   tast-ui-x86-intel: *tast-ui-job
   tast-ui-x86-amd: *tast-ui-job
+
+  v4l2-decoder-conformance-av1:
+    <<: *v4l2-decoder-conformance-job
+    params:
+      <<: *v4l2-decoder-conformance-params
+      testsuite: 'AV1-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'

--- a/config/runtime/v4l2-decoder-conformance.jinja2
+++ b/config/runtime/v4l2-decoder-conformance.jinja2
@@ -1,0 +1,4 @@
+{%- set boot_commands = 'nfs' %}
+{%- set test_method = 'v4l2-decoder-conformance' %}
+{%- set base_template = 'base/' + runtime + '.jinja2' %}
+{%- extends base_template %}

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -372,3 +372,8 @@ scheduler:
 
   - job: tast-ui-x86-intel
     <<: *test-job-chromeos-intel
+
+  - job: v4l2-decoder-conformance-av1
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r2


### PR DESCRIPTION
Enable first fluster test, AV1-TEST-VECTORS for mt8195-cherry-tomato-r2. Run the test on mainline and next until more trees are added.

Note: This is my first PR. Please review it and I'll improve it. https://github.com/kernelci/kernelci-core/pull/2535 is a pre-requisite for this.