### PR TITLE
lava_callback: migrate to fastapi

### DIFF
--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -9,15 +9,16 @@ services:
 
   lava-callback:
     # With uWSGI in socket mode, to use with reverse proxy e.g. Nginx and SSL
-    command:
-      - '/usr/local/bin/uwsgi'
-      - '--master'
-      - '--socket=:8000'
-      - '--buffer-size=32768'
-      - '-p${NPROC:-4}'
-      - '--enable-threads'
-      - '--wsgi-file=/home/kernelci/pipeline/lava_callback.py'
-      - '--callable=app'
+    command: uvicorn lava_callback:app --host 0.0.0.0 --port 8000 --app-dir /home/kernelci/pipeline/
+    #command:
+    #  - '/usr/local/bin/uwsgi'
+    #  - '--master'
+    #  - '--socket=:8000'
+    #  - '--buffer-size=32768'
+    #  - '-p${NPROC:-4}'
+    #  - '--enable-threads'
+    #  - '--wsgi-file=/home/kernelci/pipeline/lava_callback.py'
+    #  - '--callable=app'
 
     # With uWSGI HTTP server, suitable for a public instance but no SSL
     # command:

--- a/docker/lava-callback/requirements.txt
+++ b/docker/lava-callback/requirements.txt
@@ -1,2 +1,3 @@
-flask==2.3.2
 uwsgi==2.0.22
+uvicorn==0.30.1
+fastapi==0.111.0


### PR DESCRIPTION
It will be easier to maintain API and Pipeline, as both will be powered by FastAPI framework.