### PR TITLE
feat(k8s): Add regression tracker manifest

### DIFF
--- a/kube/aks/regression.yaml
+++ b/kube/aks/regression.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: regression-tracker
+  namespace: kernelci-pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: regression-tracker
+  template:
+    metadata:
+      labels:
+        app: regression-tracker
+    spec:
+      containers:
+        - name: scheduler
+          image: kernelci/kernelci:pipeline@sha256:5ecd9b94a22f064a15a9ded85cbe09ff10018fe7cf6fdfaca794121f3b4a4b5f
+          imagePullPolicy: Always
+          command:
+            - ./src/regression_tracker.py
+            - --settings=/secrets/kernelci.toml
+            - --yaml-config=/config
+            - run
+          env:
+            - name: KCI_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kernelci-api-token
+                  key: token
+          volumeMounts:
+            - name: secrets
+              mountPath: /secrets
+            - name: config-volume
+              mountPath: /config
+            - name: tmpsecrets
+              mountPath: /home/kernelci/secrets
+      volumes:
+        - name: secrets
+          secret:
+            secretName: pipeline-secrets
+        - name: config-volume
+          configMap:
+            name: pipeline-configmap
+        - name: tmpsecrets
+          emptyDir: {}


### PR DESCRIPTION
By some reason regression tracker was not added in kubernetes manifests, and recently discovered by Ricardo. Fixing that.