### PR TITLE
config: update KCIDB test suite mapping for baseline

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -386,7 +386,7 @@ jobs:
   baseline-arm64-mediatek: &baseline-job
     template: baseline.jinja2
     kind: job
-    kcidb_test_suite: kernelci_baseline
+    kcidb_test_suite: boot
 
   baseline-arm64-qualcomm: *baseline-job
 
@@ -396,7 +396,7 @@ jobs:
     params:
       boot_commands: nfs
       nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
-    kcidb_test_suite: kernelci_baseline.nfs
+    kcidb_test_suite: boot.nfs
 
   baseline-nfs-arm64-qualcomm: *baseline-nfs-job
   baseline-nfs-x86-amd: *baseline-nfs-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -17,7 +17,7 @@ _anchors:
   baseline: &baseline-job
     template: baseline.jinja2
     kind: job
-    kcidb_test_suite: kernelci_baseline
+    kcidb_test_suite: boot
 
   checkout: &checkout-event
     channel: node

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -217,7 +217,7 @@ class KCIDBBridge(Service):
         test suite name to exclude build and runtime information
         from the test path.
         For example, test path ['checkout', 'kbuild-gcc-10-x86', 'baseline-x86']
-        would be converted to "kernelci_baseline"
+        would be converted to "boot"
         """
         if isinstance(path, list):
             if is_checkout_child:


### PR DESCRIPTION
Use `boot` as KCIDB test suite mapping for all baseline tests.