### PR TITLE
config: pipeline: sort top-level entries alphabetically

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -6,6 +6,8 @@
 # Not directly loaded into the config, only used for YAML aliases in this file
 _anchors:
 
+### Device definition templates
+
   arm64-device: &arm64-device
     arch: arm64
     boot_method: u-boot
@@ -14,24 +16,17 @@ _anchors:
     <<: *arm64-device
     arch: arm
 
+  x86_64-device: &x86_64-device
+    arch: x86_64
+    boot_method: grub
+    mach: x86
+
+### Job definition templates
+
   baseline-job: &baseline-job
     template: baseline.jinja2
     kind: job
     kcidb_test_suite: boot
-
-  checkout-event: &checkout-event
-    channel: node
-    name: checkout
-    state: available
-
-  build-k8s-all: &build-k8s-all
-    event: *checkout-event
-    runtime:
-      name: k8s-all
-
-  node-event: &node-event
-    channel: node
-    result: pass
 
   kbuild-job: &kbuild-job
     template: kbuild.jinja2
@@ -39,14 +34,6 @@ _anchors:
     rules:
       tree:
       - '!android'
-
-  kbuild-clang-17-x86-job: &kbuild-clang-17-x86-job
-    <<: *kbuild-job
-    image: kernelci/staging-clang-17:x86-kselftest-kernelci
-    params: &kbuild-clang-17-x86-params
-      arch: x86_64
-      compiler: clang-17
-      defconfig: x86_64_defconfig
 
   kbuild-clang-17-arm64-job: &kbuild-clang-17-arm64-job
     <<: *kbuild-job
@@ -56,6 +43,14 @@ _anchors:
       compiler: clang-17
       cross_compile: 'aarch64-linux-gnu-'
       defconfig: defconfig
+
+  kbuild-clang-17-x86-job: &kbuild-clang-17-x86-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:x86-kselftest-kernelci
+    params: &kbuild-clang-17-x86-params
+      arch: x86_64
+      compiler: clang-17
+      defconfig: x86_64_defconfig
 
   kbuild-gcc-12-arm64-job: &kbuild-gcc-12-arm64-job
     <<: *kbuild-job
@@ -74,11 +69,33 @@ _anchors:
       compiler: gcc-12
       defconfig: x86_64_defconfig
 
-  x86_64-device: &x86_64-device
-    arch: x86_64
-    boot_method: grub
-    mach: x86
+  ltp-job: &ltp-job
+    template: ltp.jinja2
+    kind: job
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20240313.0/{debarch}'
+    params: &ltp-params
+      skip_install: "true"
+      skipfile: skipfile-lkft.yaml
+    kcidb_test_suite: ltp
+    rules:
+      fragments:
+        - '!kselftest'
 
+### Scheduler definition helpers
+
+  build-k8s-all: &build-k8s-all
+    event: &checkout-event
+      channel: node
+      name: checkout
+      state: available
+    runtime:
+      name: k8s-all
+
+  node-event: &node-event
+    channel: node
+    result: pass
+
+### Frequently used rules
 
   build-only-trees: &build-only-trees-rules
     rules:
@@ -113,11 +130,11 @@ storage:
     port: 8022
     base_url: http://172.17.0.1:8002/
 
-  staging:
-    storage_type: ssh
-    host: staging.kernelci.org
-    port: 9022
-    base_url: http://storage.staging.kernelci.org/api/
+  early-access-azure: &azure-files
+    storage_type: azure
+    base_url: https://kciapistagingstorage1.file.core.windows.net/
+    share: early-access
+    sas_public_token: "?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2024-10-17T19:19:12Z&st=2023-10-17T11:19:12Z&spr=https&sig=sLmFlvZHXRrZsSGubsDUIvTiv%2BtzgDq6vALfkrtWnv8%3D"
 
   k8s-host:
     storage_type: ssh
@@ -125,15 +142,15 @@ storage:
     port: 8022
     base_url: http://kernelci-api-storage:8002/
 
-  staging-azure: &azure-files
-    storage_type: azure
-    base_url: https://kciapistagingstorage1.file.core.windows.net/
-    share: staging
-    sas_public_token: "?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2024-10-17T19:19:12Z&st=2023-10-17T11:19:12Z&spr=https&sig=sLmFlvZHXRrZsSGubsDUIvTiv%2BtzgDq6vALfkrtWnv8%3D"
+  staging:
+    storage_type: ssh
+    host: staging.kernelci.org
+    port: 9022
+    base_url: http://storage.staging.kernelci.org/api/
 
-  early-access-azure:
+  staging-azure:
     <<: *azure-files
-    share: early-access
+    share: staging
 
 runtimes:
 
@@ -146,14 +163,14 @@ runtimes:
       - 'data/ssh/:/home/kernelci/data/ssh'
       - 'data/output/:/home/kernelci/data/output'
 
-  k8s-gke-eu-west4:
-    lab_type: kubernetes
-    context: 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
-
   k8s-all:
     lab_type: kubernetes
     context:
       - 'aks-kbuild-medium-1'
+
+  k8s-gke-eu-west4:
+    lab_type: kubernetes
+    context: 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
 
   lava-broonie:
     lab_type: lava
@@ -166,6 +183,25 @@ runtimes:
     rules:
       tree:
       - '!android'
+
+  lava-baylibre:
+    lab_type: lava
+    url: 'https://lava.baylibre.com/'
+    notify:
+      callback:
+        token: kernelci-new-api
+    rules:
+      tree:
+      - kernelci
+      - mainline
+      - next
+
+  lava-cip:
+    lab_type: lava
+    url: 'https://lava.ciplatform.org/'
+    notify:
+      callback:
+        token: kernel-ci-new-api
 
   lava-collabora: &lava-collabora-staging
     lab_type: lava
@@ -191,31 +227,12 @@ runtimes:
       callback:
         token: kernelci-api-token-lava-staging
 
-  lava-baylibre:
-    lab_type: lava
-    url: 'https://lava.baylibre.com/'
-    notify:
-      callback:
-        token: kernelci-new-api
-    rules:
-      tree:
-      - kernelci
-      - mainline
-      - next
-
   lava-qualcomm:
     lab_type: lava
     url: 'https://lava.infra.foundries.io'
     notify:
       callback:
         token: kernelci-lab-qualcomm
-
-  lava-cip:
-    lab_type: lava
-    url: 'https://lava.ciplatform.org/'
-    notify:
-      callback:
-        token: kernel-ci-new-api
 
   shell:
     lab_type: shell
@@ -230,42 +247,24 @@ jobs:
   #   template: 'fstests.jinja2'
   #   image: 'kernelci/staging-kernelci'
 
-  baseline-arm64: *baseline-job
-  baseline-arm64-broonie: *baseline-job
-  baseline-arm64-qualcomm: *baseline-job
-  baseline-arm64-android: *baseline-job
-  baseline-arm64-mfd: *baseline-job
-  baseline-arm-android: *baseline-job
-  baseline-arm-mfd: *baseline-job
   baseline-arm: *baseline-job
+  baseline-arm-android: *baseline-job
   baseline-arm-baylibre: *baseline-job
+  baseline-arm-mfd: *baseline-job
+  baseline-arm64: *baseline-job
+  baseline-arm64-android: *baseline-job
+  baseline-arm64-broonie: *baseline-job
+  baseline-arm64-kcidebug-mediatek: *baseline-job
+  baseline-arm64-kcidebug-qualcomm: *baseline-job
+  baseline-arm64-mfd: *baseline-job
+  baseline-arm64-qualcomm: *baseline-job
   baseline-x86: *baseline-job
   baseline-x86-baylibre: *baseline-job
-  baseline-x86-qualcomm: *baseline-job
   baseline-x86-cip: *baseline-job
   baseline-x86-kcidebug-amd: *baseline-job
   baseline-x86-kcidebug-intel: *baseline-job
-  baseline-arm64-kcidebug-mediatek: *baseline-job
-  baseline-arm64-kcidebug-qualcomm: *baseline-job
   baseline-x86-mfd: *baseline-job
-
-  kbuild-gcc-12-arc-haps_hs_smp_defconfig: &kbuild-gcc-12-arc-job
-    <<: *kbuild-job
-    image: kernelci/staging-gcc-12:arc-kselftest-kernelci
-    params:
-      arch: arc
-      compiler: gcc-12
-      cross_compile: 'arc-elf32-'
-      defconfig: haps_hs_smp_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-
-  # Default config and build only job
-  kbuild-gcc-12-arc-build-only:
-    <<: *kbuild-gcc-12-arc-job
-    rules: *build-only-trees-rules
+  baseline-x86-qualcomm: *baseline-job
 
   kbuild-clang-17-arm: &kbuild-clang-17-arm-job
     <<: *kbuild-job
@@ -276,14 +275,43 @@ jobs:
       cross_compile: 'arm-linux-gnueabihf-'
       defconfig: multi_v7_defconfig
 
-  kbuild-gcc-12-arm: &kbuild-gcc-12-arm-job
-    <<: *kbuild-job
-    image: kernelci/staging-gcc-12:arm-kselftest-kernelci
-    params: &kbuild-gcc-12-arm-params
-      arch: arm
-      compiler: gcc-12
-      cross_compile: 'arm-linux-gnueabihf-'
-      defconfig: multi_v7_defconfig
+  kbuild-clang-17-arm-android: &kbuild-clang-17-arm-android-job
+    <<: *kbuild-clang-17-arm-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-arm-android-allmodconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig:
+        - imx_v6_v7_defconfig
+        - 'allmodconfig'
+
+  kbuild-clang-17-arm-android-imx_v6_v7_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: imx_v6_v7_defconfig
+
+  kbuild-clang-17-arm-android-multi_v5_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: multi_v5_defconfig
+
+  kbuild-clang-17-arm-android-omap2plus_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: omap2plus_defconfig
+
+  kbuild-clang-17-arm-android-vexpress_defconfig:
+    <<: *kbuild-clang-17-arm-android-job
+    params:
+      <<: *kbuild-clang-17-arm-params
+      defconfig: vexpress_defconfig
 
   kbuild-clang-17-arm64-android: &kbuild-clang-17-arm64-android-job
     <<: *kbuild-clang-17-arm64-job
