### PR TITLE
Enable suspend and hibernation test

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -910,6 +910,28 @@ jobs:
       job_timeout: 10
     kcidb_test_suite: kselftest.cpufreq
 
+  kselftest-cpufreq-hibernate:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: cpufreq
+      env: 'KSELFTEST_MAIN_SH_ARGS="-t hibernate_rtc"'
+    rules:
+      tree:
+      - 'kernelci:staging-next'
+    kcidb_test_suite: kselftest.cpufreq.hibernate
+
+  kselftest-cpufreq-suspend:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: cpufreq
+      env: 'KSELFTEST_MAIN_SH_ARGS="-t suspend_rtc"'
+    rules:
+      tree:
+      - 'kernelci:staging-next'
+    kcidb_test_suite: kselftest.cpufreq.suspend
+
   kselftest-dmabuf-heaps:
     <<: *kselftest-job
     params:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -216,6 +216,30 @@ scheduler:
   - job: kselftest-cpufreq
     <<: *test-job-arm64-mediatek
 
+  - job: kselftest-cpufreq-hibernate
+    <<: *test-job-x86-intel
+
+  - job: kselftest-cpufreq-hibernate
+    <<: *test-job-x86-amd
+
+  - job: kselftest-cpufreq-hibernate
+    <<: *test-job-arm64-qualcomm
+
+  - job: kselftest-cpufreq-hibernate
+    <<: *test-job-arm64-mediatek
+
+  - job: kselftest-cpufreq-suspend
+    <<: *test-job-x86-intel
+
+  - job: kselftest-cpufreq-suspend
+    <<: *test-job-x86-amd
+
+  - job: kselftest-cpufreq-suspend
+    <<: *test-job-arm64-qualcomm
+
+  - job: kselftest-cpufreq-suspend
+    <<: *test-job-arm64-mediatek
+
   - job: kselftest-dmabuf-heaps
     <<: *test-job-x86-intel
 


### PR DESCRIPTION
Enable suspend and hibernation test. This patch depends on the https://github.com/kernelci/kernelci-pipeline/pull/743
