### PR TITLE
config: use the new `tree:branch` format for rules

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -450,9 +450,7 @@ jobs:
       job_timeout: 10
     rules:
       tree:
-        - collabora-next
-      branch:
-        - for-kernelci
+        - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.acpi
 
   kselftest-device-error-logs:
@@ -464,9 +462,7 @@ jobs:
       job_timeout: 10
     rules:
       tree:
-        - collabora-next
-      branch:
-        - for-kernelci
+        - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.device_error_logs
 
   tast-basic-arm64-mediatek: *tast-basic-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1403,10 +1403,8 @@ scheduler:
   - job: kbuild-gcc-12-arm64-dtbscheck
     <<: *build-k8s-all
     rules:
-      tree: 
-        - next
-      branch: 
-        - master
+      tree:
+        - next:master
 
   - job: kbuild-gcc-12-arm64-preempt_rt
     <<: *build-k8s-all
@@ -1436,10 +1434,8 @@ scheduler:
 #  - job: kbuild-gcc-12-arm64-dtbscheck
 #    <<: *build-k8s-all
 #    rules:
-#      tree: 
-#        - kernelci
-#      branch: 
-#        - staging-next
+#      tree:
+#        - kernelci:staging-next
 
   - job: kbuild-clang-17-arm-android
     <<: *build-k8s-all


### PR DESCRIPTION
For cases where we want a single branch to be allowed for a given tree, we can now use the `tree:branch` format in rules. Convert existing rules accordingly.

Depends on https://github.com/kernelci/kernelci-core/pull/2613