### PR TITLE
config: chromeos: Enable error-logs kselftest for MediaTek Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -440,6 +440,20 @@ jobs:
       branch:
         - for-kernelci
 
+  kselftest-device-error-logs:
+    template: kselftest.jinja2
+    kind: test
+    params:
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      collections: devices/error_logs
+      job_timeout: 10
+    rules:
+      tree:
+        - collabora-next
+      branch:
+        - for-kernelci
+    kcidb_test_suite: kselftest.device_error_logs
+
   tast-basic-arm64-mediatek: *tast-basic-job
   tast-basic-arm64-qualcomm: *tast-basic-job
   tast-basic-x86-intel: *tast-basic-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -187,6 +187,14 @@ scheduler:
       result: pass
     platforms: *mediatek-platforms
 
+  - job: kselftest-device-error-logs
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-10-arm64-chromebook
+      result: pass
+    platforms: *mediatek-platforms
+
   - job: kselftest-cpufreq
     <<: *test-job-x86-intel
 


### PR DESCRIPTION
Run the error-logs kselftest on MediaTek Chromebooks. This test is currently under review upstream [1] so, in the meantime, it has been added to the collabora-next tree so it can prove its value by helping to detect issues upstream.

[1] https://lore.kernel.org/all/20240423-dev-err-log-selftest-v1-0-690c1741d68b@collabora.com

Fixes #606.