### PR TITLE
config: platforms-chromeos: use CrOS R124 files

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -272,7 +272,6 @@ _anchors:
       tests:
         - filemanager.UIPerf.directory_list
         - filemanager.UIPerf.list_apps
-        - settings.DeviceMouseScrollAcceleration
         - ui.DesksAnimationPerf
         - ui.DragTabInTabletPerf.touch
         - ui.OverviewWithExpandedDesksBarPerf
@@ -304,17 +303,13 @@ _anchors:
         - platform.CrosDisksRename
         - platform.CrosDisksSSHFS
         - platform.CrosID
-        - platform.DeviceHwid
         - platform.DMVerity
         - platform.DumpVPDLog
         - platform.Firewall
         - platform.LocalPerfettoTBMTracedProbes
         - platform.Mtpd
-        - platform.SerialNumber
         - platform.TPMResponsive
-        - platform.TPMStatus
         - storage.HealthInfo
-        - storage.InternalStorage
         - storage.LowPowerStateResidence
 
   tast-power: &tast-power-job
@@ -323,12 +318,6 @@ _anchors:
       tests:
         - power.CheckStatus
         - power.CpufreqConf
-        - power.TabletModePowerOffMenu.close_menu
-        - power.TabletModePowerOffMenu.shut_down
-        - power.TabletModePowerOffMenu.sign_out
-        - power.SmartDim.flatbuffer
-        - power.SmartDim
-        - power.SmartDim.lacros
         - power.UtilCheck
         - typec.Basic
 
@@ -347,7 +336,6 @@ _anchors:
         - audio.CrasRecordQuality
         - audio.DevicePlay
         - audio.DevicePlay.unstable_model
-        - audio.DevicePlay.unstable_platform
         - audio.DeviceRecord
         - audio.UCMSequences.section_device
         - audio.UCMSequences.section_modifier

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -8,7 +8,7 @@ _anchors:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-{mach}
         image: 'kernel/Image'
       nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240422.0/{debarch}
-      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240129.0/{debarch}/tast.tgz
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240514.0/{debarch}/tast.tgz
     rules: &arm64-chromebook-device-rules
       defconfig:
         - '!allnoconfig'
@@ -116,7 +116,7 @@ platforms:
     params:
       <<: *arm64-chromebook-device-params
       flash_kernel:
-        url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240129.0/arm64
+        url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240514.0/arm64
         image: 'Image'
     rules:
       <<: *arm64-chromebook-device-rules


### PR DESCRIPTION
ChromeBooks were upgraded with a new image based on ChromiumOS R124, so we must use those files now.