### PR TITLE
config: jobs-chromeos: set large timeout for `tast-decoder-chromestack`

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -76,6 +76,8 @@ _anchors:
         # Those always fail on all platforms
         - video.ChromeStackDecoderVerification.hevc_main
         - video.ChromeStackDecoderVerification.vp9_0_svc
+      # Those jobs can run for a very long time, so we need a very large timeout
+      job_timeout: 180
 
   tast-decoder-v4l2-sf-h264: &tast-decoder-v4l2-sf-h264-job
     <<: *tast-job


### PR DESCRIPTION
With recent CrOS versions, those jobs can run for a veeery long time (> 2hrs). Increase the job timeout to 3 hrs so we can finally get meaningful results.

Depends on https://github.com/kernelci/kernelci-core/pull/2621