@@ -321,7 +349,72 @@ jobs:
       fragments:
        - CONFIG_RANDOMIZE_BASE=y
 
-  kbuild-gcc-12-arm64: *kbuild-gcc-12-arm64-job
+  kbuild-clang-17-i386: &kbuild-clang-17-i386-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:x86-kselftest-kernelci
+    params: &kbuild-clang-17-i386-params
+      arch: i386
+      compiler: clang-17
+      defconfig: i386_defconfig
+
+  kbuild-clang-17-i386-android-allnoconfig:
+    <<: *kbuild-clang-17-i386-job
+    params:
+      <<: *kbuild-clang-17-i386-params
+      defconfig:
+        - i386_defconfig
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-riscv: &kbuild-clang-17-riscv-job
+    <<: *kbuild-job
+    image: kernelci/staging-clang-17:riscv64-kselftest-kernelci
+    params: &kbuild-clang-17-riscv-params
+      arch: riscv
+      compiler: clang-17
+      cross_compile: 'riscv64-linux-gnu-'
+      defconfig: defconfig
+
+  kbuild-clang-17-riscv-android-defconfig:
+    <<: *kbuild-clang-17-riscv-job
+    params:
+      <<: *kbuild-clang-17-riscv-params
+      defconfig:
+        - defconfig
+        - allnoconfig
+    rules: &kbuild-riscv-android-rules
+      min_version:
+        version: 4
+        patchlevel: 19
+      tree:
+      - 'android'
+
+  kbuild-clang-17-x86:
+    <<: *kbuild-clang-17-x86-job
+
+  kbuild-clang-17-x86-android-allmodconfig:
+    <<: *kbuild-clang-17-x86-job
+    params:
+      <<: *kbuild-clang-17-x86-params
+      defconfig:
+        - x86_64_defconfig
+        - allmodconfig
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-clang-17-x86-android-allnoconfig:
+    <<: *kbuild-clang-17-x86-job
+    params:
+      <<: *kbuild-clang-17-x86-params
+      defconfig:
+        - x86_64_defconfig
+        - allnoconfig
+    rules:
+      tree:
+      - 'android'
 
   kbuild-gcc-12-arm64-allnoconfig:
     <<: *kbuild-gcc-12-arm64-job
@@ -334,50 +427,144 @@ jobs:
       - 'arm64'
 
   # Default config and build only job
-  kbuild-gcc-12-arm64-build-only:
-    <<: *kbuild-gcc-12-arm64-job
+  kbuild-gcc-12-arc-build-only: &kbuild-gcc-12-arc-job
+    <<: *kbuild-job
+    image: kernelci/staging-gcc-12:arc-kselftest-kernelci
+    params:
+      arch: arc
+      compiler: gcc-12
+      cross_compile: 'arc-elf32-'
+      defconfig: haps_hs_smp_defconfig
     rules: *build-only-trees-rules
 
-  kbuild-gcc-12-arm64-chromebook-kcidebug:
-    <<: *kbuild-gcc-12-arm64-job
-    params:
-      <<: *kbuild-gcc-12-arm64-params
-      cross_compile_compat: 'arm-linux-gnueabihf-'
-      fragments:
-        - lab-setup
-        - arm64-chromebook
-        - kcidebug
+  kbuild-gcc-12-arc-haps_hs_smp_defconfig:
+    <<: *kbuild-gcc-12-arc-job
+    rules:
+      tree:
+      - 'kernelci'
+      - 'stable-rc'
 
-  kbuild-gcc-12-arm64-dtbscheck:
-    <<: *kbuild-gcc-12-arm64-job
-    kind: job
-    params:
-      <<: *kbuild-gcc-12-arm64-params
-      dtbs_check: true
-    kcidb_test_suite: dtbs_check
+  kbuild-gcc-12-arm: &kbuild-gcc-12-arm-job
+    <<: *kbuild-job
+    image: kernelci/staging-gcc-12:arm-kselftest-kernelci
+    params: &kbuild-gcc-12-arm-params
+      arch: arm
+      compiler: gcc-12
+      cross_compile: 'arm-linux-gnueabihf-'
+      defconfig: multi_v7_defconfig
 
-  kbuild-gcc-12-arm64-preempt_rt:
-    <<: *kbuild-gcc-12-arm64-job
+  kbuild-gcc-12-arm-android: &kbuild-gcc-12-arm-android-job
+    <<: *kbuild-gcc-12-arm-job
+    rules:
+      tree:
+      - 'android'
+
+  kbuild-gcc-12-arm-android-allmodconfig:
+    <<: *kbuild-gcc-12-arm-android-job
     params:
-      <<: *kbuild-gcc-12-arm64-params
+      <<: *kbuild-gcc-12-arm-params
+      defconfig:
+        - imx_v6_v7_defconfig
+        - allmodconfig
+
+  kbuild-gcc-12-arm-android-imx_v6_v7_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: imx_v6_v7_defconfig
+
+  kbuild-gcc-12-arm-android-multi_v5_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: multi_v5_defconfig
+
+  kbuild-gcc-12-arm-android-omap2plus_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: omap2plus_defconfig
+
+  kbuild-gcc-12-arm-android-vexpress_defconfig:
+    <<: *kbuild-gcc-12-arm-android-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: vexpress_defconfig
+
+  # Default config and build only job
+  kbuild-gcc-12-arm-build-only:
+    <<: *kbuild-gcc-12-arm-job
+    rules: *build-only-trees-rules
+
+  kbuild-gcc-12-arm-imx_v6_v7_defconfig:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: imx_v6_v7_defconfig
+    rules:
+      tree:
+      - 'kernelci'
+      - 'stable-rc'
+
+  kbuild-gcc-12-arm-mfd:
+    <<: *kbuild-gcc-12-arm-job
+    rules:
+      tree:
+      - 'lee-mfd'
+
+  kbuild-gcc-12-arm-multi_v5_defconfig:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: multi_v5_defconfig
+    rules:
+      tree:
+      - 'kernelci'
+      - 'stable-rc'
+
+  kbuild-gcc-12-arm-multi_v7_defconfig:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: multi_v7_defconfig
+    rules:
+      tree:
+      - 'chrome-platform'
+      - 'kernelci'
+      - 'stable-rc'
+
+  kbuild-gcc-12-arm-omap2plus_defconfig:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: omap2plus_defconfig
+    rules:
+      tree:
+      - 'kernelci'
+      - 'stable-rc'
+
+  kbuild-gcc-12-arm-preempt_rt:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
       fragments:
        - 'preempt_rt'
-      defconfig: defconfig
+      defconfig: multi_v7_defconfig
     rules:
       tree:
       - 'stable-rt'
 
-  kbuild-gcc-12-arm64-preempt_rt_chromebook:
-    <<: *kbuild-gcc-12-arm64-job
+  kbuild-gcc-12-arm-vexpress_defconfig:
+    <<: *kbuild-gcc-12-arm-job
     params:
-      <<: *kbuild-gcc-12-arm64-params
-      fragments:
-       - 'preempt_rt'
-       - 'arm64-chromebook'
-      defconfig: defconfig
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: vexpress_defconfig
     rules:
       tree:
-      - 'stable-rt'
+      - 'kernelci'
+      - 'stable-rc'
+
+  kbuild-gcc-12-arm64: *kbuild-gcc-12-arm64-job
 
   kbuild-gcc-12-arm64-android: &kbuild-gcc-12-arm64-android-job
     <<: *kbuild-gcc-12-arm64-job
@@ -415,7 +602,12 @@ jobs:
       fragments:
        - CONFIG_RANDOMIZE_BASE=y
 
-  kbuild-gcc-12-arm64-chrome:
+  # Default config and build only job
+  kbuild-gcc-12-arm64-build-only:
+    <<: *kbuild-gcc-12-arm64-job
+    rules: *build-only-trees-rules
+
+  kbuild-gcc-12-arm64-chrome-platform:
     <<: *kbuild-gcc-12-arm64-job
     params:
       <<: *kbuild-gcc-12-arm64-params
@@ -425,190 +617,52 @@ jobs:
       tree:
       - 'chrome-platform'
 
+  kbuild-gcc-12-arm64-chromebook-kcidebug:
+    <<: *kbuild-gcc-12-arm64-job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      cross_compile_compat: 'arm-linux-gnueabihf-'
+      fragments:
+        - arm64-chromebook
+        - kcidebug
+        - lab-setup
+
+  kbuild-gcc-12-arm64-dtbscheck:
+    <<: *kbuild-gcc-12-arm64-job
+    kind: job
+    params:
+      <<: *kbuild-gcc-12-arm64-params
+      dtbs_check: true
+    kcidb_test_suite: dtbs_check
+
   kbuild-gcc-12-arm64-mfd:
     <<: *kbuild-gcc-12-arm64-job
     rules:
       tree:
       - 'lee-mfd'
 
-  kbuild-clang-17-arm-android: &kbuild-clang-17-arm-android-job
-    <<: *kbuild-clang-17-arm-job
-    rules:
-      tree:
-      - 'android'
-
-  kbuild-clang-17-arm-android-allmodconfig:
-    <<: *kbuild-clang-17-arm-android-job
+  kbuild-gcc-12-arm64-preempt_rt:
+    <<: *kbuild-gcc-12-arm64-job
     params:
