### PR TITLE
cleanup(disable_modules): Cleanup option as it is not needed anymore

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1019,7 +1019,6 @@ jobs:
     params:
       <<: *kbuild-gcc-12-i386-params
       defconfig: allnoconfig
-      disable_modules: true
     rules:
       tree:
       - 'kernelci'
@@ -1082,7 +1081,6 @@ jobs:
     params:
       <<: *kbuild-gcc-12-i386-params
       defconfig: tinyconfig
-      disable_modules: true
     rules:
       tree:
       - 'kernelci'
@@ -1196,7 +1194,6 @@ jobs:
     params:
       <<: *kbuild-gcc-12-riscv-params
       defconfig: nommu_k210_defconfig
-      disable_modules: true
     rules:
       tree:
       - 'kernelci'
@@ -1236,7 +1233,6 @@ jobs:
     params:
       <<: *kbuild-gcc-12-x86-params
       defconfig: allnoconfig
-      disable_modules: true
     rules:
       tree:
       - 'kernelci'
@@ -1377,7 +1373,6 @@ jobs:
     params:
       <<: *kbuild-gcc-12-x86-params
       defconfig: tinyconfig
-      disable_modules: true
     rules:
       tree:
       - 'kernelci'

--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -41,9 +41,6 @@ KBUILD_PARAMS = {
 {%- if cross_compile_compat %}
     'cross_compile_compat': '{{ cross_compile_compat }}'
 {%- endif %}
-{%- if disable_modules %}
-    'disable_modules': {{ disable_modules }}
-{%- endif %}
 {%- if dtbs_check %}
     'dtbs_check': '{{ dtbs_check }}'
 {%- endif %}


### PR DESCRIPTION
After introducing https://github.com/kernelci/kernelci-core/pull/2661 modules support detected in kbuild automatically, and manual option not needed anymore