### PR TITLE
pipeline.yaml: Disable docker kunit

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1627,10 +1627,10 @@ scheduler:
   - job: kbuild-gcc-12-arm-omap2plus_defconfig
     <<: *build-k8s-all
 
-  - job: kunit
-    event: *checkout-event
-    runtime:
-      type: docker
+#  - job: kunit
+#    event: *checkout-event
+#    runtime:
+#      type: docker
 
   - job: kunit-x86_64
     event: *checkout-event


### PR DESCRIPTION
Docker type can't really run on production (because pipeline runs in k8s itself), and even in staging it is DinD and makes unnecessary high load on each run. Disable, but dont remove, as later we might use such type for some lightweight staging jobs.