### PR TITLE
fluster-chromeos: Remove non-chromeos trees

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -386,10 +386,7 @@ _anchors:
       videodec_timeout: 90
     rules:
       tree:
-        - mainline
-        - next
         - collabora-chromeos-kernel
-        - media
 
   watchdog-reset: &watchdog-reset-job
     template: generic.jinja2


### PR DESCRIPTION
Remove the following trees for the fluster tests on chromeos:

- mainline
- next
- media