-      <<: *kbuild-clang-17-arm-params
-      defconfig:
-        - imx_v6_v7_defconfig
-        - 'allmodconfig'
-
-  kbuild-clang-17-arm-android-multi_v5_defconfig:
-    <<: *kbuild-clang-17-arm-android-job
-    params:
-      <<: *kbuild-clang-17-arm-params
-      defconfig: multi_v5_defconfig
-
-  kbuild-clang-17-arm-android-imx_v6_v7_defconfig:
-    <<: *kbuild-clang-17-arm-android-job
-    params:
-      <<: *kbuild-clang-17-arm-params
-      defconfig: imx_v6_v7_defconfig
-
-  kbuild-clang-17-arm-android-omap2plus_defconfig:
-    <<: *kbuild-clang-17-arm-android-job
-    params:
-      <<: *kbuild-clang-17-arm-params
-      defconfig: omap2plus_defconfig
-
-  kbuild-clang-17-arm-android-vexpress_defconfig:
-    <<: *kbuild-clang-17-arm-android-job
-    params:
-      <<: *kbuild-clang-17-arm-params
-      defconfig: vexpress_defconfig
-
-  # Default config and build only job
-  kbuild-gcc-12-arm-build-only:
-    <<: *kbuild-gcc-12-arm-job
-    rules: *build-only-trees-rules
-
-  kbuild-gcc-12-arm-imx_v6_v7_defconfig:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: imx_v6_v7_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-
-  kbuild-gcc-12-arm-multi_v5_defconfig:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: multi_v5_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-
-  kbuild-gcc-12-arm-multi_v7_defconfig:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: multi_v7_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-      - 'chrome-platform'
-
-  kbuild-gcc-12-arm-mfd:
-    <<: *kbuild-gcc-12-arm-job
-    rules:
-      tree:
-      - 'lee-mfd'
-
-  kbuild-gcc-12-arm-preempt_rt:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
+      <<: *kbuild-gcc-12-arm64-params
       fragments:
        - 'preempt_rt'
-      defconfig: multi_v7_defconfig
+      defconfig: defconfig
     rules:
       tree:
       - 'stable-rt'
 
-  kbuild-gcc-12-arm-vexpress_defconfig:
-    <<: *kbuild-gcc-12-arm-job
+  kbuild-gcc-12-arm64-preempt_rt_chromebook:
+    <<: *kbuild-gcc-12-arm64-job
     params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: vexpress_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-
-  kbuild-gcc-12-arm-android: &kbuild-gcc-12-arm-android-job
-    <<: *kbuild-gcc-12-arm-job
-    rules:
-      tree:
-      - 'android'
-
-  kbuild-gcc-12-arm-android-allmodconfig:
-    <<: *kbuild-gcc-12-arm-android-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig:
-        - imx_v6_v7_defconfig
-        - allmodconfig
-
-  kbuild-gcc-12-arm-android-multi_v5_defconfig:
-    <<: *kbuild-gcc-12-arm-android-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: multi_v5_defconfig
-
-  kbuild-gcc-12-arm-android-imx_v6_v7_defconfig:
-    <<: *kbuild-gcc-12-arm-android-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: imx_v6_v7_defconfig
-
-  kbuild-gcc-12-arm-android-omap2plus_defconfig:
-    <<: *kbuild-gcc-12-arm-android-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: omap2plus_defconfig
-
-  kbuild-gcc-12-arm-android-vexpress_defconfig:
-    <<: *kbuild-gcc-12-arm-android-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: vexpress_defconfig
-
-  kbuild-gcc-12-arm-omap2plus_defconfig:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: omap2plus_defconfig
-    rules:
-      tree:
-      - 'stable-rc'
-      - 'kernelci'
-
-  kbuild-gcc-12-um:
-    <<: *kbuild-job
-    image: kernelci/staging-gcc-12:x86-kselftest-kernelci
-    params:
-      arch: um
-      compiler: gcc-12
+      <<: *kbuild-gcc-12-arm64-params
+      fragments:
+       - 'arm64-chromebook'
+       - 'preempt_rt'
       defconfig: defconfig
     rules:
       tree:
-      - 'android'
-
-  kbuild-clang-17-i386: &kbuild-clang-17-i386-job
-    <<: *kbuild-job
-    image: kernelci/staging-clang-17:x86-kselftest-kernelci
-    params: &kbuild-clang-17-i386-params
-      arch: i386
-      compiler: clang-17
-      defconfig: i386_defconfig
-
-  kbuild-clang-17-i386-android-allnoconfig:
-    <<: *kbuild-clang-17-i386-job
-    params:
-      <<: *kbuild-clang-17-i386-params
-      defconfig:
-        - i386_defconfig
-        - allnoconfig
-    rules:
-      tree:
-      - 'android'
+      - 'stable-rt'
 
   kbuild-gcc-12-i386: &kbuild-gcc-12-i386-job
     <<: *kbuild-job
@@ -626,19 +680,8 @@ jobs:
       disable_modules: true
     rules:
       tree:
-      - 'stable-rc'
       - 'kernelci'
-
-  kbuild-gcc-12-i386-tinyconfig:
-    <<: *kbuild-gcc-12-i386-job
-    params:
-      <<: *kbuild-gcc-12-i386-params
-      defconfig: tinyconfig
-      disable_modules: true
-    rules:
-      tree:
       - 'stable-rc'
-      - 'kernelci'
 
   kbuild-gcc-12-i386-android-allnoconfig:
     <<: *kbuild-gcc-12-i386-job
@@ -662,6 +705,17 @@ jobs:
       tree:
       - 'lee-mfd'
 
+  kbuild-gcc-12-i386-tinyconfig:
+    <<: *kbuild-gcc-12-i386-job
+    params:
+      <<: *kbuild-gcc-12-i386-params
+      defconfig: tinyconfig
+      disable_modules: true
+    rules:
+      tree:
+      - 'kernelci'
+      - 'stable-rc'
+
   kbuild-gcc-12-mips-32r2el_defconfig: &kbuild-gcc-12-mips-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:mips-kselftest-kernelci
@@ -672,36 +726,13 @@ jobs:
       defconfig: 32r2el_defconfig
     rules:
       tree:
-      - 'stable-rc'
       - 'kernelci'
+      - 'stable-rc'
 
   # Default config and build only job
   kbuild-gcc-12-mips-build-only:
     <<: *kbuild-gcc-12-mips-job
     rules: *build-only-trees-rules
-
-  kbuild-clang-17-riscv: &kbuild-clang-17-riscv-job
-    <<: *kbuild-job
-    image: kernelci/staging-clang-17:riscv64-kselftest-kernelci
-    params: &kbuild-clang-17-riscv-params
-      arch: riscv
-      compiler: clang-17
-      cross_compile: 'riscv64-linux-gnu-'
-      defconfig: defconfig
-
-  kbuild-clang-17-riscv-android-defconfig:
-    <<: *kbuild-clang-17-riscv-job
-    params:
-      <<: *kbuild-clang-17-riscv-params
-      defconfig:
-        - defconfig
-        - allnoconfig
-    rules: &kbuild-riscv-android-rules
-      min_version:
-        version: 4
-        patchlevel: 19
-      tree:
-      - 'android'
 
   kbuild-gcc-12-riscv: &kbuild-gcc-12-riscv-job
     <<: *kbuild-job
@@ -722,10 +753,16 @@ jobs:
     rules:
       <<: *kbuild-riscv-android-rules
 
-  # Default config and build only
+  # Default config and build only job
   kbuild-gcc-12-riscv-build-only:
     <<: *kbuild-gcc-12-riscv-job
     rules: *build-only-trees-rules
+
+  kbuild-gcc-12-riscv-mfd:
+    <<: *kbuild-gcc-12-riscv-job
+    rules:
+      tree:
+      - 'lee-mfd'
 
   kbuild-gcc-12-riscv-nommu_k210_defconfig:
     <<: *kbuild-gcc-12-riscv-job
@@ -735,36 +772,16 @@ jobs:
       disable_modules: true
     rules:
       tree:
-      - 'stable-rc'
       - 'kernelci'
+      - 'stable-rc'
 
-  kbuild-gcc-12-riscv-mfd:
-    <<: *kbuild-gcc-12-riscv-job
-    rules:
-      tree:
-      - 'lee-mfd'
-
-  kbuild-clang-17-x86:
-    <<: *kbuild-clang-17-x86-job
-
-  kbuild-clang-17-x86-android-allmodconfig:
-    <<: *kbuild-clang-17-x86-job
+  kbuild-gcc-12-um:
+    <<: *kbuild-job
+    image: kernelci/staging-gcc-12:x86-kselftest-kernelci
     params:
-      <<: *kbuild-clang-17-x86-params
-      defconfig:
-        - x86_64_defconfig
-        - allmodconfig
-    rules:
-      tree:
-      - 'android'
-
-  kbuild-clang-17-x86-android-allnoconfig:
-    <<: *kbuild-clang-17-x86-job
-    params:
-      <<: *kbuild-clang-17-x86-params
-      defconfig:
-        - x86_64_defconfig
-        - allnoconfig
+      arch: um
+      compiler: gcc-12
+      defconfig: defconfig
     rules:
       tree:
       - 'android'
@@ -785,31 +802,8 @@ jobs:
       disable_modules: true
     rules:
       tree:
-      - 'stable-rc'
       - 'kernelci'
-
-  kbuild-gcc-12-x86-kcidebug:
-    <<: *kbuild-gcc-12-i386-job
-    params:
-      <<: *kbuild-gcc-12-i386-params
-      defconfig: defconfig
-      fragments:
-        - x86-board
-        - kcidebug
-    rules:
-      tree:
-      - '!android'
-
-  kbuild-gcc-12-x86-tinyconfig:
-    <<: *kbuild-gcc-12-x86-job
-    params:
-      <<: *kbuild-gcc-12-x86-params
-      defconfig: tinyconfig
-      disable_modules: true
-    rules:
-      tree:
       - 'stable-rc'
