### PR TITLE
workflows: Add token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
     if: failure() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: check
+    permissions:
+      contents: read
+      pull-requests: write    
     steps:
       - name: Add label to PR
         uses: actions/github-script@v7


### PR DESCRIPTION
GH token by default dont have permission to change label if PR opened from other repo. Attempts to change permissions in settings didnt helped.

Rant:Worst part of workflows, it is very difficult to simulate various situations, as there is no proper debugger.