### PR TITLE
Rename early access configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ The `lava-callback` service is used to receive notifications from LAVA after a j
 [runtime.lava-collabora]
 runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
 callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
-
-[runtime.lava-collabora-early-access]
-runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA-EARLY-ACCESS"
-callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
 ```
 In case we have single token, it will be same token used to submit job(by scheduler), runtime_token only, but if we use different to tokens to submit job and to receive callback, we need to specify both runtime_token and callback_token.
 

--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -76,7 +76,3 @@ storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"
 # in case callback_token is not set, runtime_token is expected to be used
 #runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
 #callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"
-
-#[runtime.lava-collabora-early-access]
-#runtime_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA-EARLY-ACCESS"
-#callback_token = "REPLACE-LAVA-TOKEN-GENERATED-BY-LAB-LAVA-COLLABORA"

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -134,7 +134,7 @@ api:
   staging:
     url: https://staging.kernelci.org:9000
 
-  early-access:
+  production:
     url: https://kernelci-api.westus3.cloudapp.azure.com
 
   k8s-host:
@@ -149,10 +149,10 @@ storage:
     port: 8022
     base_url: http://172.17.0.1:8002/
 
-  early-access-azure: &azure-files
+  production-azure: &azure-files
     storage_type: azure
     base_url: https://kciapistagingstorage1.file.core.windows.net/
-    share: early-access
+    share: production
     sas_public_token: "?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D"
 
   k8s-host:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -231,14 +231,6 @@ runtimes:
       callback:
         token: kernelci-api-token-staging
 
-  # ToDo: avoid creating a separate Runtime entry
-  # https://github.com/kernelci/kernelci-core/issues/2088
-  lava-collabora-early-access:
-    <<: *lava-collabora-staging
-    notify:
-      callback:
-        token: kernelci-api-token-early-access
-
   lava-collabora-staging:
     <<: *lava-collabora-staging
     url: https://staging.lava.collabora.dev/

--- a/doc/result-summary.md
+++ b/doc/result-summary.md
@@ -24,7 +24,7 @@ Then point it to the appropriate Maestro instance by editing the
 to the current production instance:
 
 ```
-$ sed -i 's/api_config = "docker-host"/api_config = "early-access"/' config/kernelci.toml
+$ sed -i 's/api_config = "docker-host"/api_config = "production"/' config/kernelci.toml
 ```
 
 ## How to use it

--- a/kube/aks/kernelci-secrets.toml.example
+++ b/kube/aks/kernelci-secrets.toml.example
@@ -39,7 +39,7 @@ storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"
 [storage.staging-azure]
 storage_cred = ""
 
-[storage.early-access-azure]
+[storage.production-azure]
 storage_cred = ""
 
 [runtime.lava-collabora]

--- a/kube/aks/kernelci-secrets.toml.example
+++ b/kube/aks/kernelci-secrets.toml.example
@@ -44,6 +44,3 @@ storage_cred = ""
 
 [runtime.lava-collabora]
 runtime_token = ""
-
-[runtime.lava-collabora-early-access]
-runtime_token = ""

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -53,7 +53,6 @@ lava_labs = {
     "lava-baylibre": "https://lava.baylibre.com",
     "lava-broonie": "https://lava.sirena.org.uk",
     "lava-collabora": "https://lava.collabora.dev",
-    "lava-collabora-early-access": "https://staging.lava.collabora.dev",
     "lava-collabora-staging": "https://staging.lava.collabora.dev",
 }
 


### PR DESCRIPTION
Related to https://github.com/kernelci/kernelci-core/pull/2638
- Rename configurations for `early-access` to `production`
- Remove `lava-collabora-early-access` lab