-      - 'kernelci'
 
   kbuild-gcc-12-x86-android-allmodconfig:
     <<: *kbuild-gcc-12-x86-job
@@ -833,10 +827,28 @@ jobs:
       tree:
       - 'android'
 
-  # Default config and build only
+  # Default config and build only job
   kbuild-gcc-12-x86-build-only:
     <<: *kbuild-gcc-12-x86-job
     rules: *build-only-trees-rules
+
+  kbuild-gcc-12-x86-kcidebug:
+    <<: *kbuild-gcc-12-i386-job
+    params:
+      <<: *kbuild-gcc-12-i386-params
+      defconfig: defconfig
+      fragments:
+        - kcidebug
+        - x86-board
+    rules:
+      tree:
+      - '!android'
+
+  kbuild-gcc-12-x86-mfd:
+    <<: *kbuild-gcc-12-x86-job
+    rules:
+      tree:
+      - 'lee-mfd'
 
   kbuild-gcc-12-x86-preempt_rt:
     <<: *kbuild-gcc-12-x86-job
@@ -861,28 +873,16 @@ jobs:
       tree:
       - 'stable-rt'
 
-  kbuild-gcc-12-x86-mfd:
+  kbuild-gcc-12-x86-tinyconfig:
     <<: *kbuild-gcc-12-x86-job
+    params:
+      <<: *kbuild-gcc-12-x86-params
+      defconfig: tinyconfig
+      disable_modules: true
     rules:
       tree:
-      - 'lee-mfd'
-
-  kunit: &kunit-job
-    template: kunit.jinja2
-    kind: job
-    image: kernelci/staging-gcc-12:x86-kunit-kernelci
-    kcidb_test_suite: kunit
-
-  kunit-x86_64:
-    <<: *kunit-job
-    params:
-      arch: x86_64
-
-  kver:
-    template: kver.jinja2
-    kind: test
-    image: kernelci/staging-kernelci
-    kcidb_test_suite: kernelci_kver
+      - 'kernelci'
+      - 'stable-rc'
 
   kselftest-cpufreq: &kselftest-job
     template: kselftest.jinja2
@@ -925,17 +925,22 @@ jobs:
       collections: iommu
     kcidb_test_suite: kselftest.iommu
 
-  ltp: &ltp-job
-    template: ltp.jinja2
+  kunit: &kunit-job
+    template: kunit.jinja2
     kind: job
-    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20240313.0/{debarch}'
-    params: &ltp-params
-      skip_install: "true"
-      skipfile: skipfile-lkft.yaml
-    kcidb_test_suite: ltp
-    rules:
-      fragments:
-        - '!kselftest'
+    image: kernelci/staging-gcc-12:x86-kunit-kernelci
+    kcidb_test_suite: kunit
+
+  kunit-x86_64:
+    <<: *kunit-job
+    params:
+      arch: x86_64
+
+  kver:
+    template: kver.jinja2
+    kind: test
+    image: kernelci/staging-kernelci
+    kcidb_test_suite: kernelci_kver
 
   ltp-cap-bounds:
     <<: *ltp-job
@@ -1169,6 +1174,9 @@ trees:
   amlogic:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git"
 
+  android:
+    url: 'https://android.googlesource.com/kernel/common'
+
   ardb:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git"
 
@@ -1199,14 +1207,35 @@ trees:
   clk:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git"
 
+  collabora-next:
+    url: 'https://gitlab.collabora.com/kernel/collabora-next.git'
+
+  collabora-chromeos-kernel:
+    url: 'https://gitlab.collabora.com/google/chromeos-kernel.git'
+
   efi:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git"
 
   kernelci:
     url: "https://github.com/kernelci/linux.git"
 
+  lee-mfd:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
+
   mainline:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+
+  media:
+    url: 'https://git.linuxtv.org/media_stage.git'
+
+  mediatek:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
+
+  next:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
+
+  peterz:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/peterz/queue.git"
 
   stable-rc:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git'
@@ -1214,47 +1243,8 @@ trees:
   stable-rt:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git'
 
-  lee-mfd:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
-
-  next:
-    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git'
-
-  mediatek:
-    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
-
-  peterz:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/peterz/queue.git"
-
-  android:
-    url: 'https://android.googlesource.com/kernel/common'
-
-  collabora-next:
-    url: 'https://gitlab.collabora.com/kernel/collabora-next.git'
-
-  collabora-chromeos-kernel:
-    url: 'https://gitlab.collabora.com/google/chromeos-kernel.git'
-
-  media:
-    url: 'https://git.linuxtv.org/media_stage.git'
-
 platforms:
 
-  docker:
-
-  qemu-x86: &qemu-device
-    base_name: qemu
-    arch: x86_64
-    boot_method: qemu
-    mach: qemu
-    context:
-      arch: x86_64
-      cpu: qemu64
-      guestfs_interface: ide
-
-  qemu: *qemu-device
-
-  minnowboard-turbot-E3826: *x86_64-device
   aaeon-UPN-EHLX4RE-A10-0864: *x86_64-device
 
   bcm2711-rpi-4-b:
@@ -1267,25 +1257,21 @@ platforms:
     mach: broadcom
     dtb: dtbs/bcm2836-rpi-2-b.dtb
 
+  docker:
+
   imx6q-sabrelite:
     <<: *arm-device
     mach: imx
     dtb: dtbs/imx6q-sabrelite.dtb
 
-  sun50i-h5-libretech-all-h3-cc:
-    <<: *arm64-device
-    mach: allwinner
-    dtb: dtbs/allwinner/sun50i-h5-libretech-all-h3-cc.dtb
-
-  sun7i-a20-cubieboard2:
-    <<: *arm-device
-    mach: allwinner
-    dtb: dtbs/sun7i-a20-cubieboard2.dtb
+  kubernetes:
 
   meson-g12b-a311d-khadas-vim3:
     <<: *arm64-device
     mach: amlogic
     dtb: dtbs/amlogic/meson-g12b-a311d-khadas-vim3.dtb
+
+  minnowboard-turbot-E3826: *x86_64-device
 
   odroid-xu3:
     <<: *arm-device
@@ -1297,6 +1283,18 @@ platforms:
     boot_method: fastboot
     mach: qcom
     dtb: dtbs/qcom/qcs6490-rb3gen2.dtb
+
+  qemu: &qemu-device
+    base_name: qemu
+    arch: x86_64
+    boot_method: qemu
+    mach: qemu
+    context:
+      arch: x86_64
+      cpu: qemu64
+      guestfs_interface: ide
+
+  qemu-x86: *qemu-device
 
   rk3288-rock2-square:
     <<: *arm-device
@@ -1325,70 +1323,33 @@ platforms:
     mach: rockchip
     dtb: dtbs/rockchip/rk3588-rock-5b.dtb
 
+  shell:
+
+  sun7i-a20-cubieboard2:
+    <<: *arm-device
+    mach: allwinner
+    dtb: dtbs/sun7i-a20-cubieboard2.dtb
+
+  sun50i-h5-libretech-all-h3-cc:
+    <<: *arm64-device
+    mach: allwinner
+    dtb: dtbs/allwinner/sun50i-h5-libretech-all-h3-cc.dtb
+
   sun50i-h6-pine-h64:
     <<: *arm64-device
     mach: allwinner
     dtb: dtbs/allwinner/sun50i-h6-pine-h64.dtb
 
-  kubernetes:
-
-  shell:
-
 
 scheduler:
 
-  - job: baseline-arm64
-    event: &kbuild-gcc-12-arm64-node-event
+  - job: baseline-arm
+    event: &kbuild-gcc-12-arm-node-event
       <<: *node-event
-      name: kbuild-gcc-12-arm64
+      name: kbuild-gcc-12-arm
     runtime: &lava-collabora-runtime
       type: lava
       name: lava-collabora
-    platforms: &collabora-arm64-platforms
-      - bcm2711-rpi-4-b
-      - meson-g12b-a311d-khadas-vim3
-      - rk3399-gru-kevin
-      - rk3399-rock-pi-4b
-      - rk3588-rock-5b
-      - sun50i-h6-pine-h64
-
-  - job: baseline-arm64-broonie
-    event: *kbuild-gcc-12-arm64-node-event
-    runtime:
-      type: lava
-      name: lava-broonie
-    platforms:
-      - sun50i-h5-libretech-all-h3-cc
-
-  - job: baseline-arm64-qualcomm
-    event: *kbuild-gcc-12-arm64-node-event
-    runtime:
-      type: lava
-      name: lava-qualcomm
-    platforms:
-      - bcm2711-rpi-4-b
-      - qcs6490-rb3gen2
-
-  - job: baseline-arm64-android
-    event:
-      <<: *node-event
-      name: kbuild-gcc-12-arm64-android
-    runtime: *lava-collabora-runtime
-    platforms: *collabora-arm64-platforms
-
-  - job: baseline-arm64-mfd
-    event:
-      <<: *node-event
-      name: kbuild-gcc-12-arm64-mfd
-    runtime: *lava-collabora-runtime
-    platforms:
-      - bcm2711-rpi-4-b
-
-  - job: baseline-arm-android
-    event:
-      <<: *node-event
-      name: kbuild-gcc-12-arm-android
-    runtime: *lava-collabora-runtime
     platforms: &collabora-arm-platforms
       - bcm2836-rpi-2-b
       - imx6q-sabrelite
@@ -1396,18 +1357,10 @@ scheduler:
       - rk3288-rock2-square
       - rk3288-veyron-jaq
 
-  - job: baseline-arm-mfd
+  - job: baseline-arm-android
     event:
       <<: *node-event
