### PR TITLE
tests/validate_yaml: add validation for KCIDB mapping

### DIFF
--- a/tests/validate_yaml.py
+++ b/tests/validate_yaml.py
@@ -15,7 +15,16 @@ def validate_yaml():
         if file.endswith('.yaml'):
             with open('config/' + file, 'r') as stream:
                 try:
-                    yaml.safe_load(stream)
+                    data = yaml.safe_load(stream)
+                    jobs = data.get('jobs')
+                    if not jobs:
+                        continue
+                    for name, definition in jobs.items():
+                        if definition.get('kind') in ("test", "job"):
+                            if not definition.get('kcidb_test_suite'):
+                                raise yaml.YAMLError(
+                                    f"KCIDB test suite mapping not found for job: {name}'"
+                                )
                 except yaml.YAMLError as exc:
                     print(f'Error in {file}: {exc}')
                     sys.exit(1)


### PR DESCRIPTION
To submit KernelCI generated data to KCIDB, it is required to have a mapping for all the job definitions with
`kcidb_test_suite` property.
Add validation to ensure all the jobs have a mapping present to avoid missing data submission. This check is to notify test authors trying to enable tests in maestro to include the required property for the mapping in their definition.