### PR TITLE
config: remove qemu jobs from lab-qualcomm

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -803,17 +803,6 @@ scheduler:
       name: lava-collabora
     platforms: *qualcomm-platforms
 
-  - job: baseline-x86-qualcomm
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86
-      result: pass
-    runtime:
-      type: lava
-      name: lava-qualcomm
-    platforms:
-      - qemu
-
   - job: baseline-x86-cip
     event:
       channel: node


### PR DESCRIPTION
QEMU jobs use container pulled from hub.docker.com. After the lab move pulling from this registry is no longer possible at Qualcomm. This patch disables QEMU jobs from Qualcomm lab.