### PR TITLE
fix(docker-compose): Disable restart for result-summary

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - './config:/home/kernelci/config'
       - './data/output:/home/kernelci/data/output'
       - './logs:/home/kernelci/logs'
-    restart: on-failure
+    #restart: on-failure
 
   scheduler: &scheduler
     container_name: 'kernelci-pipeline-scheduler'


### PR DESCRIPTION
Result-summary doesn't work properly on staging as it dont have proper config. Do not restart if it fails.