### PR TITLE
regression_tracker: bugfix: catch empty search condition

### DIFF
--- a/src/regression_tracker.py
+++ b/src/regression_tracker.py
@@ -112,9 +112,9 @@ class RegressionTracker(Service):
         # filtering in python code
         path = search_params.pop('path')
         nodes = self._api.node.find(search_params)
+        nodes = [node for node in nodes if node['path'] == path]
         if not nodes:
             return None
-        nodes = [node for node in nodes if node['path'] == path]
         node = sorted(
             nodes,
             key=lambda node: node['created'],


### PR DESCRIPTION
Fix _get_last_matching_node(), after the previous change there was an unhandled scenario where nodes may be empty but the function wouldn't return None immediately.