### PR TITLE
Enable discoverable devices probe kselftest on MediaTek chromebooks

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1420,6 +1420,18 @@ jobs:
       - 'kernelci:staging-next'
     kcidb_test_suite: kselftest.cpufreq.suspend
 
+  kselftest-devices-probe:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: devices/probe
+      env: "KSELFTEST_TEST_DISCOVERABLE_DEVICES_PY_ARGS=--boards-dir=/opt/platform-test-parameters/kselftest/test_discoverable_devices/boards/"
+    rules:
+      min_version:
+        version: 6
+        patchlevel: 11
+    kcidb_test_suite: kselftest.devices-probe
+
   kselftest-dmabuf-heaps:
     <<: *kselftest-job
     params:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1393,7 +1393,7 @@ jobs:
     params: &kselftest-params
       test_method: kselftest
       boot_commands: nfs
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20241007.0/{debarch}'
       collections: cpufreq
       job_timeout: 10
     kcidb_test_suite: kselftest.cpufreq

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -204,6 +204,14 @@ scheduler:
       result: pass
     platforms: *mediatek-platforms
 
+  - job: kselftest-devices-probe
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-12-arm64-chromebook
+      result: pass
+    platforms: *mediatek-platforms
+
   - job: kselftest-cpufreq
     <<: *test-job-x86-intel
 


### PR DESCRIPTION
Enable the discoverable devices probe kselftest on the MediaTek Chromebook platforms. This test will validate that the devices connected through USB or PCI on those platforms have been probed successfully. The devices are, namely, the camera on mt8183-juniper and mt8186-steelix, and the camera, wifi and bluetooth on mt8195-tomato.

Depends on https://github.com/kernelci/kernelci-core/pull/2577.

Fixes #579 .