### PR TITLE
Use timed rotation logging

### DIFF
--- a/config/logger.conf
+++ b/config/logger.conf
@@ -22,7 +22,7 @@ keys=root,
      trigger
 
 [handlers]
-keys=consoleHandler, fileHandler
+keys=consoleHandler, timedRotatingHandler
 
 [formatters]
 keys=defaultFormatter
@@ -33,11 +33,11 @@ level=DEBUG
 formatter=defaultFormatter
 args=(sys.stdout,)
 
-[handler_fileHandler]
-class=FileHandler
+[handler_timedRotatingHandler]
+class=logging.handlers.TimedRotatingFileHandler
 level=DEBUG
 formatter=defaultFormatter
-args=(os.path.join('logs', '%(log_file)s'), 'w')
+args=(os.path.join('logs', '%(log_file)s'), 'D', 15, 1)
 
 [formatter_defaultFormatter]
 format=%(asctime)s [%(levelname)s] %(message)s
@@ -49,90 +49,90 @@ handlers=consoleHandler
 
 [logger_monitor]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=monitor
 propagate=0
 
 [logger_patchset]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=patchset
 propagate=0
 
 [logger_regression_tracker]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=regression_tracker
 propagate=0
 
 [logger_result_summary]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=result_summary
 propagate=0
 
 [logger_scheduler]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=scheduler
 propagate=0
 
 [logger_scheduler_docker]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=scheduler_docker
 propagate=0
 
 [logger_scheduler_lava]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=scheduler_lava
 propagate=0
 
 [logger_scheduler_k8s]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=scheduler_k8s
 propagate=0
 
 [logger_send_kcidb]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=send_kcidb
 propagate=0
 
 [logger_tarball]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=tarball
 propagate=0
 
 [logger_test_report]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=test_report
 propagate=0
 
 [logger_timeout]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=timeout
 propagate=0
 
 [logger_timeout-closing]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=timeout-closing
 propagate=0
 
 [logger_timeout-holdoff]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=timeout-holdoff
 propagate=0
 
 [logger_trigger]
 level=DEBUG
-handlers=consoleHandler, fileHandler
+handlers=consoleHandler, timedRotatingHandler
 qualname=trigger
 propagate=0

--- a/src/logger.py
+++ b/src/logger.py
@@ -23,7 +23,7 @@ class Logger:
 
     def __init__(self, config_path, name='root'):
         """Returns logger object using configurations and logger name"""
-        log_file_name = f'{name}_{time.strftime("%Y_%m_%d-%H:%M:%S")}.log'
+        log_file_name = f'{name}.log'
         logging.config.fileConfig(config_path,
                                   defaults={'log_file': log_file_name})
         self._logger = logging.getLogger(name)

--- a/src/logger.py
+++ b/src/logger.py
@@ -10,7 +10,7 @@
 import logging
 import logging.config
 import traceback
-import time
+import sys
 
 
 class Logger:
@@ -23,9 +23,16 @@ class Logger:
 
     def __init__(self, config_path, name='root'):
         """Returns logger object using configurations and logger name"""
-        log_file_name = f'{name}.log'
-        logging.config.fileConfig(config_path,
-                                  defaults={'log_file': log_file_name})
+        try:
+            log_file_name = f'{name}.log'
+            logging.config.fileConfig(config_path,
+                                      defaults={'log_file': log_file_name})
+        except FileNotFoundError as exc:
+            print("Exception: Not able to dump logs to file:", str(exc))
+            logging.basicConfig(format="%(asctime)s [%(levelname)s] %(message)s",
+                                datefmt="%m/%d/%Y %I:%M:%S %p %Z",
+                                level=logging.DEBUG,
+                                handlers=[logging.StreamHandler(sys.stdout)])
         self._logger = logging.getLogger(name)
 
     def log_message(self, log_level, msg):


### PR DESCRIPTION
Fixes https://github.com/kernelci/kernelci-pipeline/issues/682

Use timed rotating file handler to optimize storage space for log files instead of using a regular file handler.
It will create a new log file with `<service-name>.log` convention and keep one backup file for older logs than
7 days. It will delete older backup log files on rollover if exists.
In case of `logs` directory is not mounted due to a different environment such as `k8s`, the service would crash with
`FileNotFoundError`. Enable only console logging when file logging fails to fix the issue.