-      name: kbuild-gcc-12-arm-mfd
-    runtime: *lava-collabora-runtime
-    platforms:
-      - bcm2836-rpi-2-b
-
-  - job: baseline-arm
-    event: &kbuild-gcc-12-arm-node-event
-      <<: *node-event
-      name: kbuild-gcc-12-arm
+      name: kbuild-gcc-12-arm-android
     runtime: *lava-collabora-runtime
     platforms: *collabora-arm-platforms
 
@@ -1418,6 +1371,77 @@ scheduler:
       name: lava-baylibre
     platforms:
       - sun7i-a20-cubieboard2
+
+  - job: baseline-arm-mfd
+    event:
+      <<: *node-event
+      name: kbuild-gcc-12-arm-mfd
+    runtime: *lava-collabora-runtime
+    platforms:
+      - bcm2836-rpi-2-b
+
+  - job: baseline-arm64
+    event: &kbuild-gcc-12-arm64-node-event
+      <<: *node-event
+      name: kbuild-gcc-12-arm64
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-arm64-platforms
+      - bcm2711-rpi-4-b
+      - meson-g12b-a311d-khadas-vim3
+      - rk3399-gru-kevin
+      - rk3399-rock-pi-4b
+      - rk3588-rock-5b
+      - sun50i-h6-pine-h64
+
+  - job: baseline-arm64-android
+    event:
+      <<: *node-event
+      name: kbuild-gcc-12-arm64-android
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
+
+  - job: baseline-arm64-broonie
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-broonie
+    platforms:
+      - sun50i-h5-libretech-all-h3-cc
+
+  - job: baseline-arm64-kcidebug-mediatek
+    event: &kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
+      <<: *node-event
+      name: kbuild-gcc-12-arm64-chromebook-kcidebug
+    runtime: *lava-collabora-runtime
+    platforms:
+      - mt8183-kukui-jacuzzi-juniper-sku16
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+
+  - job: baseline-arm64-kcidebug-qualcomm
+    event: *kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - sc7180-trogdor-kingoftown
+      - sc7180-trogdor-lazor-limozeen
+
+  - job: baseline-arm64-mfd
+    event:
+      <<: *node-event
+      name: kbuild-gcc-12-arm64-mfd
+    runtime: *lava-collabora-runtime
+    platforms:
+      - bcm2711-rpi-4-b
+
+  - job: baseline-arm64-qualcomm
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-qualcomm
+    platforms:
+      - bcm2711-rpi-4-b
+      - qcs6490-rb3gen2
 
   - job: baseline-x86
     event: &kbuild-gcc-12-x86-node-event
@@ -1431,6 +1455,14 @@ scheduler:
   - job: baseline-x86-baylibre
     event: *kbuild-gcc-12-x86-node-event
     runtime: *lava-baylibre-runtime
+    platforms:
+      - qemu
+
+  - job: baseline-x86-cip
+    event: *kbuild-gcc-12-x86-node-event
+    runtime:
+      type: lava
+      name: lava-cip
     platforms:
       - qemu
 
@@ -1468,32 +1500,6 @@ scheduler:
       - hp-x360-14-G1-sona
       - hp-x360-12b-ca0010nr-n4020-octopus
 
-  - job: baseline-arm64-kcidebug-mediatek
-    event: &kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
-      <<: *node-event
-      name: kbuild-gcc-12-arm64-chromebook-kcidebug
-    runtime: *lava-collabora-runtime
-    platforms:
-      - mt8183-kukui-jacuzzi-juniper-sku16
-      - mt8186-corsola-steelix-sku131072
-      - mt8192-asurada-spherion-r0
-      - mt8195-cherry-tomato-r2
-
-  - job: baseline-arm64-kcidebug-qualcomm
-    event: *kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
-    runtime: *lava-collabora-runtime
-    platforms:
-      - sc7180-trogdor-kingoftown
-      - sc7180-trogdor-lazor-limozeen
-
-  - job: baseline-x86-cip
-    event: *kbuild-gcc-12-x86-node-event
-    runtime:
-      type: lava
-      name: lava-cip
-    platforms:
-      - qemu
-
   - job: baseline-x86-mfd
     event:
       <<: *node-event
@@ -1502,13 +1508,22 @@ scheduler:
     platforms:
       - minnowboard-turbot-E3826
 
-  - job: kbuild-clang-17-x86
+  - job: kbuild-clang-17-arm-android
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-x86-android-allmodconfig
+  - job: kbuild-clang-17-arm-android-allmodconfig
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-x86-android-allnoconfig
+  - job: kbuild-clang-17-arm-android-imx_v6_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-multi_v5_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-omap2plus_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-clang-17-arm-android-vexpress_defconfig
     <<: *build-k8s-all
 
   - job: kbuild-clang-17-arm64-android
@@ -1526,68 +1541,25 @@ scheduler:
   - job: kbuild-clang-17-arm64-android-randomize
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64
+  - job: kbuild-clang-17-i386-android-allnoconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-dtbscheck
-    <<: *build-k8s-all
-    rules:
-      tree:
-        - next:master
-
-  - job: kbuild-gcc-12-arm64-preempt_rt
+  - job: kbuild-clang-17-riscv-android-defconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-preempt_rt_chromebook
+  - job: kbuild-clang-17-x86
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-android
+  - job: kbuild-clang-17-x86-android-allmodconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-android-allmodconfig
+  - job: kbuild-clang-17-x86-android-allnoconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-android-allnoconfig
+  - job: kbuild-gcc-12-arc-build-only
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm64-android-big_endian
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm64-android-randomize
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm64-chrome
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm64-mfd
-    <<: *build-k8s-all
-
-# Example of same job name to apply to different tree/branch
-#  - job: kbuild-gcc-12-arm64-dtbscheck
-#    <<: *build-k8s-all
-#    rules:
-#      tree:
-#        - kernelci:staging-next
-
-  - job: kbuild-clang-17-arm-android
-    <<: *build-k8s-all
-
-  - job: kbuild-clang-17-arm-android-allmodconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-clang-17-arm-android-multi_v5_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-clang-17-arm-android-imx_v6_v7_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-clang-17-arm-android-omap2plus_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-build-only
-    <<: *build-k8s-all
-
-  - job: kbuild-clang-17-arm-android-vexpress_defconfig
+  - job: kbuild-gcc-12-arc-haps_hs_smp_defconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm
@@ -1611,23 +1583,108 @@ scheduler:
   - job: kbuild-gcc-12-arm-android-vexpress_defconfig
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm-build-only
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-imx_v6_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-mfd
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-multi_v5_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-multi_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-omap2plus_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-preempt_rt
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-vexpress_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm64-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-allmodconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-big_endian
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-android-randomize
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm64-build-only
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm64-chrome-platform
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm64-chromebook-kcidebug
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-um
+  - job: kbuild-gcc-12-arm64-dtbscheck
+    <<: *build-k8s-all
+    rules:
+      tree:
+        - next:master
+
+# Example of same job name to apply to different tree/branch
+#  - job: kbuild-gcc-12-arm64-dtbscheck
+#    <<: *build-k8s-all
+#    rules:
+#      tree:
+#        - kernelci:staging-next
+
+  - job: kbuild-gcc-12-arm64-mfd
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-preempt_rt
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-preempt_rt_chromebook
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-i386
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-riscv-android-defconfig
+  - job: kbuild-gcc-12-i386-allnoconfig
     <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-i386-android-allnoconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-i386-build-only
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-i386-tinyconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-i386-mfd
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-mips-32r2el_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-mips-build-only
+    <<: *build-k8s-all
+    rules:
+      tree:
+        - '!efi'
 
   - job: kbuild-gcc-12-riscv
     <<: *build-k8s-all
@@ -1644,16 +1701,22 @@ scheduler:
       tree:
         - '!efi'
 
+  - job: kbuild-gcc-12-riscv-mfd
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-riscv-nommu_k210_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-um
+    <<: *build-k8s-all
+    rules:
+      tree:
+        - '!efi'
+
   - job: kbuild-gcc-12-x86
     <<: *build-k8s-all
   
   - job: kbuild-gcc-12-x86-allnoconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-x86-kcidebug
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-x86-tinyconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-android-allmodconfig
@@ -1665,77 +1728,26 @@ scheduler:
   - job: kbuild-gcc-12-x86-build-only
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-x86-kcidebug
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-x86-mfd
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86-preempt_rt
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-preempt_rt_x86_board
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-x86-mfd
+  - job: kbuild-gcc-12-x86-tinyconfig
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-i386-android-allnoconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-i386-allnoconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-i386-tinyconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-i386-android-allnoconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-i386-build-only
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-i386-mfd
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-mips-32r2el_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-mips-build-only
-    <<: *build-k8s-all
-    rules:
-      tree:
-        - '!efi'
-
-  - job: kbuild-gcc-12-riscv-nommu_k210_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-riscv-mfd
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arc-haps_hs_smp_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arc-build-only
-    <<: *build-k8s-all
-    rules:
-      tree:
-        - '!efi'
-
-  - job: kbuild-gcc-12-arm-imx_v6_v7_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-multi_v5_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-multi_v7_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-mfd
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-vexpress_defconfig
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-preempt_rt
-    <<: *build-k8s-all
-
-  - job: kbuild-gcc-12-arm-omap2plus_defconfig
-    <<: *build-k8s-all
+  - job: kselftest-dt
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - bcm2711-rpi-4-b
 
 #  - job: kunit
 #    event: *checkout-event
@@ -1751,12 +1763,6 @@ scheduler:
     event: *checkout-event
     runtime:
       type: shell
-
-  - job: kselftest-dt
-    event: *kbuild-gcc-12-arm64-node-event
-    runtime: *lava-collabora-runtime
-    platforms:
-      - bcm2711-rpi-4-b
 
   - job: ltp-crypto
     event: *kbuild-gcc-12-arm-node-event
@@ -1982,130 +1988,6 @@ build_configs:
     tree: amlogic
     branch: 'integ'
 
