### PR TITLE
scheduler.py: If event have jobfilter, inject it to the node data

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -189,6 +189,10 @@ class Scheduler(Service):
             event = self._api_helper.receive_event_data(sub_id)
             for job, runtime, platform, rules in self._sched.get_schedule(event):
                 input_node = self._api.node.get(event['id'])
+                jobfilter = event.get('jobfilter')
+                # Add to node data the jobfilter if it exists in event
+                if jobfilter and isinstance(jobfilter, list):
+                    input_node['jobfilter'] = jobfilter
                 if self._api_helper.should_create_node(rules, input_node):
                     self._run_job(job, runtime, platform, input_node)
 


### PR DESCRIPTION
When someone generate artificial event with jobfilter, this is likely maintainer trying to repeat job. Treat this accordingly, and inject job filter to job node, so we will run only tests maintainer wants.