### PR TITLE
config: platforms-chromeos: Add serial delay for some MediaTek platforms

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -118,6 +118,8 @@ platforms:
       flash_kernel:
         url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240514.0/arm64
         image: 'Image'
+    context:
+      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:
@@ -128,6 +130,8 @@ platforms:
     <<: *mediatek-chromebook-device
     base_name: asurada
     dtb: dtbs/mediatek/mt8192-asurada-spherion-r0.dtb
+    context:
+      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:
@@ -138,6 +142,8 @@ platforms:
     <<: *mediatek-chromebook-device
     base_name: cherry
     dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
+    context:
+      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:


### PR DESCRIPTION
Add test_character_delay to the Spherion and Tomato platforms to workaround the fact that they're sometimes unable to process serial input fast enough, resulting in mangled commands and consequently flaky test results, as described in
https://github.com/kernelci/kernelci-project/issues/366.

The right place to do this change would be in the device-type template as described in LAVA's documentation [1]. This overriding in KernelCI is meant only as a temporary workaround to verify whether this fixes the issue. If it does, then we'll do it in LAVA upstream instead.

[1] https://docs.lavasoftware.org/lava/debugging.html#differences-in-input-speeds
Signed-off-by: Nícolas F. R. A. Prado <nfraprado@collabora.com>