### PR TITLE
pipeline.yaml: Add kselftest-landlock to x86 devices

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1012,6 +1012,15 @@ jobs:
       tst_cmd: 'svsematest'
     kcidb_test_suite: rt-tests.svsematest
 
+  kselftest-landlock:
+    template: kselftest.jinja2
+    kind: job
+    params:
+      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      collections: landlock
+      job_timeout: 10
+    kcidb_test_suite: kselftest.landlock
+
   # amd64-only temporary
   sleep:
     template: sleep.jinja2
@@ -1598,6 +1607,19 @@ scheduler:
       name: lava-collabora
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: kselftest-landlock
+    event:
+      channel: node
+      name: kbuild-gcc-12-x86
+      result: pass
+    runtime:
+      type: lava
+      name: lava-collabora
+    platforms:
+      - acer-chromebox-cxi4-puff
+      - acer-cp514-3wh-r0qs-guybrush
+      - acer-cp514-2h-1160g7-volteer
 
   - job: sleep
     event:


### PR DESCRIPTION
During cleanup in legacy system, author of PR https://github.com/kernelci/kernelci-core/pull/1505 expressed interest in enabling landlock tests.
Let's do first step and enable landlock tests at least on x86 devices.