### PR TITLE
src: update return values of `APIHelper.receive_event_node`

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -234,7 +234,7 @@ class RegressionTracker(Service):
         self.log.info("Press Ctrl-C to stop.")
         sys.stdout.flush()
         while True:
-            node = self._api_helper.receive_event_node(sub_id)
+            node, _ = self._api_helper.receive_event_node(sub_id)
             if node['kind'] == 'checkout' or node['kind'] == 'regression':
                 continue
             self._process_node(node)

--- a/src/result_summary/monitor.py
+++ b/src/result_summary/monitor.py
@@ -101,7 +101,7 @@ def send_email_report(service, context, report_text):
 
 def run(service, context):
     while True:
-        node = service._api_helper.receive_event_node(context['sub_id'])
+        node, _ = service._api_helper.receive_event_node(context['sub_id'])
         service.log.debug(f"Node event received: {node['id']}")
         preset_params = context['preset_params']
         for param_set in context['preset_params']:

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -183,7 +183,7 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            checkout_node = self._api_helper.receive_event_node(sub_id)
+            checkout_node, _ = self._api_helper.receive_event_node(sub_id)
 
             build_config = self._find_build_config(checkout_node)
             if build_config is None:

--- a/src/test_report.py
+++ b/src/test_report.py
@@ -151,7 +151,7 @@ class TestReportLoop(TestReport):
         self.log.info("Press Ctrl-C to stop.")
 
         while True:
-            root_node = self._api_helper.receive_event_node(sub_id)
+            root_node, _ = self._api_helper.receive_event_node(sub_id)
             content, subject = self._get_report(root_node)
             self._dump_report(content)
             self._send_report(subject, content)


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2550

`APIHelper.receive_event_node` method is used to receive node data from PubSub event. The method has been updated to return `is_hierarchy` flag as well which represents events related to node hierarchy.
Update pipeline services using the method accordingly.