### PR TITLE
config: scheduler-chromeos: enable codec Tast tests on corsola

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -283,20 +283,18 @@ scheduler:
 
   - job: tast-decoder-v4l2-sl-h264-arm64-mediatek
     <<: *test-job-chromeos-mediatek
-    platforms:
-      - mt8183-kukui-jacuzzi-juniper-sku16
-      - mt8192-asurada-spherion-r0
-      - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sl-vp8-arm64-mediatek
     <<: *test-job-chromeos-mediatek
     platforms:
+      - mt8186-corsola-steelix-sku131072
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
   - job: tast-decoder-v4l2-sl-vp9-arm64-mediatek
     <<: *test-job-chromeos-mediatek
     platforms:
+      - mt8186-corsola-steelix-sku131072
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 


### PR DESCRIPTION
This device's hardware decoder is able to process H.264, VP8 and VP9.