### PR TITLE
config/kernelci.toml: update KCIDB origin name

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -30,7 +30,7 @@ output = "/home/kernelci/data/output"
 [send_kcidb]
 kcidb_topic_name = "playground_kcidb_new"
 kcidb_project_id = "kernelci-production"
-origin = "kernelci"
+origin = "maestro"
 
 [test_report]
 email_sender = "bot@kernelci.org"


### PR DESCRIPTION
As we agreed to refer new KernelCI API & Pipeline as "maestro", use the new name while submitting data
to KCIDB.