### PR TITLE
config: jobs-chromeos: Add lab-setup fragment

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -12,6 +12,7 @@ _anchors:
       defconfig: 'cros://chromeos-{krev}/{crosarch}/chromiumos-{flavour}.flavour.config'
       flavour: '{crosarch}-generic'
       fragments:
+        - lab-setup
         - arm64-chromebook
         - CONFIG_MODULE_COMPRESS=n
         - CONFIG_MODULE_COMPRESS_NONE=y
@@ -28,6 +29,7 @@ _anchors:
       defconfig: 'cros://chromeos-{krev}/{crosarch}/chromeos-{flavour}.flavour.config'
       flavour: '{crosarch}-generic'
       fragments:
+        - lab-setup
         - x86-board
         - CONFIG_MODULE_COMPRESS=n
         - CONFIG_MODULE_COMPRESS_NONE=y

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -390,6 +390,7 @@ jobs:
     params:
       <<: *kbuild-gcc-10-x86-params
       fragments:
+        - lab-setup
         - 'x86-board'
 
   kbuild-gcc-10-x86-allnoconfig:


### PR DESCRIPTION
Add the lab-setup fragment to the chromebook builds, which contains the architecture independent kernel configs needed to run tests on the platform. Notably this disables IP autoconfig by the kernel.

The result of this change is that the 12 seconds boot delay and the consequent deferred probe pending warnings will no longer happen on any platform. Particularly on mt8186-corsola-steelix-sku131072 (due to a different network adapter being used) on which it was still happening.