### PR TITLE
config: chromeos: Enable cpufreq kselftest

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -279,6 +279,15 @@ jobs:
     kind: test
     image: kernelci/staging-kernelci
 
+  kselftest-cpufreq:
+    template: kselftest.jinja2
+    kind: test
+    params:
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      collections: cpufreq
+      job_timeout: 10
+    kcidb_test_suite: kselftest.cpufreq
+
   kselftest-dt:
     template: kselftest.jinja2
     kind: test

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -187,6 +187,18 @@ scheduler:
       result: pass
     platforms: *mediatek-platforms
 
+  - job: kselftest-cpufreq
+    <<: *test-job-x86-intel
+
+  - job: kselftest-cpufreq
+    <<: *test-job-x86-amd
+
+  - job: kselftest-cpufreq
+    <<: *test-job-arm64-qualcomm
+
+  - job: kselftest-cpufreq
+    <<: *test-job-arm64-mediatek
+
   - job: tast-basic-arm64-mediatek
     <<: *test-job-chromeos-mediatek
 


### PR DESCRIPTION
Enable cpufreq kselftest on all the trees and branches.