### PR TITLE
config: chromeos: enable wifi basic test on Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -388,7 +388,7 @@ _anchors:
 
   wifi-basic: &wifi-basic-job
     template: generic.jinja2
-    kind: test
+    kind: job
     params: &wifi-basic-job-params
       test_method: wifi-basic
       boot_commands: nfs
@@ -475,7 +475,7 @@ jobs:
 
   kselftest-device-error-logs:
     template: generic.jinja2
-    kind: test
+    kind: job
     params:
       test_method: kselftest
       boot_commands: nfs

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -360,9 +360,11 @@ _anchors:
         - ui.WindowControl
 
   v4l2-decoder-conformance: &v4l2-decoder-conformance-job
-    template: 'v4l2-decoder-conformance.jinja2'
+    template: 'generic.jinja2'
     kind: job
     params: &v4l2-decoder-conformance-params
+      test_method: v4l2-decoder-conformance
+      boot_commands: nfs
       nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240703.0/{debarch}/'
       job_timeout: 30
       videodec_parallel_jobs: 1
@@ -376,9 +378,10 @@ _anchors:
     kcidb_test_suite: fluster.v4l2
 
   watchdog-reset: &watchdog-reset-job
-    template: watchdog-reset.jinja2
+    template: generic.jinja2
     kind: job
     params: &watchdog-reset-job-params
+      test_method: watchdog-reset
       bl_message: 'coreboot-'
       wdt_dev: 'watchdog0'
     kcidb_test_suite: kernelci_watchdog_reset
@@ -444,9 +447,11 @@ jobs:
       flavour: intel-pineview
 
   kselftest-acpi:
-    template: kselftest.jinja2
+    template: generic.jinja2
     kind: job
     params:
+      test_method: kselftest
+      boot_commands: nfs
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
       collections: acpi
       job_timeout: 10
@@ -456,9 +461,11 @@ jobs:
     kcidb_test_suite: kselftest.acpi
 
   kselftest-device-error-logs:
-    template: kselftest.jinja2
+    template: generic.jinja2
     kind: test
     params:
+      test_method: kselftest
+      boot_commands: nfs
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
       collections: devices/error_logs
       job_timeout: 10

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -386,6 +386,19 @@ _anchors:
       wdt_dev: 'watchdog0'
     kcidb_test_suite: kernelci_watchdog_reset
 
+  wifi-basic: &wifi-basic-job
+    template: generic.jinja2
+    kind: test
+    params: &wifi-basic-job-params
+      test_method: wifi-basic
+      boot_commands: nfs
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20240313.0/{debarch}/'
+    rules:
+      tree:
+        - mainline
+        - next
+    kcidb_test_suite: kernelci_wifi_basic
+
 jobs:
 
   baseline-arm64-mediatek: &baseline-job
@@ -657,3 +670,7 @@ jobs:
   watchdog-reset-arm64-qualcomm: *watchdog-reset-job
   watchdog-reset-x86-amd: *watchdog-reset-job
   watchdog-reset-x86-intel: *watchdog-reset-job
+
+  wifi-basic-arm64-mediatek: *wifi-basic-job
+  wifi-basic-x86-amd: *wifi-basic-job
+  wifi-basic-x86-intel: *wifi-basic-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -884,9 +884,11 @@ jobs:
       - 'stable-rc'
 
   kselftest-cpufreq: &kselftest-job
-    template: kselftest.jinja2
+    template: generic.jinja2
     kind: job
     params: &kselftest-params
+      test_method: kselftest
+      boot_commands: nfs
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
       collections: cpufreq
       job_timeout: 10
@@ -1161,9 +1163,10 @@ jobs:
 
   # amd64-only temporary
   sleep:
-    template: sleep.jinja2
+    template: generic.jinja2
     kind: job
     params:
+      test_method: sleep
       nfsroot: http://storage.kernelci.org/images/rootfs/debian/bullseye/20240129.0/{debarch}
       sleep_params: mem freeze
     kcidb_test_suite: kernelci_sleep

--- a/config/runtime/generic.jinja2
+++ b/config/runtime/generic.jinja2
@@ -1,0 +1,2 @@
+{% set base_template = 'base/' + runtime + '.jinja2' %}
+{%- extends base_template %}

--- a/config/runtime/kselftest.jinja2
+++ b/config/runtime/kselftest.jinja2
@@ -1,4 +1,0 @@
-{%- set boot_commands = 'nfs' %}
-{%- set test_method = 'kselftest' %}
-{%- set base_template = 'base/' + runtime + '.jinja2' %}
-{%- extends base_template %}

--- a/config/runtime/sleep.jinja2
+++ b/config/runtime/sleep.jinja2
@@ -1,3 +1,0 @@
-{%- set test_method = 'sleep' %}
-{%- set base_template = 'base/' + runtime + '.jinja2' %}
-{%- extends base_template %}

--- a/config/runtime/v4l2-decoder-conformance.jinja2
+++ b/config/runtime/v4l2-decoder-conformance.jinja2
@@ -1,4 +1,0 @@
-{%- set boot_commands = 'nfs' %}
-{%- set test_method = 'v4l2-decoder-conformance' %}
-{%- set base_template = 'base/' + runtime + '.jinja2' %}
-{%- extends base_template %}

--- a/config/runtime/watchdog-reset.jinja2
+++ b/config/runtime/watchdog-reset.jinja2
@@ -1,3 +1,0 @@
-{%- set test_method = 'watchdog-reset' %}
-{%- set base_template = 'base/' + runtime + '.jinja2' %}
-{%- extends base_template %}

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -548,3 +548,12 @@ scheduler:
     <<: *test-job-x86-intel
     platforms:
       - hp-x360-12b-ca0010nr-n4020-octopus
+
+  - job: wifi-basic-arm64-mediatek
+    <<: *test-job-arm64-mediatek
+
+  - job: wifi-basic-x86-amd
+    <<: *test-job-x86-amd
+
+  - job: wifi-basic-x86-intel
+    <<: *test-job-x86-intel

--- a/doc/developer-documentation.md
+++ b/doc/developer-documentation.md
@@ -101,9 +101,10 @@ Common patterns are often defined using YAML anchors and aliases. This approach 
 The test job example is:
 ```yaml
   kselftest-exec:
-    template: kselftest.jinja2
+    template: generic.jinja2
     kind: job
     params:
+      test_method: kselftest
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
       collections: exec
       job_timeout: 10
@@ -177,9 +178,10 @@ Here is an example of enabling `kselftest` (found in `<linux_kernel>/tools/testi
 1. Create a job definition in `jobs` section.
 ```
   kselftest-dt:
-    template: kselftest.jinja2
+    template: generic.jinja2
     kind: job
     params:
+      test_method: kselftest
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{debarch}'
       collections: dt
       job_timeout: 10


### PR DESCRIPTION
Add basic test to verify basic WiFi functionality. Enable the test on ARM64 and x86_64 Chromebooks.

Requires: https://github.com/kernelci/kernelci-core/pull/2581