### PR TITLE
config: pipeline: run baseline on non-allmodconfig for android

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1125,7 +1125,7 @@ scheduler:
   - job: baseline-arm64-android
     event:
       channel: node
-      name: kbuild-gcc-12-arm64-android-allmodconfig
+      name: kbuild-gcc-12-arm64-android
       result: pass
     runtime:
       type: lava
@@ -1152,7 +1152,7 @@ scheduler:
   - job: baseline-arm-android
     event:
       channel: node
-      name: kbuild-gcc-12-arm-android-allmodconfig
+      name: kbuild-gcc-12-arm-android
       result: pass
     runtime:
       type: lava


### PR DESCRIPTION
The allmodconfig generates very large kernel image. It cannot be booted on the arm64 and arm targets as tftp errors out that size is too large. Reduce the kernel image size. Use the default defconfig. The same defconfigs have been booting for other trees.