### PR TITLE
validate_yaml.py: Improve pipeline validation

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -549,6 +549,21 @@ jobs:
 
 trees:
 
+  broonie-misc:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git"
+
+  broonie-regmap:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regmap.git"
+
+  broonie-regulator:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regulator.git"
+
+  broonie-sound:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/sound.git"
+
+  broonie-spi:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/spi.git"
+
   kernelci:
     url: "https://github.com/kernelci/linux.git"
 
@@ -982,6 +997,51 @@ build_variants:
 
 
 build_configs:
+
+  broonie-misc:
+    tree: broonie-misc
+    branch: 'for-kernelci'
+    variants: *build-variants
+
+  broonie-regmap:
+    tree: broonie-regmap
+    branch: 'for-next'
+    variants: *build-variants
+
+  broonie-regmap-fixes:
+    tree: broonie-regmap
+    branch: 'for-linus'
+    variants: *build-variants
+
+  broonie-regulator:
+    tree: broonie-regulator
+    branch: 'for-next'
+    variants: *build-variants
+
+  broonie-regulator-fixes:
+    tree: broonie-regulator
+    branch: 'for-linus'
+    variants: *build-variants
+
+  broonie-sound:
+    tree: broonie-sound
+    branch: 'for-next'
+    variants: *build-variants
+
+  broonie-sound-fixes:
+    tree: broonie-sound
+    branch: 'for-linus'
+    variants: *build-variants
+
+  broonie-spi:
+    tree: broonie-spi
+    branch: 'for-next'
+    variants: *build-variants
+
+  broonie-spi-fixes:
+    tree: broonie-spi
+    branch: 'for-linus'
+    variants: *build-variants
 
   kernelci_staging-mainline:
     tree: kernelci

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -893,9 +893,6 @@ scheduler:
   - job: kbuild-gcc-12-riscv-nommu_k210_defconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-riscv-rv32_defconfig
-    <<: *build-k8s-all
-
   - job: kbuild-gcc-12-arc-haps_hs_smp_defconfig
     <<: *build-k8s-all
 

--- a/tests/validate_yaml.py
+++ b/tests/validate_yaml.py
@@ -7,27 +7,82 @@ import os
 import yaml
 import sys
 
-def validate_yaml():
+def recursive_merge(d1, d2):
+    '''
+    Recursively merge two dictionaries, which might have lists
+    Not sure if i done this right, but it works
+    '''
+    for k, v in d2.items():
+        if k in d1:
+            if isinstance(v, dict):
+                d1[k] = recursive_merge(d1[k], v)
+            elif isinstance(v, list):
+                d1[k] += v
+            else:
+                d1[k] = v
+        else:
+            d1[k] = v
+    return d1
+
+def validate_jobs(jobs):
+    '''
+    Validate jobs, they must have a kcidb_test_suite mapping
+    '''
+    for name, definition in jobs.items():
+        if definition.get('kind') in ("test", "job"):
+            if not definition.get('kcidb_test_suite'):
+                raise yaml.YAMLError(
+                    f"KCIDB test suite mapping not found for job: {name}'"
+                )
+
+def validate_scheduler_jobs(data):
+    '''
+    Each entry in scheduler have a job, that should be defined in jobs
+    '''
+    sch_entries = data.get('scheduler')
+    jobs = data.get('jobs')
+    for entry in sch_entries:
+        if entry.get('job') not in jobs.keys():
+            raise yaml.YAMLError(
+                f"Job {entry.get('job')} not found in jobs"
+            )
+
+def validate_unused_jobs(data):
+    '''
+    Check if all jobs are used in scheduler
+    '''
+    sch_entries = data.get('scheduler')
+    jobs = data.get('jobs')
+    sch_jobs = [entry.get('job') for entry in sch_entries]
+    for job in jobs.keys():
+        if job not in sch_jobs:
+            print(f"Warning: Job {job} is not used in scheduler")
+
+def validate_yaml(dir='config/'):
     '''
     Validate all yaml files in the config/ directory
     '''
-    for file in os.listdir('config/'):
+    merged_data = {}
+    for file in os.listdir(dir):
         if file.endswith('.yaml'):
-            with open('config/' + file, 'r') as stream:
+            print(f"Validating {file}")
+            fpath = os.path.join(dir, file)
+            with open(fpath, 'r') as stream:
                 try:
                     data = yaml.safe_load(stream)
+                    merged_data = recursive_merge(merged_data, data)
                     jobs = data.get('jobs')
-                    if not jobs:
-                        continue
-                    for name, definition in jobs.items():
-                        if definition.get('kind') in ("test", "job"):
-                            if not definition.get('kcidb_test_suite'):
-                                raise yaml.YAMLError(
-                                    f"KCIDB test suite mapping not found for job: {name}'"
-                                )
+                    if jobs:
+                        validate_jobs(jobs)
                 except yaml.YAMLError as exc:
                     print(f'Error in {file}: {exc}')
                     sys.exit(1)
+    print("Validating scheduler entries to jobs")
+    validate_scheduler_jobs(merged_data)
+    validate_unused_jobs(merged_data)
 
 if __name__ == '__main__':
-    validate_yaml()
+    if len(sys.argv) > 1:
+        validate_yaml(sys.argv[1])
+    else:
+        validate_yaml()

--- a/tests/validate_yaml.py
+++ b/tests/validate_yaml.py
@@ -46,9 +46,9 @@ def validate_scheduler_jobs(data):
     '''
     Each entry in scheduler have a job, that should be defined in jobs
     '''
-    sch_entries = data.get('scheduler')
+    schedules = data.get('scheduler')
     jobs = data.get('jobs')
-    for entry in sch_entries:
+    for entry in schedules:
         if entry.get('job') not in jobs.keys():
             raise yaml.YAMLError(
                 f"Job {entry.get('job')} not found in jobs"
@@ -58,9 +58,9 @@ def validate_unused_jobs(data):
     '''
     Check if all jobs are used in scheduler
     '''
-    sch_entries = data.get('scheduler')
+    schedules = data.get('scheduler')
     jobs = data.get('jobs')
-    sch_jobs = [entry.get('job') for entry in sch_entries]
+    sch_jobs = [entry.get('job') for entry in schedules]
     for job in jobs.keys():
         if job not in sch_jobs:
             print(f"Warning: Job {job} is not used in scheduler")

--- a/tests/validate_yaml.py
+++ b/tests/validate_yaml.py
@@ -89,7 +89,7 @@ def validate_unused_trees(data):
         if tree not in build_trees:
             print(f"Warning: Tree {tree} is not used in build_configs")
 
-def validate_yaml(dir='config/'):
+def validate_yaml(dir='config'):
     '''
     Validate all yaml files in the config/ directory
     '''


### PR DESCRIPTION
Add validation that scheduler entries have matching job entry, this is critical validation, and job entries have at least one entry in the scheduler.
Fix one entry detected by this validation