### PR TITLE
Fix "Enabling new tree" section

### DIFF
--- a/doc/developer-documentation.md
+++ b/doc/developer-documentation.md
@@ -5,7 +5,7 @@ description: "KernelCI Pipeline developer manual"
 weight: 4
 ---
 
-## Enabling a new Kernel tree
+## Enabling new Kernel trees, builds, and tests
 
 We can monitor different kernel trees in KernelCI. The builds and test jobs are triggered whenever the specified branches are updated.
 This manual describes how to enable trees in [`kernelci-pipeline`](https://github.com/kernelci/kernelci-pipeline.git).

--- a/doc/developer-documentation.md
+++ b/doc/developer-documentation.md
@@ -106,6 +106,7 @@ The test job example is:
 Please have a look at [config/pipeline.yaml](https://github.com/kernelci/kernelci-pipeline/blob/main/config/pipeline.yaml) and [config/jobs-chromeos.yaml](https://github.com/kernelci/kernelci-pipeline/blob/main/config/jobs-chromeos.yaml) files to check currently added job definitions for reference.
 
 We need to specify which branch to monitor of a particular tree for trigering jobs in `build_configs`.
+
 ```yaml
 build_configs:
   <name-of-variant0>:
@@ -115,6 +116,8 @@ build_configs:
   <name-of-variant1>:
     tree: <tree-name>
     branch: <branch-name1>
+```
+
 That's it! The tree is enabled now. All the jobs defined under `jobs` section of [config file](https://github.com/kernelci/kernelci-pipeline/blob/main/config/pipeline.yaml) would run on the specified branched for this tree.
 
 ### Schedule the job


### PR DESCRIPTION
- Fix a minor bug in YAML block formatting
- Rename a section from "Enabling a new Kernel tree" to "Enabling new KernelCI trees and tests" as it explains enabling tests as well

Fixes: f5f57de ("doc: developer-documentation: Update documentation by adding more details")