### PR TITLE
Enable Android builds in different configurations with gcc-12 and clang-17 both

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1620,6 +1620,10 @@ build_configs:
     tree: android
     branch: 'android15-6.6'
 
+  android15-6.6-lts:
+    tree: android
+    branch: 'android15-6.6-lts'
+
   collabora-next_for-kernelci:
     tree: collabora-next
     branch: 'for-kernelci'

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1527,122 +1527,98 @@ build_configs:
   android_4.9-p:
     tree: android
     branch: 'android-4.9-p'
-    variants: *build-variants
 
   android_4.9-q-release:
     tree: android
     branch: 'android-4.9-q-release'
-    variants: *build-variants
 
   android_4.14-p:
     tree: android
     branch: 'android-4.14-p'
-    variants: *build-variants
 
   android_4.14-q-release:
     tree: android
     branch: 'android-4.14-q-release'
-    variants: *build-variants
 
   android_4.14-stable:
     tree: android
     branch: 'android-4.14-stable'
-    variants: *build-variants
 
   android_4.19-q-release:
     tree: android
     branch: 'android-4.19-q-release'
-    variants: *build-variants
 
   android_4.19-stable:
     tree: android
     branch: 'android-4.19-stable'
-    variants: *build-variants
 
   android_mainline:
     tree: android
     branch: 'android-mainline'
-    variants: *build-variants
 
   android_mainline_tracking:
     tree: android
     branch: 'android-mainline-tracking'
-    variants: *build-variants
 
   android11-5.4:
     tree: android
     branch: 'android11-5.4'
-    variants: *build-variants
 
   android12-5.4:
     tree: android
     branch: 'android12-5.4'
-    variants: *build-variants
 
   android12-5.4-lts:
     tree: android
     branch: 'android12-5.4-lts'
-    variants: *build-variants
 
   android12-5.10:
     tree: android
     branch: 'android12-5.10'
-    variants: *build-variants
 
   android12-5.10-lts:
     tree: android
     branch: 'android12-5.10-lts'
-    variants: *build-variants
 
   android13-5.10:
     tree: android
     branch: 'android13-5.10'
-    variants: *build-variants
 
   android13-5.10-lts:
     tree: android
     branch: 'android13-5.10-lts'
-    variants: *build-variants
 
   android13-5.15:
     tree: android
     branch: 'android13-5.15'
-    variants: *build-variants
 
   android13-5.15-lts:
     tree: android
     branch: 'android13-5.15-lts'
-    variants: *build-variants
 
   android14-5.15:
     tree: android
     branch: 'android14-5.15'
-    variants: *build-variants
 
   android14-5.15-lts:
     tree: android
     branch: 'android14-5.15-lts'
-    variants: *build-variants
 
   android14-6.1:
     tree: android
     branch: 'android14-6.1'
-    variants: *build-variants
 
   android14-6.1-lts:
     tree: android
     branch: 'android14-6.1-lts'
-    variants: *build-variants
 
   android15-6.1:
     tree: android
     branch: 'android15-6.1'
-    variants: *build-variants
 
   android15-6.6:
     tree: android
     branch: 'android15-6.6'
-    variants: *build-variants
 
   collabora-next_for-kernelci:
     tree: collabora-next

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -341,6 +341,40 @@ jobs:
       tree:
       - 'stable-rt'
 
+  kbuild-gcc-12-arm64-android: &kbuild-gcc-12-arm64-android-job
+    <<: *kbuild-gcc-12-arm64-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-gcc-12-arm64-android-allmodconfig:
+    <<: *kbuild-gcc-12-arm64-android-job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      fragments:
+       - 'allmodconfig'
+
+  kbuild-gcc-12-arm64-android-allnoconfig:
+    <<: *kbuild-gcc-12-arm64-android-job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      fragments:
+       - 'allnoconfig'
+
+  kbuild-gcc-12-arm64-android-big_endian:
+    <<: *kbuild-gcc-12-arm64-android-job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      fragments:
+       - CONFIG_CPU_BIG_ENDIAN=y
+
+  kbuild-gcc-12-arm64-android-randomize:
+    <<: *kbuild-gcc-12-arm64-android-job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      fragments:
+       - CONFIG_RANDOMIZE_BASE=y
+
   kbuild-gcc-12-arm-imx_v6_v7_defconfig:
     <<: *kbuild-gcc-12-arm-job
     params:
@@ -398,11 +432,37 @@ jobs:
       tree:
       - 'android'
 
-  kbuild-gcc-12-arm-android-imx: &kbuild-gcc-12-arm-android-imx-job
+  kbuild-gcc-12-arm-android-allmodconfig:
     <<: *kbuild-gcc-12-arm-android-job
     params:
       <<: *kbuild-gcc-12-arm-params
       defconfig: imx_v6_v7_defconfig
+      fragments:
+        - 'allmodconfig'
+
+  kbuild-gcc-12-arm-android-multi_v5_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: multi_v5_defconfig
+
+  kbuild-gcc-12-arm-android-imx_v6_v7_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: imx_v6_v7_defconfig
+
+  kbuild-gcc-12-arm-android-omap2plus_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: omap2plus_defconfig
+
+  kbuild-gcc-12-arm-android-vexpress_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: vexpress_defconfig
 
   kbuild-gcc-12-arm-omap2plus_defconfig:
     <<: *kbuild-gcc-12-arm-job
@@ -455,6 +515,16 @@ jobs:
       - 'stable-rc'
       - 'kernelci'
 
+  kbuild-gcc-12-i386-android-allnoconfig:
+    <<: *kbuild-gcc-12-i386-job
+    params:
+      <<: *kbuild-gcc-12-i386-params
+      fragments:
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
+
   kbuild-gcc-12-mips-32r2el_defconfig:
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:mips-kselftest-kernelci
@@ -476,6 +546,16 @@ jobs:
       compiler: gcc-12
       cross_compile: 'riscv64-linux-gnu-'
       defconfig: defconfig
+
+  kbuild-gcc-12-riscv-android-defconfig:
+    <<: *kbuild-gcc-12-riscv-job
+    params:
+      <<: *kbuild-gcc-12-riscv-params
+      fragments:
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
 
   kbuild-gcc-12-riscv-nommu_k210_defconfig:
     <<: *kbuild-gcc-12-riscv-job
@@ -532,6 +612,26 @@ jobs:
       tree:
       - 'stable-rc'
       - 'kernelci'
+
+  kbuild-gcc-12-x86-android-allmodconfig:
+    <<: *kbuild-gcc-12-x86-job
+    params:
+      <<: *kbuild-gcc-12-x86-params
+      fragments:
+       - allmodconfig
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-gcc-12-x86-android-allnoconfig:
+    <<: *kbuild-gcc-12-x86-job
+    params:
+      <<: *kbuild-gcc-12-x86-params
+      fragments:
+       - allnoconfig
+    rules:
+      tree:
+      - 'android'
 
   kbuild-gcc-12-x86-preempt_rt:
     <<: *kbuild-gcc-12-x86-job
@@ -936,6 +1036,21 @@ scheduler:
   - job: kbuild-gcc-12-arm64-preempt_rt_chromebook
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm64-android
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-big_endian
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-randomize
+    <<: *build-k8s-all
+
 # Example of same job name to apply to different tree/branch
 #  - job: kbuild-gcc-12-arm64-dtbscheck
 #    <<: *build-k8s-all
@@ -951,7 +1066,19 @@ scheduler:
   - job: kbuild-gcc-12-arm-android
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm-android-imx
+  - job: kbuild-gcc-12-arm-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-android-multi_v5_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-android-imx_v6_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-android-omap2plus_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-android-vexpress_defconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm64-chromebook-kcidebug
@@ -966,6 +1093,9 @@ scheduler:
   - job: kbuild-gcc-12-riscv
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-riscv-android-defconfig
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86
     <<: *build-k8s-all
   
