### PR TITLE
Enable log file support

### DIFF
--- a/config/logger.conf
+++ b/config/logger.conf
@@ -6,9 +6,13 @@
 [loggers]
 keys=root,
      monitor,
+     patchset,
      regression_tracker,
      result_summary,
      scheduler,
+     scheduler_docker,
+     scheduler_lava,
+     scheduler_k8s,
      send_kcidb,
      tarball,
      test_report,
@@ -49,6 +53,12 @@ handlers=consoleHandler, fileHandler
 qualname=monitor
 propagate=0
 
+[logger_patchset]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=patchset
+propagate=0
+
 [logger_regression_tracker]
 level=DEBUG
 handlers=consoleHandler, fileHandler
@@ -65,6 +75,24 @@ propagate=0
 level=DEBUG
 handlers=consoleHandler, fileHandler
 qualname=scheduler
+propagate=0
+
+[logger_scheduler_docker]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=scheduler_docker
+propagate=0
+
+[logger_scheduler_lava]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=scheduler_lava
+propagate=0
+
+[logger_scheduler_k8s]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=scheduler_k8s
 propagate=0
 
 [logger_send_kcidb]

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -5,8 +5,9 @@
 
 [loggers]
 keys=root,
-     notifier,
+     monitor,
      regression_tracker,
+     result_summary,
      scheduler,
      send_kcidb,
      tarball,
@@ -42,16 +43,22 @@ datefmt=%m/%d/%Y %I:%M:%S %p %Z
 level=INFO
 handlers=consoleHandler
 
-[logger_notifier]
+[logger_monitor]
 level=DEBUG
 handlers=consoleHandler, fileHandler
-qualname=notifier
+qualname=monitor
 propagate=0
 
 [logger_regression_tracker]
 level=DEBUG
 handlers=consoleHandler, fileHandler
 qualname=regression_tracker
+propagate=0
+
+[logger_result_summary]
+level=DEBUG
+handlers=consoleHandler, fileHandler
+qualname=result_summary
 propagate=0
 
 [logger_scheduler]

--- a/config/logger.conf
+++ b/config/logger.conf
@@ -17,7 +17,7 @@ keys=root,
      trigger
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler, fileHandler
 
 [formatters]
 keys=defaultFormatter
@@ -27,6 +27,12 @@ class=StreamHandler
 level=DEBUG
 formatter=defaultFormatter
 args=(sys.stdout,)
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=defaultFormatter
+args=(os.path.join('logs', '%(log_file)s'), 'w')
 
 [formatter_defaultFormatter]
 format=%(asctime)s [%(levelname)s] %(message)s
@@ -38,60 +44,60 @@ handlers=consoleHandler
 
 [logger_notifier]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=notifier
 propagate=0
 
 [logger_regression_tracker]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=regression_tracker
 propagate=0
 
 [logger_scheduler]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=scheduler
 propagate=0
 
 [logger_send_kcidb]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=send_kcidb
 propagate=0
 
 [logger_tarball]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=tarball
 propagate=0
 
 [logger_test_report]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=test_report
 propagate=0
 
 [logger_timeout]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=timeout
 propagate=0
 
 [logger_timeout-closing]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=timeout-closing
 propagate=0
 
 [logger_timeout-holdoff]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=timeout-holdoff
 propagate=0
 
 [logger_trigger]
 level=DEBUG
-handlers=consoleHandler
+handlers=consoleHandler, fileHandler
 qualname=trigger
 propagate=0

--- a/docker-compose-kcidb.yaml
+++ b/docker-compose-kcidb.yaml
@@ -24,7 +24,7 @@ services:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
       - './data/kcidb:/home/kernelci/data/kcidb'
-
+      - './logs:/home/kernelci/logs'
 networks:
   kcidb:
     driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--runtimes=shell'
+      - '--name=scheduler'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
@@ -71,6 +72,7 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--runtimes=docker'
+      - '--name=scheduler_docker'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
@@ -88,6 +90,7 @@ services:
       - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
+      - '--name=scheduler_lava'
       - '--runtimes'
       - 'lava-collabora'
       - 'lava-collabora-staging'
@@ -106,6 +109,7 @@ services:
       - './pipeline/scheduler.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
