### PR TITLE
Fix `kci-maintainer` tool

### DIFF
--- a/tools/kci-maintainer
+++ b/tools/kci-maintainer
@@ -97,8 +97,7 @@ def get_repo_info(repodir):
 def prepare_checkout(args):
     token = get_token()
     if not token:
-        print('API token is required')
-        return
+        token = args.token
 
     # Developer have several ways to provide checkout data
     # Always require commit ID

--- a/tools/kci-maintainer
+++ b/tools/kci-maintainer
@@ -19,7 +19,7 @@ import sys
 PIPELINE_ENDPOINTS = {
     'staging': 'https://staging.kernelci.org:9100/',
     'production': 'https://kernelci-pipeline.westus3.cloudapp.azure.com/',
-    'local': 'http://localhost:8000/'
+    'local': 'http://localhost:8100/'
 }
 
 API_ENDPOINTS = {


### PR DESCRIPTION
- Fix getting token for `prepare_checkout` when token is not available in env variable
- Fix the URL for local pipeline API