### PR TITLE
regression_tracker: workaround: match node paths programmatically

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -107,9 +107,14 @@ class RegressionTracker(Service):
         TODO: Move this to core helpers.
 
         """
+        # Workaround: Don't use 'path' as a search parameter (we can't
+        # use lists as query parameter values). Instead, do the
+        # filtering in python code
+        path = search_params.pop('path')
         nodes = self._api.node.find(search_params)
         if not nodes:
             return None
+        nodes = [node for node in nodes if node['path'] == path]
         node = sorted(
             nodes,
             key=lambda node: node['created'],


### PR DESCRIPTION
Don't use 'path' as an api search parameter. The use of lists as query parameters (path is a list) is undefined. Instead, do the filtering in code.

**NOT TESTED YET**, waiting to see it running on staging