### PR TITLE
config: chromeos: enable watchdog reset test on Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -369,6 +369,13 @@ _anchors:
         - collabora-chromeos-kernel
         - media
 
+  watchdog-reset: &watchdog-reset-job
+    template: watchdog-reset.jinja2
+    kind: test
+    params: &watchdog-reset-job-params
+      bl_message: 'coreboot-'
+      wdt_dev: 'watchdog0'
+
 jobs:
 
   baseline-arm64-mediatek: &baseline-job
@@ -617,3 +624,8 @@ jobs:
       decoders:
         - 'GStreamer-VP9-V4L2-Gst1.0'
         - 'GStreamer-VP9-V4L2SL-Gst1.0'
+
+  watchdog-reset-arm64-mediatek: *watchdog-reset-job
+  watchdog-reset-arm64-qualcomm: *watchdog-reset-job
+  watchdog-reset-x86-amd: *watchdog-reset-job
+  watchdog-reset-x86-intel: *watchdog-reset-job

--- a/config/runtime/watchdog-reset.jinja2
+++ b/config/runtime/watchdog-reset.jinja2
@@ -1,0 +1,3 @@
+{%- set test_method = 'watchdog-reset' %}
+{%- set base_template = 'base/' + runtime + '.jinja2' %}
+{%- extends base_template %}

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -434,3 +434,17 @@ scheduler:
 
   - job: v4l2-decoder-conformance-vp9
     <<: *test-job-arm64-qualcomm
+
+  - job: watchdog-reset-arm64-mediatek
+    <<: *test-job-arm64-mediatek
+
+  - job: watchdog-reset-arm64-qualcomm
+    <<: *test-job-arm64-qualcomm
+
+  - job: watchdog-reset-x86-amd
+    <<: *test-job-x86-amd
+
+  - job: watchdog-reset-x86-intel
+    <<: *test-job-x86-intel
+    platforms:
+      - hp-x360-12b-ca0010nr-n4020-octopus


### PR DESCRIPTION
Add a basic test to verify watchdog reset functionality. Enable the test on all ARM64 and AMD x86_64 Chromebooks. For Intel Chromebooks, enable the test only on octopus, as ACPI PM Timer on the other devices has been disabled in coreboot.

Requires: https://github.com/kernelci/kernelci-core/pull/2562