### PR TITLE
v4l2-decoder-conformance: Enable Fluster tests on ChromeOS

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -390,7 +390,6 @@ _anchors:
         - next
         - collabora-chromeos-kernel
         - media
-    kcidb_test_suite: fluster.chromeos
 
   watchdog-reset: &watchdog-reset-job
     template: generic.jinja2
@@ -695,6 +694,7 @@ jobs:
       testsuite: 'AV1-TEST-VECTORS'
       decoders:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_av1
 
   fluster-chromeos-av1-chromium-10bit:
     <<: *fluster-chromeos-job
@@ -703,6 +703,7 @@ jobs:
       testsuite: 'CHROMIUM-10bit-AV1-TEST-VECTORS'
       decoders:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_av1_chromium
 
   fluster-chromeos-h264:
     <<: *fluster-chromeos-job
@@ -712,7 +713,7 @@ jobs:
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
-
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_h264
   fluster-chromeos-h264-frext:
     <<: *fluster-chromeos-job
     params:
@@ -721,6 +722,7 @@ jobs:
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_h264_frext
 
   fluster-chromeos-h265:
     <<: *fluster-chromeos-job
@@ -730,6 +732,7 @@ jobs:
       decoders:
         - 'GStreamer-H.265-V4L2-Gst1.0'
         - 'GStreamer-H.265-V4L2SL-Gst1.0'
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_h265
 
   fluster-chromeos-vp8:
     <<: *fluster-chromeos-job
@@ -739,7 +742,7 @@ jobs:
       decoders:
         - 'GStreamer-VP8-V4L2-Gst1.0'
         - 'GStreamer-VP8-V4L2SL-Gst1.0'
-
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_vp8
   fluster-chromeos-vp9:
     <<: *fluster-chromeos-job
     params:
@@ -748,6 +751,7 @@ jobs:
       decoders:
         - 'GStreamer-VP9-V4L2-Gst1.0'
         - 'GStreamer-VP9-V4L2SL-Gst1.0'
+    kcidb_test_suite: fluster.chromeos.v4l2.gstreamer_vp9
 
   watchdog-reset-arm64-mediatek: *watchdog-reset-job
   watchdog-reset-arm64-qualcomm: *watchdog-reset-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -376,6 +376,22 @@ _anchors:
         - collabora-chromeos-kernel
         - media
 
+  fluster-chromeos: &fluster-chromeos-job
+    template: 'fluster-chromeos.jinja2'
+    kind: job
+    params: &fluster-chromeos-params
+      test_method: fluster-chromeos
+      job_timeout: 30
+      videodec_parallel_jobs: 1
+      videodec_timeout: 90
+    rules:
+      tree:
+        - mainline
+        - next
+        - collabora-chromeos-kernel
+        - media
+    kcidb_test_suite: fluster.chromeos
+
   watchdog-reset: &watchdog-reset-job
     template: generic.jinja2
     kind: job
@@ -671,6 +687,67 @@ jobs:
         - 'GStreamer-VP9-V4L2-Gst1.0'
         - 'GStreamer-VP9-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_vp9
+
+  fluster-chromeos-av1:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'AV1-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'
+
+  fluster-chromeos-av1-chromium-10bit:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'CHROMIUM-10bit-AV1-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'
+
+  fluster-chromeos-h264:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'JVT-AVC_V1'
+      decoders:
+        - 'GStreamer-H.264-V4L2-Gst1.0'
+        - 'GStreamer-H.264-V4L2SL-Gst1.0'
+
+  fluster-chromeos-h264-frext:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'JVT-FR-EXT'
+      decoders:
+        - 'GStreamer-H.264-V4L2-Gst1.0'
+        - 'GStreamer-H.264-V4L2SL-Gst1.0'
+
+  fluster-chromeos-h265:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'JCT-VC-HEVC_V1'
+      decoders:
+        - 'GStreamer-H.265-V4L2-Gst1.0'
+        - 'GStreamer-H.265-V4L2SL-Gst1.0'
+
+  fluster-chromeos-vp8:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'VP8-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-VP8-V4L2-Gst1.0'
+        - 'GStreamer-VP8-V4L2SL-Gst1.0'
+
+  fluster-chromeos-vp9:
+    <<: *fluster-chromeos-job
+    params:
+      <<: *fluster-chromeos-params
+      testsuite: 'VP9-TEST-VECTORS'
+      decoders:
+        - 'GStreamer-VP9-V4L2-Gst1.0'
+        - 'GStreamer-VP9-V4L2SL-Gst1.0'
 
   watchdog-reset-arm64-mediatek: *watchdog-reset-job
   watchdog-reset-arm64-qualcomm: *watchdog-reset-job

--- a/config/runtime/fluster-chromeos.jinja2
+++ b/config/runtime/fluster-chromeos.jinja2
@@ -1,0 +1,21 @@
+{%- set base_kurl = platform_config.params.flash_kernel.url %}
+{%- set boot_commands = 'nfs' %}
+{%- set boot_namespace = 'modules' %}
+{%- set flash_modules = 'modules.tar.xz' %}
+{%- if platform_config.params.flash_kernel.modules %}
+{%-   set flash_modules = platform_config.params.flash_kernel.modules %}
+{%- endif %}
+
+{%- set kernel_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.image %}
+{%- set modules_url = base_kurl ~ '/' ~ flash_modules %}
+{%- if platform_config.params.flash_kernel.dtb %}
+{%-   set dtb_url = base_kurl ~ '/' ~ platform_config.params.flash_kernel.dtb %}
+{%- elif device_dtb %}
+{%-   set dtb_url = base_kurl ~ '/' ~ device_dtb %}
+{%- endif %}
+{%- set nfsroot = platform_config.params.nfsroot %}
+
+{%- set test_method = 'fluster-chromeos' %}
+
+{%- set base_template = 'base/' + runtime + '.jinja2' %}
+{%- extends base_template %}

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -520,6 +520,41 @@ scheduler:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
+  - job: fluster-chromeos-av1
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-chromeos-av1-chromium-10bit
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-chromeos-h264
+    <<: *test-job-arm64-mediatek
+
+  - job: fluster-chromeos-h264-frext
+    <<: *test-job-arm64-mediatek
+
+  - job: fluster-chromeos-h265
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-chromeos-vp8
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-chromeos-vp9
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+
   - job: v4l2-decoder-conformance-h264
     <<: *test-job-arm64-qualcomm
 


### PR DESCRIPTION
This PR combines creates a new template `v4l2-decoder-conformance-chromeos` to execute Fluster test on ChromeOS.
It re-use the ChromeOS kernel module loading structure from Tast and Fluster parser script calling from v4l2-decoder-conformance test.
This PR depends on the template defined on https://github.com/kernelci/kernelci-core/pull/2617 PR