### PR TITLE
config: platforms-chromeos: Add serial delay for Jacuzzi

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -103,6 +103,8 @@ platforms:
     base_name: jacuzzi
     mach: mediatek
     dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
+    context:
+      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:
@@ -118,8 +120,6 @@ platforms:
       flash_kernel:
         url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240514.0/arm64
         image: 'Image'
-    context:
-      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:
@@ -130,8 +130,6 @@ platforms:
     <<: *mediatek-chromebook-device
     base_name: asurada
     dtb: dtbs/mediatek/mt8192-asurada-spherion-r0.dtb
-    context:
-      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:
@@ -142,8 +140,6 @@ platforms:
     <<: *mediatek-chromebook-device
     base_name: cherry
     dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
-    context:
-      test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
       min_version:


### PR DESCRIPTION
Add `test_character_delay` to Jacuzzi Chromebooks, similar to other Mediatek Chromebooks. This workaround addresses the issue of not processing serial input quickly enough, which may cause output mangling and inconsistent test results.

This is a temporary workaround to identify the correct delay value. The proper place to define the delay is the LAVA device dictionaries.

Similar to: https://github.com/kernelci/kernelci-pipeline/pull/626

Instance of test failure caused by corrupt serial output, causing a false regression on this platform (`ttyS ttyS0: 1 input overrun(s)` is also reported in the log): https://lava.collabora.dev/scheduler/job/14838004#L6255