@@ -978,6 +1108,12 @@ scheduler:
   - job: kbuild-gcc-12-x86-tinyconfig
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-x86-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-x86-android-allnoconfig
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86-preempt_rt
     <<: *build-k8s-all
 
@@ -988,6 +1124,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-i386-tinyconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-i386-android-allnoconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-mips-32r2el_defconfig

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -661,6 +661,9 @@ jobs:
       <<: *kbuild-clang-17-riscv-params
       fragments:
         - allnoconfig
+      filters:
+        - blocklist:
+            kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']
     rules:
       tree:
       - 'android'
@@ -680,6 +683,9 @@ jobs:
       <<: *kbuild-gcc-12-riscv-params
       fragments:
         - allnoconfig
+      filters:
+        - blocklist:
+            kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']
     rules:
       tree:
       - 'android'

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -44,6 +44,15 @@ _anchors:
       compiler: clang-17
       defconfig: x86_64_defconfig
 
+  kbuild-clang-12-arm64: &kbuild-clang-17-arm64-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:arm64-kselftest-kernelci
+    params: &kbuild-clang-17-arm64-params
+      arch: arm64
+      compiler: clang-17
+      cross_compile: 'aarch64-linux-gnu-'
+      defconfig: defconfig
+
   kbuild-gcc-12-arm64: &kbuild-gcc-12-arm64-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:arm64-kselftest-kernelci
@@ -280,6 +289,15 @@ jobs:
       - 'stable-rc'
       - 'kernelci'
 
+  kbuild-clang-17-arm: &kbuild-clang-17-arm-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:arm64-kselftest-kernelci
+    params: &kbuild-clang-17-arm-params
+      arch: arm
+      compiler: clang-17
+      cross_compile: 'arm-linux-gnueabihf-'
+      defconfig: multi_v7_defconfig
+
   kbuild-gcc-12-arm: &kbuild-gcc-12-arm-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:arm64-kselftest-kernelci
@@ -288,6 +306,40 @@ jobs:
       compiler: gcc-12
       cross_compile: 'arm-linux-gnueabihf-'
       defconfig: multi_v7_defconfig
+
+  kbuild-clang-17-arm64-android: &kbuild-clang-17-arm64-android-job
+    <<: *kbuild-clang-17-arm64-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-arm64-android-allmodconfig:
+    <<: *kbuild-clang-17-arm64-android-job
+    params:
+      <<: *kbuild-clang-17-arm64-params
+      fragments:
+       - 'allmodconfig'
+
+  kbuild-clang-17-arm64-android-allnoconfig:
+    <<: *kbuild-clang-17-arm64-android-job
+    params:
+      <<: *kbuild-clang-17-arm64-params
+      fragments:
+       - 'allnoconfig'
+
+  kbuild-clang-17-arm64-android-big_endian:
+    <<: *kbuild-clang-17-arm64-android-job
+    params:
+      <<: *kbuild-clang-17-arm64-params
+      fragments:
+       - CONFIG_CPU_BIG_ENDIAN=y
+
+  kbuild-clang-17-arm64-android-randomize:
+    <<: *kbuild-clang-17-arm64-android-job
+    params:
+      <<: *kbuild-clang-17-arm64-params
+      fragments:
+       - CONFIG_RANDOMIZE_BASE=y
 
   kbuild-gcc-12-arm64:
     <<: *kbuild-gcc-12-arm64-job
@@ -374,6 +426,44 @@ jobs:
       <<: *kbuild-gcc-12-arm64-params
       fragments:
        - CONFIG_RANDOMIZE_BASE=y
