### PR TITLE
config: pipeline: Remove android's deprecated branches

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1749,30 +1749,6 @@ build_configs:
     branch: 'for-next'
     variants: *build-variants
 
-  android_4.9-p:
-    tree: android
-    branch: 'android-4.9-p'
-
-  android_4.9-q-release:
-    tree: android
-    branch: 'android-4.9-q-release'
-
-  android_4.14-p:
-    tree: android
-    branch: 'android-4.14-p'
-
-  android_4.14-q-release:
-    tree: android
-    branch: 'android-4.14-q-release'
-
-  android_4.14-stable:
-    tree: android
-    branch: 'android-4.14-stable'
-
-  android_4.19-q-release:
-    tree: android
-    branch: 'android-4.19-q-release'
-
   android_4.19-stable:
     tree: android
     branch: 'android-4.19-stable'


### PR DESCRIPTION
It has been confirmed with Todd that we should remove the deprecated branches. Hence remove those branches.