### PR TITLE
regression_tracker: add a new data field to regressions (node type)

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -83,6 +83,7 @@ class RegressionTracker(Service):
         regression['state'] = 'done'
         error = self._collect_errors(failed_node)
         regression['data'] = {
+            'fail_node_kind': failed_node['kind'],
             'fail_node': failed_node['id'],
             'pass_node': last_pass_node['id'],
             'arch': failed_node['data'].get('arch'),


### PR DESCRIPTION
Store the type (kind) of node that caused the regression. This will come in handy when processing the output of nodes.

If later we decide we won't need this we can drop it.