### PR TITLE
Revert "workflows: Run pull_request_target for differnt context"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -49,7 +49,7 @@ jobs:
         run: |
           python tests/validate_yaml.py
   on-fail:
-    if: failure() && github.event_name == 'pull_request_target'
+    if: failure() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: check
     permissions:


### PR DESCRIPTION
This reverts commit a382e0e4a951c6e29eba5a383abb1457476cfc03. Running pull_request_target have too many security implications.