### PR TITLE
Revert autolabeling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,19 +48,4 @@ jobs:
       - name: Run basic yaml validation
         run: |
           python tests/validate_yaml.py
-  on-fail:
-    if: failure() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - name: Add label to PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const label = 'staging-skip';
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: [label]
-            });
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,6 @@ jobs:
     if: failure() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: check
-    permissions:
-      contents: read
-      pull-requests: write    
     steps:
       - name: Add label to PR
         uses: actions/github-script@v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,6 @@ jobs:
     needs: check
     permissions:
       contents: read
-      issues: write
       pull-requests: write    
     steps:
       - name: Add label to PR

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -49,7 +49,7 @@ jobs:
         run: |
           python tests/validate_yaml.py
   on-fail:
-    if: failure() && github.event_name == 'pull_request_target'
+    if: failure() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: check
     permissions:


### PR DESCRIPTION
Revert autolabeling.
If we run it in pull_request context - we cannot add labels, if someone create PR from their repo. (This is our normal workflow)
pull_request_target have too many security implications
Providing PAT token will need periodic maintenance due expiration and still gives a bit too wide permissions