-  ardb:
-    tree: ardb
-    branch: 'for-kernelci'
-
-  arm64:
-    tree: arm64
-    branch: 'for-kernelci'
-
-  arnd:
-    tree: arnd
-    branch: 'to-build'
-
-  broonie-misc:
-    tree: broonie-misc
-    branch: 'for-kernelci'
-
-  broonie-regmap:
-    tree: broonie-regmap
-    branch: 'for-next'
-
-  broonie-regmap-fixes:
-    tree: broonie-regmap
-    branch: 'for-linus'
-
-  broonie-regulator:
-    tree: broonie-regulator
-    branch: 'for-next'
-
-  broonie-regulator-fixes:
-    tree: broonie-regulator
-    branch: 'for-linus'
-
-  broonie-sound:
-    tree: broonie-sound
-    branch: 'for-next'
-
-  broonie-sound-fixes:
-    tree: broonie-sound
-    branch: 'for-linus'
-
-  broonie-spi:
-    tree: broonie-spi
-    branch: 'for-next'
-
-  broonie-spi-fixes:
-    tree: broonie-spi
-    branch: 'for-linus'
-
-  chrome-platform:
-    tree: chrome-platform
-    branch: 'for-next'
-
-  chrome-platform-firmware:
-    tree: chrome-platform
-    branch: 'for-firmware-next'
-
-  clk:
-    tree: clk
-    branch: 'clk-next'
-
-  efi:
-    tree: efi
-    branch: 'next'
-
-  kernelci_staging-mainline:
-    tree: kernelci
-    branch: 'staging-mainline'
-
-  kernelci_staging-next:
-    tree: kernelci
-    branch: 'staging-next'
-
-  kernelci_staging-stable:
-    tree: kernelci
-    branch: 'staging-stable'
-
-  mainline:
-    tree: mainline
-    branch: 'master'
-
-  stable-rc_4.19: &stable-rc
-    tree: stable-rc
-    branch: 'linux-4.19.y'
-
-  stable-rc_5.4:
-    <<: *stable-rc
-    branch: 'linux-5.4.y'
-
-  stable-rc_5.10:
-    <<: *stable-rc
-    branch: 'linux-5.10.y'
-
-  stable-rc_5.15:
-    <<: *stable-rc
-    branch: 'linux-5.15.y'
-
-  stable-rc_6.1:
-    <<: *stable-rc
-    branch: 'linux-6.1.y'
-
-  stable-rc_6.6:
-    <<: *stable-rc
-    branch: 'linux-6.6.y'
-
-  stable-rc_6.7:
-    <<: *stable-rc
-    branch: 'linux-6.7.y'
-
-  stable-rc_6.9:
-    <<: *stable-rc
-    branch: 'linux-6.9.y'
-
-  stable-rc_6.10:
-    <<: *stable-rc
-    branch: 'linux-6.10.y'
-
-  next_master:
-    tree: next
-    branch: 'master'
-
-  mediatek_for_next:
-    tree: mediatek
-    branch: 'for-next'
-
   android_4.19-stable:
     tree: android
     branch: 'android-4.19-stable'
@@ -2182,29 +2064,153 @@ build_configs:
     tree: android
     branch: 'android15-6.6-lts'
 
-  collabora-next_for-kernelci:
-    tree: collabora-next
+  ardb:
+    tree: ardb
     branch: 'for-kernelci'
+
+  arm64:
+    tree: arm64
+    branch: 'for-kernelci'
+
+  arnd:
+    tree: arnd
+    branch: 'to-build'
+
+  broonie-misc:
+    tree: broonie-misc
+    branch: 'for-kernelci'
+
+  broonie-regmap:
+    tree: broonie-regmap
+    branch: 'for-next'
+
+  broonie-regmap-fixes:
+    tree: broonie-regmap
+    branch: 'for-linus'
+
+  broonie-regulator:
+    tree: broonie-regulator
+    branch: 'for-next'
+
+  broonie-regulator-fixes:
+    tree: broonie-regulator
+    branch: 'for-linus'
+
+  broonie-sound:
+    tree: broonie-sound
+    branch: 'for-next'
+
+  broonie-sound-fixes:
+    tree: broonie-sound
+    branch: 'for-linus'
+
+  broonie-spi:
+    tree: broonie-spi
+    branch: 'for-next'
+
+  broonie-spi-fixes:
+    tree: broonie-spi
+    branch: 'for-linus'
+
+  chrome-platform:
+    tree: chrome-platform
+    branch: 'for-next'
+
+  chrome-platform-firmware:
+    tree: chrome-platform
+    branch: 'for-firmware-next'
+
+  clk:
+    tree: clk
+    branch: 'clk-next'
 
   collabora-chromeos-kernel_for-kernelci:
     tree: collabora-chromeos-kernel
     branch: 'for-kernelci'
 
+  collabora-next_for-kernelci:
+    tree: collabora-next
+    branch: 'for-kernelci'
+
+  efi:
+    tree: efi
+    branch: 'next'
+
+  kernelci_staging-mainline:
+    tree: kernelci
+    branch: 'staging-mainline'
+
+  kernelci_staging-next:
+    tree: kernelci
+    branch: 'staging-next'
+
+  kernelci_staging-stable:
+    tree: kernelci
+    branch: 'staging-stable'
+
   lee_mfd:
     tree: lee-mfd
     branch: 'for-mfd-next'
 
-  media_master:
-    tree: media
+  mainline:
+    tree: mainline
     branch: 'master'
 
   media_fixes:
     tree: media
     branch: 'fixes'
 
+  media_master:
+    tree: media
+    branch: 'master'
+
+  mediatek_for_next:
+    tree: mediatek
+    branch: 'for-next'
+
+  next_master:
+    tree: next
+    branch: 'master'
+
   peterz:
     tree: peterz
     branch: 'kernelci'
+
+  stable-rc_4.19: &stable-rc
+    tree: stable-rc
+    branch: 'linux-4.19.y'
+
+  stable-rc_5.4:
+    <<: *stable-rc
+    branch: 'linux-5.4.y'
+
+  stable-rc_5.10:
+    <<: *stable-rc
+    branch: 'linux-5.10.y'
+
+  stable-rc_5.15:
+    <<: *stable-rc
+    branch: 'linux-5.15.y'
+
+  stable-rc_6.1:
+    <<: *stable-rc
+    branch: 'linux-6.1.y'
+
+  stable-rc_6.6:
+    <<: *stable-rc
+    branch: 'linux-6.6.y'
+
+  stable-rc_6.7:
+    <<: *stable-rc
+    branch: 'linux-6.7.y'
+
+  stable-rc_6.9:
+    <<: *stable-rc
+    branch: 'linux-6.9.y'
+
+  stable-rc_6.10:
+    <<: *stable-rc
+    branch: 'linux-6.10.y'
 
   stable-rt_v4.14-rt:
     tree: stable-rt

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -29,6 +29,10 @@ _anchors:
     runtime:
       name: k8s-all
 
+  node-event: &node-event
+    channel: node
+    result: pass
+
   kbuild: &kbuild-job
     template: kbuild.jinja2
     kind: kbuild
@@ -75,41 +79,6 @@ _anchors:
     boot_method: grub
     mach: x86
 
-  amd-platforms: &amd-platforms
-    - acer-R721T-grunt
-    - acer-cp514-3wh-r0qs-guybrush
-    - asus-CM1400CXA-dalboz
-    - dell-latitude-3445-7520c-skyrim
-    - hp-14-db0003na-grunt
-    - hp-11A-G6-EE-grunt
-    - hp-14b-na0052xx-zork
-    - hp-x360-14a-cb0001xx-zork
-    - lenovo-TPad-C13-Yoga-zork
-
-  intel-platforms: &intel-platforms
-    - acer-cb317-1h-c3z6-dedede
-    - acer-cbv514-1h-34uz-brya
-    - acer-chromebox-cxi4-puff
-    - acer-cp514-2h-1130g7-volteer
-    - acer-cp514-2h-1160g7-volteer
-    - asus-C433TA-AJ0005-rammus
-    - asus-C436FA-Flip-hatch
-    - asus-C523NA-A20057-coral
-    - dell-latitude-5300-8145U-arcada
-    - dell-latitude-5400-4305U-sarien
-    - dell-latitude-5400-8665U-sarien
-    - hp-x360-14-G1-sona
-    - hp-x360-12b-ca0010nr-n4020-octopus
-
-  mediatek-platforms: &mediatek-platforms
-    - mt8183-kukui-jacuzzi-juniper-sku16
-    - mt8186-corsola-steelix-sku131072
-    - mt8192-asurada-spherion-r0
-    - mt8195-cherry-tomato-r2
-
-  qualcomm-platforms: &qualcomm-platforms
-    - sc7180-trogdor-kingoftown
-    - sc7180-trogdor-lazor-limozeen
 
   build-only-trees: &build-only-trees-rules
     rules:
@@ -352,8 +321,7 @@ jobs:
       fragments:
        - CONFIG_RANDOMIZE_BASE=y
 
-  kbuild-gcc-12-arm64:
-    <<: *kbuild-gcc-12-arm64-job
+  kbuild-gcc-12-arm64: *kbuild-gcc-12-arm64-job
 
   kbuild-gcc-12-arm64-allnoconfig:
     <<: *kbuild-gcc-12-arm64-job
@@ -371,22 +339,14 @@ jobs:
     rules: *build-only-trees-rules
 
   kbuild-gcc-12-arm64-chromebook-kcidebug:
-    template: kbuild.jinja2
-    kind: kbuild
-    image: kernelci/staging-gcc-12:arm64-kselftest-kernelci
+    <<: *kbuild-gcc-12-arm64-job
     params:
-      arch: arm64
-      compiler: gcc-12
-      cross_compile: 'aarch64-linux-gnu-'
+      <<: *kbuild-gcc-12-arm64-params
       cross_compile_compat: 'arm-linux-gnueabihf-'
