### PR TITLE
src/send_kcidb: submit all job nodes

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -451,10 +451,9 @@ in {test_node['data'].get('runtime')}",
                                     parsed_test_node, parsed_build_node)
 
             elif node['kind'] == 'job':
-                # Send only failed/incomplete job nodes
-                if node['result'] != 'pass':
-                    self._get_test_data(node, context['origin'],
-                                        parsed_test_node, parsed_build_node)
+                # Send job node
+                self._get_test_data(node, context['origin'],
+                                    parsed_test_node, parsed_build_node)
                 if is_hierarchy:
                     self._get_test_data_recursively(node, context['origin'],
                                                     parsed_test_node, parsed_build_node)


### PR DESCRIPTION
For the convenience of data analysis on KCIDB dashboard, submit all the job nodes irrespective of node results.