### PR TITLE
KCIDB submission: skip `setup` tests submission

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -413,13 +413,17 @@ in {test_node['data'].get('runtime')}",
                 )
 
             elif node['kind'] == 'test':
+                self._get_test_data(node, context['origin'],
+                                    parsed_test_node, parsed_build_node)
+
+            elif node['kind'] == 'job':
+                # Send only failed/incomplete job nodes
+                if node['result'] != 'pass':
+                    self._get_test_data(node, context['origin'],
+                                        parsed_test_node, parsed_build_node)
                 if is_hierarchy:
                     self._get_test_data_recursively(node, context['origin'],
                                                     parsed_test_node, parsed_build_node)
-
-                elif not self._api.node.count({'parent': node['id']}):
-                    self._get_test_data(node, context['origin'],
-                                        parsed_test_node, parsed_build_node)
 
             revision = {
                 'checkouts': parsed_checkout_node,

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -404,7 +404,7 @@ in {test_node['data'].get('runtime')}",
 
         while True:
             node, is_hierarchy = self._api_helper.receive_event_node(context['sub_id'])
-            self.log.info(f"Submitting node to KCIDB: {node['id']}")
+            self.log.info(f"Received an event for node: {node['id']}")
 
             parsed_checkout_node = []
             parsed_build_node = []

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -377,6 +377,11 @@ in {test_node['data'].get('runtime')}",
         if not test_node['path']:
             self.log.info(f"Not sending test as path information is missing: {test_node['id']}")
             return
+
+        if 'setup' in test_node.get('path'):
+            # do not send setup tests
+            return
+
         parsed_test_node.append(test_node)
         if build_node:
             parsed_build_node.append(build_node)

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -57,14 +57,16 @@ class KCIDBBridge(Service):
 
     def _send_revision(self, client, revision):
         revision = self._remove_none_fields(revision)
-        self.log.debug(f"DEBUG: sending revision: {revision}")
-        if kcidb.io.SCHEMA.is_valid(revision):
-            return client.submit(revision)
-        self.log.error("Aborting, invalid data")
-        try:
-            kcidb.io.SCHEMA.validate(revision)
-        except Exception as exc:
-            self.log.error(f"Validation error: {str(exc)}")
+        if any(value for key, value in revision.items() if key != 'version'):
+            self.log.debug(f"DEBUG: sending revision: {revision}")
+            if kcidb.io.SCHEMA.is_valid(revision):
+                client.submit(revision)
+            else:
+                self.log.error("Aborting, invalid data")
+                try:
+                    kcidb.io.SCHEMA.validate(revision)
+                except Exception as exc:
+                    self.log.error(f"Validation error: {str(exc)}")
 
     @staticmethod
     def _set_timezone(created_timestamp):


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-pipeline/pull/639

`setup` test suite has been introduced to store test results for environment setup checks before running an actual test suite.
KCIDB doesn't require `setup` test suite result as long as the main test job result is submitted.