### PR TITLE
kbuild.jinja2: support defconfig as list or str

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -19,7 +19,17 @@ import sys
 KBUILD_PARAMS = {
     'arch': '{{ arch }}',
     'compiler': '{{ compiler }}',
-    'defconfig': '{{ defconfig }}',
+    'defconfig': 
+{%- if defconfig is string %}
+    '{{ defconfig }}'
+{%- elif defconfig %}
+    [
+    {%- for item in defconfig %}
+        '{{ item }}'
+        {%- if not loop.last %}, {% endif %}
+    {%- endfor %}
+    ]   
+{%- endif %},
 {%- if fragments %}
     'fragments': {{ fragments }},
 {%- else %}


### PR DESCRIPTION
As required in https://github.com/kernelci/kernelci-core/pull/2608 defconfig might be two types. Support it in jinja2 accordingly.