+
+  kbuild-clang-17-arm-android: &kbuild-clang-17-arm-android-job
+    <<: *kbuild-clang-17-arm-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-arm-android-allmodconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: imx_v6_v7_defconfig
+      fragments:
+        - 'allmodconfig'
+
+  kbuild-clang-17-arm-android-multi_v5_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: multi_v5_defconfig
+
+  kbuild-clang-17-arm-android-imx_v6_v7_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: imx_v6_v7_defconfig
+
+  kbuild-clang-17-arm-android-omap2plus_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: omap2plus_defconfig
+
+  kbuild-clang-17-arm-android-vexpress_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: vexpress_defconfig
 
   kbuild-gcc-12-arm-imx_v6_v7_defconfig:
     <<: *kbuild-gcc-12-arm-job
@@ -485,6 +575,24 @@ jobs:
       tree:
       - 'android'
 
+  kbuild-clang-17-i386: &kbuild-clang-17-i386-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:x86-kselftest-kernelci
+    params: &kbuild-clang-17-i386-params
+      arch: i386
+      compiler: clang-17
+      defconfig: i386_defconfig
+
+  kbuild-clang-17-i386-android-allnoconfig:
+    <<: *kbuild-clang-17-i386-job
+    params:
+      <<: *kbuild-clang-17-i386-params
+      fragments:
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
+
   kbuild-gcc-12-i386: &kbuild-gcc-12-i386-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:x86-kselftest-kernelci
@@ -538,6 +646,25 @@ jobs:
       - 'stable-rc'
       - 'kernelci'
 
+  kbuild-clang-17-riscv: &kbuild-clang-17-riscv-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:riscv64-kselftest-kernelci
+    params: &kbuild-clang-17-riscv-params
+      arch: riscv
+      compiler: clang-17
+      cross_compile: 'riscv64-linux-gnu-'
+      defconfig: defconfig
+
+  kbuild-clang-17-riscv-android-defconfig:
+    <<: *kbuild-clang-17-riscv-job
+    params:
+      <<: *kbuild-clang-17-riscv-params
+      fragments:
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
+
   kbuild-gcc-12-riscv: &kbuild-gcc-12-riscv-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:riscv64-kselftest-kernelci
@@ -570,6 +697,26 @@ jobs:
 
   kbuild-clang-17-x86:
     <<: *kbuild-clang-17-x86-job
+
+  kbuild-clang-17-x86-android-allmodconfig:
+    <<: *kbuild-clang-17-x86-job
+    params:
+      <<: *kbuild-clang-17-x86-params
+      fragments:
+       - allmodconfig
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-x86-android-allnoconfig:
+    <<: *kbuild-clang-17-x86-job
+    params:
+      <<: *kbuild-clang-17-x86-params
+      fragments:
+       - allnoconfig
+    rules:
+      tree:
+      - 'android'
 
   kbuild-gcc-12-x86:
     <<: *kbuild-gcc-12-x86-job
@@ -1019,6 +1166,27 @@ scheduler:
   - job: kbuild-clang-17-x86
     <<: *build-k8s-all
 
+  - job: kbuild-clang-17-x86-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-x86-android-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm64-android
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm64-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm64-android-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm64-android-big_endian
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm64-android-randomize
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm64
     <<: *build-k8s-all
 
@@ -1060,6 +1228,24 @@ scheduler:
 #      branch: 
 #        - staging-next
 
+  - job: kbuild-clang-17-arm-android
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-multi_v5_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-imx_v6_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-omap2plus_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-vexpress_defconfig
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm
     <<: *build-k8s-all
 
@@ -1090,6 +1276,9 @@ scheduler:
   - job: kbuild-gcc-12-i386
     <<: *build-k8s-all
 
+  - job: kbuild-clang-17-riscv-android-defconfig
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-riscv
     <<: *build-k8s-all
 
@@ -1118,6 +1307,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-preempt_rt_x86_board
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-i386-android-allnoconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-i386-allnoconfig


### PR DESCRIPTION
Android UM builds are already enabled. This PR enables android builds for arm, arm64, x86, i386, riscv with gcc-12 and clang-17.