### PR TITLE
result_summary presets: refine presets for v4l2-decoder-conformance

### DIFF
--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -700,3 +700,53 @@ monitor-v4l2-decoder-conformance-failures__runtime-errors:
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
+
+summary-v4l2-decoder-conformance-regressions:
+  metadata:
+    action: summary
+    title: "KernelCI v4l2-decoder-conformance regressions"
+    template: "generic-regressions.html.jinja2"
+    output_file: "v4l2-decoder-conformance-regressions.html"
+  preset:
+    regression:
+      - data.error_code: null
+        group__re: v4l2-decoder-conformance
+        repos:
+          - tree: mainline
+          - tree: next
+          - tree: collabora-chromeos-kernel
+          - tree: media
+
+summary-v4l2-decoder-conformance-failures__runtime-errors:
+  metadata:
+    action: summary
+    title: "KernelCI v4l2-decoder-conformance failures due to runtime errors"
+    template: "generic-test-results.html.jinja2"
+    output_file: "v4l2-decoder-conformance-failures__runtime-errors.html"
+  preset:
+    test:
+      - data.error_code__ne: null
+        result: fail
+        name__re: v4l2-decoder-conformance
+        repos:
+          - tree: mainline
+          - tree: next
+          - tree: collabora-chromeos-kernel
+          - tree: media
+
+summary-v4l2-decoder-conformance-failures:
+  metadata:
+    action: summary
+    title: "KernelCI v4l2-decoder-conformance failures"
+    template: "generic-test-results.html.jinja2"
+    output_file: "v4l2-decoder-conformance-failures.html"
+  preset:
+    test:
+      - data.error_code: null
+        result: fail
+        group__re: v4l2-decoder-conformance
+        repos:
+          - tree: mainline
+          - tree: next
+          - tree: collabora-chromeos-kernel
+          - tree: media

--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -666,33 +666,33 @@ all-android-builds:
         repos:
           - tree: android
 
-#### Failures and regressions in v4l2-decoder-conformance tests in collabora-next
+#### Failures and regressions in v4l2-decoder-conformance tests
 
 monitor-v4l2-decoder-conformance-regressions:
   metadata:
     action: monitor
-    title: "KernelCI v4l2-decoder-conformance regressions found"
+    title: "KernelCI v4l2-decoder-conformance regressions"
     template: "generic-regression-report.html.jinja2"
     output_file: "v4l2-decoder-conformance-regressions.html"
   preset:
     regression:
       - data.error_code: null
-        name__re: v4l2-decoder-conformance
+        group__re: v4l2-decoder-conformance
         repos:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
 
-monitor-v4l2-decoder-conformance-failures:
+monitor-v4l2-decoder-conformance-failures__runtime-errors:
   metadata:
     action: monitor
-    title: "KernelCI v4l2-decoder-conformance failures found"
-    template: "generic-regression-report.html.jinja2"
-    output_file: "v4l2-decoder-conformance-failures.html"
+    title: "KernelCI v4l2-decoder-conformance failures due to runtime errors"
+    template: "generic-test-results.html.jinja2"
+    output_file: "v4l2-decoder-conformance-failures__runtime-errors.html"
   preset:
     test:
-      - data.error_code: null
+      - data.error_code__ne: null
         result: fail
         name__re: v4l2-decoder-conformance
         repos:


### PR DESCRIPTION
Refine the current monitor presets for the `v4l2-decoder-conformance` tests and add a few summary presets too.