### PR TITLE
src/send_kcidb: remove a log line for printing `compatible`

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -349,7 +349,6 @@ the test: {sub_path}")
         platform = test_node['data'].get('platform')
         if platform:
             compatible = self._platforms[platform].compatible
-            self.log.info(f"Compatible string: {test_node['id']}:{compatible}")
 
         parsed_test_node = {
             'build_id': build_id,


### PR DESCRIPTION
The log printing device tree compatible info was intended for development purpose. Hence, drop it.