### PR TITLE
fix(k8s): Add name option

### DIFF
--- a/kube/aks/scheduler-k8s.yaml
+++ b/kube/aks/scheduler-k8s.yaml
@@ -21,13 +21,14 @@ spec:
     spec:
       containers:
         - name: scheduler
-          image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb
+          image: kernelci/kernelci:pipeline@sha256:5ecd9b94a22f064a15a9ded85cbe09ff10018fe7cf6fdfaca794121f3b4a4b5f
           imagePullPolicy: Always
           command:
             - ./src/scheduler.py
             - --settings=/secrets/kernelci.toml
             - --yaml-config=/config
             - loop
+            - --name=scheduler_k8s
             - --runtimes
             - k8s-gke-eu-west4
             - k8s-all

--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -21,13 +21,14 @@ spec:
     spec:
       containers:
         - name: scheduler
-          image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb
+          image: kernelci/kernelci:pipeline@sha256:5ecd9b94a22f064a15a9ded85cbe09ff10018fe7cf6fdfaca794121f3b4a4b5f
           imagePullPolicy: Always
           command:
             - ./src/scheduler.py
             - --settings=/secrets/kernelci.toml
             - --yaml-config=/config
             - loop
+            - --name=scheduler_lava
             - --runtimes
             - lava-collabora
             - lava-broonie


### PR DESCRIPTION
PR https://github.com/kernelci/kernelci-pipeline/pull/672 introduced new mandatory option. Except docker-compose such options should be added to k8s manifests too.