-      defconfig: defconfig
       fragments:
         - lab-setup
         - arm64-chromebook
         - kcidebug
-    rules:
-      tree:
-      - '!android'
 
   kbuild-gcc-12-arm64-dtbscheck:
     <<: *kbuild-gcc-12-arm64-job
@@ -924,31 +884,27 @@ jobs:
     image: kernelci/staging-kernelci
     kcidb_test_suite: kernelci_kver
 
-  kselftest-cpufreq:
+  kselftest-cpufreq: &kselftest-job
     template: kselftest.jinja2
     kind: job
-    params:
+    params: &kselftest-params
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
       collections: cpufreq
       job_timeout: 10
     kcidb_test_suite: kselftest.cpufreq
 
   kselftest-dmabuf-heaps:
-    template: kselftest.jinja2
-    kind: job
+    <<: *kselftest-job
     params:
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      <<: *kselftest-params
       collections: dmabuf-heaps
-      job_timeout: 10
     kcidb_test_suite: kselftest.dmabuf-heaps
 
   kselftest-dt:
-    template: kselftest.jinja2
-    kind: job
+    <<: *kselftest-job
     params:
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240221.0/{debarch}'
+      <<: *kselftest-params
       collections: dt
-      job_timeout: 10
     rules:
       min_version:
         version: 6
@@ -956,21 +912,17 @@ jobs:
     kcidb_test_suite: kselftest.dt
 
   kselftest-exec:
-    template: kselftest.jinja2
-    kind: job
+    <<: *kselftest-job
     params:
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      <<: *kselftest-params
       collections: exec
-      job_timeout: 10
     kcidb_test_suite: kselftest.exec
 
   kselftest-iommu:
-    template: kselftest.jinja2
-    kind: job
+    <<: *kselftest-job
     params:
-      nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/{debarch}'
+      <<: *kselftest-params
       collections: iommu
-      job_timeout: 10
     kcidb_test_suite: kselftest.iommu
 
   ltp: &ltp-job
@@ -1387,13 +1339,12 @@ scheduler:
 
   - job: baseline-arm64
     event: &kbuild-gcc-12-arm64-node-event
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm64
-      result: pass
-    runtime: &runtime-lava-collabora
+    runtime: &lava-collabora-runtime
       type: lava
       name: lava-collabora
-    platforms:
+    platforms: &collabora-arm64-platforms
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
       - rk3399-gru-kevin
@@ -1420,34 +1371,25 @@ scheduler:
 
   - job: baseline-arm64-android
     event:
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm64-android
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms:
-      - bcm2711-rpi-4-b
-      - meson-g12b-a311d-khadas-vim3
-      - rk3399-gru-kevin
-      - rk3399-rock-pi-4b
-      - rk3588-rock-5b
-      - sun50i-h6-pine-h64
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
 
   - job: baseline-arm64-mfd
     event:
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm64-mfd
-      result: pass
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
 
   - job: baseline-arm-android
     event:
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm-android
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms:
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-arm-platforms
       - bcm2836-rpi-2-b
       - imx6q-sabrelite
       - odroid-xu3
@@ -1456,92 +1398,96 @@ scheduler:
 
   - job: baseline-arm-mfd
     event:
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm-mfd
-      result: pass
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2836-rpi-2-b
 
   - job: baseline-arm
     event: &kbuild-gcc-12-arm-node-event
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms:
-      - bcm2836-rpi-2-b
-      - imx6q-sabrelite
-      - odroid-xu3
-      - rk3288-rock2-square
-      - rk3288-veyron-jaq
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm-platforms
 
   - job: baseline-arm-baylibre
     event: *kbuild-gcc-12-arm-node-event
-    runtime:
+    runtime: &lava-baylibre-runtime
       type: lava
       name: lava-baylibre
     platforms:
       - sun7i-a20-cubieboard2
 
   - job: baseline-x86
-    event:
-      channel: node
+    event: &kbuild-gcc-12-x86-node-event
+      <<: *node-event
       name: kbuild-gcc-12-x86
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms:
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-x86-platforms
       - qemu-x86
       - minnowboard-turbot-E3826
 
   - job: baseline-x86-baylibre
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86
-      result: pass
-    runtime:
-      type: lava
-      name: lava-baylibre
+    event: *kbuild-gcc-12-x86-node-event
+    runtime: *lava-baylibre-runtime
     platforms:
       - qemu
 
   - job: baseline-x86-kcidebug-amd
-    event:
-      channel: node
+    event: &kbuild-gcc-12-x86-kcidebug-node-event
+      <<: *node-event
       name: kbuild-gcc-12-x86-kcidebug
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: *amd-platforms
+    runtime: *lava-collabora-runtime
+    platforms:
+      - acer-R721T-grunt
+      - acer-cp514-3wh-r0qs-guybrush
+      - asus-CM1400CXA-dalboz
+      - dell-latitude-3445-7520c-skyrim
+      - hp-14-db0003na-grunt
+      - hp-11A-G6-EE-grunt
+      - hp-14b-na0052xx-zork
+      - hp-x360-14a-cb0001xx-zork
+      - lenovo-TPad-C13-Yoga-zork
 
   - job: baseline-x86-kcidebug-intel
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86-kcidebug
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: *intel-platforms
+    event: *kbuild-gcc-12-x86-kcidebug-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - acer-cb317-1h-c3z6-dedede
+      - acer-cbv514-1h-34uz-brya
+      - acer-chromebox-cxi4-puff
+      - acer-cp514-2h-1130g7-volteer
+      - acer-cp514-2h-1160g7-volteer
+      - asus-C433TA-AJ0005-rammus
+      - asus-C436FA-Flip-hatch
+      - asus-C523NA-A20057-coral
+      - dell-latitude-5300-8145U-arcada
+      - dell-latitude-5400-4305U-sarien
+      - dell-latitude-5400-8665U-sarien
+      - hp-x360-14-G1-sona
+      - hp-x360-12b-ca0010nr-n4020-octopus
 
   - job: baseline-arm64-kcidebug-mediatek
-    event:
-      channel: node
+    event: &kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
+      <<: *node-event
       name: kbuild-gcc-12-arm64-chromebook-kcidebug
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: *mediatek-platforms
+    runtime: *lava-collabora-runtime
+    platforms:
+      - mt8183-kukui-jacuzzi-juniper-sku16
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
 
   - job: baseline-arm64-kcidebug-qualcomm
-    event:
-      channel: node
-      name: kbuild-gcc-12-arm64-chromebook-kcidebug
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: *qualcomm-platforms
+    event: *kbuild-gcc-12-arm64-chromebook-kcidebug-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - sc7180-trogdor-kingoftown
+      - sc7180-trogdor-lazor-limozeen
 
   - job: baseline-x86-cip
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86
-      result: pass
+    event: *kbuild-gcc-12-x86-node-event
     runtime:
       type: lava
       name: lava-cip
@@ -1550,10 +1496,9 @@ scheduler:
 
   - job: baseline-x86-mfd
     event:
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-x86-mfd
-      result: pass
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - minnowboard-turbot-E3826
 
@@ -1809,82 +1754,72 @@ scheduler:
 
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
 
   - job: ltp-crypto
     event: *kbuild-gcc-12-arm-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2836-rpi-2-b
 
   - job: ltp-dio
     event: *kbuild-gcc-12-arm-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2836-rpi-2-b
 
   - job: ltp-fcntl-locktests
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - rk3399-gru-kevin
 
   - job: ltp-fsx
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
 
   - job: ltp-pty
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - rk3399-gru-kevin
   
   - job: ltp-smoketest
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
   
   - job: ltp-timers
     event: *kbuild-gcc-12-arm64-node-event
-    runtime: *runtime-lava-collabora
+    runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
       - rk3399-gru-kevin
 
   - job: ltp-timers_qemu
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86
-      result: pass
-    runtime: *runtime-lava-collabora
+    event: *kbuild-gcc-12-x86-node-event
+    runtime: *lava-collabora-runtime
     platforms:
       - qemu-x86
 
   - job: rt-tests-cyclicdeadline
     event: &kbuild-gcc-12-arm64-preempt_rt-node-event
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm64-preempt_rt
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: &arm64-preempt_rt-platforms
-      - bcm2711-rpi-4-b
-      - meson-g12b-a311d-khadas-vim3
-      - rk3399-gru-kevin
-      - rk3399-rock-pi-4b
-      - rk3588-rock-5b
-      - sun50i-h6-pine-h64
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
 
   - job: rt-tests-cyclicdeadline
     event: &kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
-      <<: *kbuild-gcc-12-arm64-preempt_rt-node-event
+      <<: *node-event
       name: kbuild-gcc-12-arm64-preempt_rt_chromebook
-    runtime: *runtime-lava-collabora
-    platforms: &arm64-preempt_rt_chromebook-platforms
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-arm64-chromebook-platforms
       - mt8183-kukui-jacuzzi-juniper-sku16
       - mt8186-corsola-steelix-sku131072
       - mt8192-asurada-spherion-r0
@@ -1894,20 +1829,17 @@ scheduler:
 
   - job: rt-tests-cyclicdeadline
     event: &kbuild-gcc-12-x86-preempt_rt-node-event
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-x86-preempt_rt
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: &x86-preempt_rt-platforms
-      - qemu-x86
-      - minnowboard-turbot-E3826
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-platforms
 
   - job: rt-tests-cyclicdeadline
-    event: &kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
-      <<: *kbuild-gcc-12-x86-preempt_rt-node-event
-      name: kbuild-gcc-12-x86-preempt_rt_chromebook
-    runtime: *runtime-lava-collabora
-    platforms: &x86-preempt_rt_chromebook-platforms
+    event: &kbuild-gcc-12-x86-preempt_rt_x86_board-node-event
+      <<: *node-event
+      name: kbuild-gcc-12-x86-preempt_rt_x86_board
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-x86-rt-chromebook-platforms
       - acer-cb317-1h-c3z6-dedede
       - acer-cbv514-1h-34uz-brya
       - acer-R721T-grunt
