### PR TITLE
config/runtime/kunit.jinja2: fix result map

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -19,7 +19,7 @@ import kernelci.api.helper
 RESULT_MAP = {
     'PASS': 'pass',
     'FAIL': 'fail',
-    'SKIP': None,
+    'SKIP': 'skip',
 }
 ARCH = '{{ arch }}'
 {% endblock %}


### PR DESCRIPTION
Addresses one of the issues from https://github.com/kernelci/kernelci-api/issues/536

Fix result map for skipped tests. Initially, API didn't have `skip` available node result in the schema. That's why it was 
mapped to `None` result. But now API has `skip` result to denote skipped tests.
Fix the result mapping accordingly.