+      - '--name=scheduler_k8s'
       - '--runtimes'
       - 'k8s-gke-eu-west4'
       - 'k8s-all'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     volumes: &base-volumes
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
+      - './logs:/home/kernelci/logs'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -37,6 +38,7 @@ services:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
       - './data/output:/home/kernelci/data/output'
+      - './logs:/home/kernelci/logs'
 
   scheduler: &scheduler
     container_name: 'kernelci-pipeline-scheduler'
@@ -55,6 +57,7 @@ services:
       - './data/k8s-credentials/.kube:/home/kernelci/.kube'
       - './data/k8s-credentials/.config/gcloud:/home/kernelci/.config/gcloud'
       - './data/k8s-credentials/.azure:/home/kernelci/.azure'
+      - './logs:/home/kernelci/logs'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -74,6 +77,7 @@ services:
       - './data/output:/home/kernelci/data/output'
       - './.docker-env:/home/kernelci/.docker-env'
       - '/var/run/docker.sock:/var/run/docker.sock'  # Docker-in-Docker
+      - './logs:/home/kernelci/logs'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -121,6 +125,7 @@ services:
       - './data/ssh:/home/kernelci/data/ssh'
       - './data/src:/home/kernelci/data/src'
       - './data/output:/home/kernelci/data/output'
+      - './logs:/home/kernelci/logs'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -210,4 +215,4 @@ services:
       - './data/ssh:/home/kernelci/data/ssh'
       - './data/src:/home/kernelci/data/src'
       - './data/output:/home/kernelci/data/output'
-
+      - './logs:/home/kernelci/logs'

--- a/src/logger.py
+++ b/src/logger.py
@@ -10,6 +10,7 @@
 import logging
 import logging.config
 import traceback
+import time
 
 
 class Logger:
@@ -22,7 +23,9 @@ class Logger:
 
     def __init__(self, config_path, name='root'):
         """Returns logger object using configurations and logger name"""
-        logging.config.fileConfig(config_path)
+        log_file_name = f'{name}_{time.strftime("%Y_%m_%d-%H:%M:%S")}.log'
+        logging.config.fileConfig(config_path,
+                                  defaults={'log_file': log_file_name})
         self._logger = logging.getLogger(name)
 
     def log_message(self, log_level, msg):

--- a/src/patchset.py
+++ b/src/patchset.py
@@ -319,7 +319,7 @@ class cmd_run(Command):
     ]
 
     def __call__(self, configs, args):
-        return Patchset(configs, args).run(args)
+        return Patchset(configs, args, 'patchset').run(args)
 
 
 if __name__ == "__main__":

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -27,7 +27,7 @@ class Scheduler(Service):
     """Service to schedule jobs that match received events"""
 
     def __init__(self, configs, args):
-        super().__init__(configs, args, 'scheduler')
+        super().__init__(configs, args, args.name)
         self._api_config_yaml = yaml.dump(self._api_config)
         self._verbose = args.verbose
         self._output = args.output
@@ -208,6 +208,11 @@ class cmd_loop(Command):
             'name': '--runtimes',
             'nargs': '*',
             'help': "Runtime environments to use, all by default",
+        },
+        {
+            'name': '--name',
+            'help': "Service name used to create log file",
+            'required': True
         },
     ]
 

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -37,8 +37,8 @@ cd {target_dir}
 git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
 """
 
-    def __init__(self, global_configs, service_config):
-        super().__init__(global_configs, service_config, 'tarball')
+    def __init__(self, global_configs, service_config, name):
+        super().__init__(global_configs, service_config, name)
         self._service_config = service_config
         self._build_configs = global_configs['build_configs']
         if not os.path.exists(self._service_config.output):
@@ -237,7 +237,7 @@ class cmd_run(Command):
     ]
 
     def __call__(self, configs, args):
-        return Tarball(configs, args).run(args)
+        return Tarball(configs, args, 'tarball').run(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes https://github.com/kernelci/kernelci-project/issues/334

Enable multiple log streams for `Logger`.
    
Create a file handler to dump logs to files. Use stream and file handlers for all the pipeline services to redirect logs to both the streams including `stdout` and log file.
Update the logger config file.