### PR TITLE
src/send_kcidb: handle incomplete builds

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -166,6 +166,14 @@ class KCIDBBridge(Service):
             return data[-(16*1024):]
 
     def _parse_build_node(self, origin, node):
+        result = node.get('result')
+        result_map = {
+            'pass': True,
+            'fail': False,
+            'incomplete': None,
+        }
+        valid = result_map.get(result) if result else None
+
         parsed_build_node = {
             'checkout_id': f"{origin}:{node['parent']}",
             'id': f"{origin}:{node['id']}",
@@ -175,7 +183,7 @@ class KCIDBBridge(Service):
             'architecture': node['data'].get('arch'),
             'compiler': node['data'].get('compiler'),
             'config_name': node['data'].get('defconfig'),
-            'valid': node['result'] == 'pass',
+            'valid': valid,
             'misc': {
                 'platform': node['data'].get('platform'),
                 'runtime': node['data'].get('runtime'),

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -173,6 +173,7 @@ class KCIDBBridge(Service):
             'incomplete': None,
         }
         valid = result_map.get(result) if result else None
+        error_code = node['data'].get('error_code')
 
         parsed_build_node = {
             'checkout_id': f"{origin}:{node['parent']}",
@@ -190,8 +191,9 @@ class KCIDBBridge(Service):
                 'job_id': node['data'].get('job_id'),
                 'job_context': node['data'].get('job_context'),
                 'kernel_type': node['data'].get('kernel_type'),
-                'error_code': node['data'].get('error_code'),
-                'error_msg': node['data'].get('error_msg'),
+                'error_code': error_code if error_code != 'node_timeout' else None,
+                'error_msg': node['data'].get('error_msg')
+                if error_code != 'node_timeout' else None,
             }
         }
         artifacts = node.get('artifacts')


### PR DESCRIPTION
As KCIDB only supports `pass` and `fail` status for builds and doesn't have a separate status for incomplete/missed build jobs, keep `valid` flag empty for incomplete builds.