### PR TITLE
config/jobs-chromes: add kcidb test suite property for watchdog test

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -379,6 +379,7 @@ _anchors:
     params: &watchdog-reset-job-params
       bl_message: 'coreboot-'
       wdt_dev: 'watchdog0'
+    kcidb_test_suite: kernelci_watchdog_reset
 
 jobs:
 


### PR DESCRIPTION
Related PR: https://github.com/kernelci/kcidb/pull/530

Add KCIDB test suite mapping for `watchdog_reset` test.