### PR TITLE
callback_url: Update config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,14 @@ Runtime is configured in yaml file following way, for example:
     notify:
       callback:
         token: kernelci-api-token-staging
-        url: https://staging.kernelci.org:9100
 ```
 
 - url is endpoint of LAVA lab API where job will be submitted.
-- notify.callback.url is endpoint of lava-callback service where LAVA will send results.
 - notify.callback.token is token DESCRIPTION used in LAVA job definition. This part is a little bit tricky: https://docs.lavasoftware.org/lava/user-notifications.html#notification-callbacks
 If you specify token name that does not exist in LAVA under user submitting job, callback will return token secret set to description. If following example it will be "kernelci-api-token-staging".
 If you specify token name that matches existing token in LAVA, callback will return token value (secret) from LAVA, which is usually long alphanumeric string.
 Tokens generated in LAVA in "API -> Tokens" section. Token name is "DESCRIPTION" and token value (secret) can be shown by clicking on green eye icon named "View token hash".
+Callback URL is set in pipeline instance environment variable KCI_INSTANCE_CALLBACK.
 
 The `lava-callback` service is used to receive notifications from LAVA after a job has finished.  It is configured to listen on port 8000 by default and expects in header "Authorization" token value(secret) from LAVA. Mapping of token value to lab name is done over toml file. Example:
 ```

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -185,7 +185,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-new-api-callback
-        url: https://staging.kernelci.org:9100
     rules:
       tree:
       - '!android'
@@ -198,7 +197,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-api-token-staging
-        url: https://staging.kernelci.org:9100
     rules:
       tree:
       - '!android'
@@ -210,7 +208,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-api-token-early-access
-        url: https://staging.kernelci.org:9100
 
   lava-collabora-staging:
     <<: *lava-collabora-staging
@@ -218,7 +215,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-api-token-lava-staging
-        url: https://staging.kernelci.org:9100
 
   lava-baylibre:
     lab_type: lava
@@ -226,7 +222,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-new-api
-        url: https://staging.kernelci.org:9100
     rules:
       tree:
       - kernelci
@@ -239,7 +234,6 @@ runtimes:
     notify:
       callback:
         token: kernelci-lab-qualcomm
-        url: https://staging.kernelci.org:9100
 
   lava-cip:
     lab_type: lava
@@ -247,7 +241,6 @@ runtimes:
     notify:
       callback:
         token: kernel-ci-new-api
-        url: https://staging.kernelci.org:9100
 
   shell:
     lab_type: shell


### PR DESCRIPTION
As we are moving callback URL to environment variable, updating config and README accordingly.