@@ -1919,95 +1851,91 @@ scheduler:
 
   - job: rt-tests-cyclicdeadline
     event: &kbuild-gcc-12-arm-preempt_rt-node-event
-      channel: node
+      <<: *node-event
       name: kbuild-gcc-12-arm-preempt_rt
-      result: pass
-    runtime: *runtime-lava-collabora
-    platforms: &arm-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: &collabora-arm-preempt_rt-platforms
       - bcm2836-rpi-2-b
       - imx6q-sabrelite
 
   - job: rt-tests-cyclictest
     event: *kbuild-gcc-12-arm64-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
 
   - job: rt-tests-cyclictest
     event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt_chromebook-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-chromebook-platforms
 
   - job: rt-tests-cyclictest
     event: *kbuild-gcc-12-x86-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-platforms
 
   - job: rt-tests-cyclictest
-    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt_chromebook-platforms
+    event: *kbuild-gcc-12-x86-preempt_rt_x86_board-node-event
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-rt-chromebook-platforms
 
   - job: rt-tests-cyclictest
     event: *kbuild-gcc-12-arm-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm-preempt_rt-platforms
 
   - job: rt-tests-rtla-osnoise
     event: *kbuild-gcc-12-arm64-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
 
   - job: rt-tests-rtla-osnoise
     event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt_chromebook-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-chromebook-platforms
 
   - job: rt-tests-rtla-osnoise
     event: *kbuild-gcc-12-x86-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-platforms
 
   - job: rt-tests-rtla-osnoise
-    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt_chromebook-platforms
+    event: *kbuild-gcc-12-x86-preempt_rt_x86_board-node-event
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-rt-chromebook-platforms
 
   - job: rt-tests-rtla-osnoise
     event: *kbuild-gcc-12-arm-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm-preempt_rt-platforms
 
   - job: rt-tests-rtla-timerlat
     event: *kbuild-gcc-12-arm64-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-platforms
 
   - job: rt-tests-rtla-timerlat
     event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm64-preempt_rt_chromebook-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm64-chromebook-platforms
 
   - job: rt-tests-rtla-timerlat
     event: *kbuild-gcc-12-x86-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-platforms
 
   - job: rt-tests-rtla-timerlat
-    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *x86-preempt_rt_chromebook-platforms
+    event: *kbuild-gcc-12-x86-preempt_rt_x86_board-node-event
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-x86-rt-chromebook-platforms
 
   - job: rt-tests-rtla-timerlat
     event: *kbuild-gcc-12-arm-preempt_rt-node-event
-    runtime: *runtime-lava-collabora
-    platforms: *arm-preempt_rt-platforms
+    runtime: *lava-collabora-runtime
+    platforms: *collabora-arm-preempt_rt-platforms
 
   - job: sleep
-    event:
-      channel: node
-      name: kbuild-gcc-12-x86
-      result: pass
-    runtime: *runtime-lava-collabora
+    event: *kbuild-gcc-12-x86-node-event
+    runtime: *lava-collabora-runtime
     platforms:
       - acer-chromebox-cxi4-puff
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -97,15 +97,14 @@ _anchors:
 
 ### Frequently used rules
 
-  build-only-trees: &build-only-trees-rules
-    rules:
-      tree:
-      - 'amlogic'
-      - 'ardb'
-      - 'arnd'
-      - 'clk'
-      - 'efi'
-      - 'peterz'
+  build-only-trees-rules: &build-only-trees-rules
+    tree:
+    - 'amlogic'
+    - 'ardb'
+    - 'arnd'
+    - 'clk'
+    - 'efi'
+    - 'peterz'
 
 api:
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -14,12 +14,12 @@ _anchors:
     <<: *arm64-device
     arch: arm
 
-  baseline: &baseline-job
+  baseline-job: &baseline-job
     template: baseline.jinja2
     kind: job
     kcidb_test_suite: boot
 
-  checkout: &checkout-event
+  checkout-event: &checkout-event
     channel: node
     name: checkout
     state: available
@@ -33,14 +33,14 @@ _anchors:
     channel: node
     result: pass
 
-  kbuild: &kbuild-job
+  kbuild-job: &kbuild-job
     template: kbuild.jinja2
     kind: kbuild
     rules:
       tree:
       - '!android'
 
-  kbuild-clang-17-x86: &kbuild-clang-17-x86-job
+  kbuild-clang-17-x86-job: &kbuild-clang-17-x86-job
     <<: *kbuild-job
     image: kernelci/staging-clang-17:x86-kselftest-kernelci
     params: &kbuild-clang-17-x86-params
@@ -48,7 +48,7 @@ _anchors:
       compiler: clang-17
       defconfig: x86_64_defconfig
 
-  kbuild-clang-12-arm64: &kbuild-clang-17-arm64-job
+  kbuild-clang-17-arm64-job: &kbuild-clang-17-arm64-job
     <<: *kbuild-job
     image: kernelci/staging-clang-17:arm64-kselftest-kernelci
     params: &kbuild-clang-17-arm64-params
@@ -57,7 +57,7 @@ _anchors:
       cross_compile: 'aarch64-linux-gnu-'
       defconfig: defconfig
 
-  kbuild-gcc-12-arm64: &kbuild-gcc-12-arm64-job
+  kbuild-gcc-12-arm64-job: &kbuild-gcc-12-arm64-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:arm64-kselftest-kernelci
     params: &kbuild-gcc-12-arm64-params
@@ -66,7 +66,7 @@ _anchors:
       cross_compile: 'aarch64-linux-gnu-'
       defconfig: defconfig
 
-  kbuild-gcc-12-x86: &kbuild-gcc-12-x86-job
+  kbuild-gcc-12-x86-job: &kbuild-gcc-12-x86-job
     <<: *kbuild-job
     image: kernelci/staging-gcc-12:x86-kselftest-kernelci
     params: &kbuild-gcc-12-x86-params
@@ -1069,7 +1069,7 @@ jobs:
     kind: job
     nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-rt/20240313.0/{debarch}'
     params: &rt-tests-params
-      job_timeout: '10'
+      job_timeout: 10
       duration: '60s'
     kcidb_test_suite: rt-tests
     rules:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1954,7 +1954,7 @@ build_environments:
 
 
 build_variants:
-  variants: &build-variants
+  variants:
     gcc-12:
       build_environment: gcc-12
       architectures:
@@ -1997,47 +1997,38 @@ build_configs:
   broonie-misc:
     tree: broonie-misc
     branch: 'for-kernelci'
-    variants: *build-variants
 
   broonie-regmap:
     tree: broonie-regmap
     branch: 'for-next'
-    variants: *build-variants
 
   broonie-regmap-fixes:
     tree: broonie-regmap
     branch: 'for-linus'
-    variants: *build-variants
 
   broonie-regulator:
     tree: broonie-regulator
     branch: 'for-next'
-    variants: *build-variants
 
   broonie-regulator-fixes:
     tree: broonie-regulator
     branch: 'for-linus'
-    variants: *build-variants
 
   broonie-sound:
     tree: broonie-sound
     branch: 'for-next'
-    variants: *build-variants
 
   broonie-sound-fixes:
     tree: broonie-sound
     branch: 'for-linus'
-    variants: *build-variants
 
   broonie-spi:
     tree: broonie-spi
     branch: 'for-next'
-    variants: *build-variants
 
   broonie-spi-fixes:
     tree: broonie-spi
     branch: 'for-linus'
-    variants: *build-variants
 
   chrome-platform:
     tree: chrome-platform
@@ -2058,27 +2049,22 @@ build_configs:
   kernelci_staging-mainline:
     tree: kernelci
     branch: 'staging-mainline'
-    variants: *build-variants
 
   kernelci_staging-next:
     tree: kernelci
     branch: 'staging-next'
-    variants: *build-variants
 
   kernelci_staging-stable:
     tree: kernelci
     branch: 'staging-stable'
-    variants: *build-variants
 
   mainline:
     tree: mainline
     branch: 'master'
-    variants: *build-variants
 
   stable-rc_4.19: &stable-rc
     tree: stable-rc
     branch: 'linux-4.19.y'
-    variants: *build-variants
 
   stable-rc_5.4:
     <<: *stable-rc
@@ -2115,12 +2101,10 @@ build_configs:
   next_master:
     tree: next
     branch: 'master'
-    variants: *build-variants
 
   mediatek_for_next:
     tree: mediatek
     branch: 'for-next'
-    variants: *build-variants
 
   android_4.19-stable:
     tree: android
@@ -2201,12 +2185,10 @@ build_configs:
   collabora-next_for-kernelci:
     tree: collabora-next
     branch: 'for-kernelci'
-    variants: *build-variants
 
   collabora-chromeos-kernel_for-kernelci:
     tree: collabora-chromeos-kernel
     branch: 'for-kernelci'
-    variants: *build-variants
 
   lee_mfd:
     tree: lee-mfd
@@ -2215,12 +2197,10 @@ build_configs:
   media_master:
     tree: media
     branch: 'master'
-    variants: *build-variants
 
   media_fixes:
     tree: media
     branch: 'fixes'
-    variants: *build-variants
 
   peterz:
     tree: peterz


### PR DESCRIPTION
Note: this PR is mostly there to indulge my OCD, although I believe it can be useful for long-term maintainability.

This makes it easier to find a specific entry location within the file if one knows the entry's name. It also prevents chaos within this file which, as everyone knows, is likely a good thing.

Some future CI check to ensure things stay ordered that way would likely be good as well, but is not included in this change.

Includes #728, draft and `staging-skip` for the same reasons.