### PR TITLE
config: pipeline: fix rt-tests scheduling

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1825,6 +1825,143 @@ scheduler:
     platforms:
       - qemu-x86
 
+  - job: rt-tests-cyclicdeadline
+    event: &kbuild-gcc-12-arm64-preempt_rt-node-event
+      channel: node
+      name: kbuild-gcc-12-arm64-preempt_rt
+      result: pass
+    runtime: *runtime-lava-collabora
+    platforms: &arm64-preempt_rt-platforms
+      - bcm2711-rpi-4-b
+      - meson-g12b-a311d-khadas-vim3
+      - rk3399-gru-kevin
+      - rk3399-rock-pi-4b
+      - rk3588-rock-5b
+      - sun50i-h6-pine-h64
+
+  - job: rt-tests-cyclicdeadline
+    event: &kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
+      <<: *kbuild-gcc-12-arm64-preempt_rt-node-event
+      name: kbuild-gcc-12-arm64-preempt_rt_chromebook
+    runtime: *runtime-lava-collabora
+    platforms: &arm64-preempt_rt_chromebook-platforms
+      - mt8183-kukui-jacuzzi-juniper-sku16
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+      - sc7180-trogdor-kingoftown
+      - sc7180-trogdor-lazor-limozeen
+
+  - job: rt-tests-cyclicdeadline
+    event: &kbuild-gcc-12-x86-preempt_rt-node-event
+      channel: node
+      name: kbuild-gcc-12-x86-preempt_rt
+      result: pass
+    runtime: *runtime-lava-collabora
+    platforms: &x86-preempt_rt-platforms
+      - qemu-x86
+      - minnowboard-turbot-E3826
+
+  - job: rt-tests-cyclicdeadline
+    event: &kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
+      <<: *kbuild-gcc-12-x86-preempt_rt-node-event
+      name: kbuild-gcc-12-x86-preempt_rt_chromebook
+    runtime: *runtime-lava-collabora
+    platforms: &x86-preempt_rt_chromebook-platforms
+      - acer-cb317-1h-c3z6-dedede
+      - acer-cbv514-1h-34uz-brya
+      - acer-R721T-grunt
+      - acer-cp514-3wh-r0qs-guybrush
+      - hp-11A-G6-EE-grunt
+      - hp-14b-na0052xx-zork
+      - hp-x360-14-G1-sona
+      - hp-x360-12b-ca0010nr-n4020-octopus
+
+  - job: rt-tests-cyclicdeadline
+    event: &kbuild-gcc-12-arm-preempt_rt-node-event
+      channel: node
+      name: kbuild-gcc-12-arm-preempt_rt
+      result: pass
+    runtime: *runtime-lava-collabora
+    platforms: &arm-preempt_rt-platforms
+      - bcm2836-rpi-2-b
+      - imx6q-sabrelite
+
+  - job: rt-tests-cyclictest
+    event: *kbuild-gcc-12-arm64-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt-platforms
+
+  - job: rt-tests-cyclictest
+    event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-cyclictest
+    event: *kbuild-gcc-12-x86-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt-platforms
+
+  - job: rt-tests-cyclictest
+    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-cyclictest
+    event: *kbuild-gcc-12-arm-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm-preempt_rt-platforms
+
+  - job: rt-tests-rtla-osnoise
+    event: *kbuild-gcc-12-arm64-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt-platforms
+
+  - job: rt-tests-rtla-osnoise
+    event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-rtla-osnoise
+    event: *kbuild-gcc-12-x86-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt-platforms
+
+  - job: rt-tests-rtla-osnoise
+    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-rtla-osnoise
+    event: *kbuild-gcc-12-arm-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm-preempt_rt-platforms
+
+  - job: rt-tests-rtla-timerlat
+    event: *kbuild-gcc-12-arm64-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt-platforms
+
+  - job: rt-tests-rtla-timerlat
+    event: *kbuild-gcc-12-arm64-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm64-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-rtla-timerlat
+    event: *kbuild-gcc-12-x86-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt-platforms
+
+  - job: rt-tests-rtla-timerlat
+    event: *kbuild-gcc-12-x86-preempt_rt_chromebook-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *x86-preempt_rt_chromebook-platforms
+
+  - job: rt-tests-rtla-timerlat
+    event: *kbuild-gcc-12-arm-preempt_rt-node-event
+    runtime: *runtime-lava-collabora
+    platforms: *arm-preempt_rt-platforms
+
   - job: sleep
     event:
       channel: node

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -485,54 +485,6 @@ scheduler:
 #  - job: tast-ui-x86-intel
 #    <<: *test-job-chromeos-intel
 
-  - job: rt-tests-cyclicdeadline
-    <<: *test-job-x86-intel
-
-  - job: rt-tests-cyclicdeadline
-    <<: *test-job-x86-amd
-
-  - job: rt-tests-cyclicdeadline
-    <<: *test-job-arm64-qualcomm
-
-  - job: rt-tests-cyclicdeadline
-    <<: *test-job-arm64-mediatek
-
-  - job: rt-tests-cyclictest
-    <<: *test-job-x86-intel
-
-  - job: rt-tests-cyclictest
-    <<: *test-job-x86-amd
-
-  - job: rt-tests-cyclictest
-    <<: *test-job-arm64-qualcomm
-
-  - job: rt-tests-cyclictest
-    <<: *test-job-arm64-mediatek
-
-  - job: rt-tests-rtla-osnoise
-    <<: *test-job-x86-intel
-
-  - job: rt-tests-rtla-osnoise
-    <<: *test-job-x86-amd
-
-  - job: rt-tests-rtla-osnoise
-    <<: *test-job-arm64-qualcomm
-
-  - job: rt-tests-rtla-osnoise
-    <<: *test-job-arm64-mediatek
-
-  - job: rt-tests-rtla-timerlat
-    <<: *test-job-x86-intel
-
-  - job: rt-tests-rtla-timerlat
-    <<: *test-job-x86-amd
-
-  - job: rt-tests-rtla-timerlat
-    <<: *test-job-arm64-qualcomm
-
-  - job: rt-tests-rtla-timerlat
-    <<: *test-job-arm64-mediatek
-
   - job: v4l2-decoder-conformance-av1
     <<: *test-job-arm64-mediatek
     platforms:


### PR DESCRIPTION
The rt-tests were wrongly set to trigger based on chromebook jobs which didn't had preempt-rt fragment. Fix it by specifying the correct event which is the name of preempt-rt kbuild job names. Run each of 4 enabled rt-test on each variant of kernel. The kbuild variant are 2 arm64, 2 x86 and 1 arm.

Schedule the tests on a few devices instead of scheduling on all of the devices. Select devices from different vendors for each architecture.