### PR TITLE
config: pipeline: fix improper use of "filters" attribute

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -687,10 +687,10 @@ jobs:
       defconfig:
         - defconfig
         - allnoconfig
-      filters:
-        - blocklist:
-            kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']
-    rules:
+    rules: &kbuild-riscv-android-rules
+      min_version:
+        version: 4
+        patchlevel: 19
       tree:
       - 'android'
 
@@ -710,12 +710,8 @@ jobs:
       defconfig:
         - defconfig
         - allnoconfig
-      filters:
-        - blocklist:
-            kernel: ['v3.', 'v4.4', 'v4.9', 'v4.14']
     rules:
-      tree:
-      - 'android'
+      <<: *kbuild-riscv-android-rules
 
   kbuild-gcc-12-riscv-nommu_k210_defconfig:
     <<: *kbuild-gcc-12-riscv-job
@@ -926,12 +922,13 @@ jobs:
     template: rt-tests.jinja2
     kind: job
     nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-rt/20240313.0/{debarch}'
-    filters:
-      - passlist: {defconfig: ['preempt_rt']}
     params: &rt-tests-params
       job_timeout: '10'
       duration: '60s'
     kcidb_test_suite: rt-tests
+    rules:
+      fragments:
+        - preempt_rt
 
   rt-tests-cyclicdeadline:
     <<: *rt-tests


### PR DESCRIPTION
The `filters` param was used in the legacy system but has been replaced by `rules`, with a different syntax.

For Android RISC-V builds, this was used to deny job execution on kernels < 4.19, so let's translate this condition with the rules format, and do a similar change for the `rt-tests`-based jobs.