### PR TITLE
src/send_kcidb: add error info to build nodes

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -147,6 +147,8 @@ class KCIDBBridge(Service):
                 'job_id': node['data'].get('job_id'),
                 'job_context': node['data'].get('job_context'),
                 'kernel_type': node['data'].get('kernel_type'),
+                'error_code': node['data'].get('error_code'),
+                'error_msg': node['data'].get('error_msg'),
             }
         }
         artifacts = node.get('artifacts')


### PR DESCRIPTION
Add error metadata fields such as `error_code` and `error_msg` to `misc` field for build nodes.