### PR TITLE
config: platforms-chromeos: Update the URL of the tast images

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -8,7 +8,7 @@ _anchors:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-{mach}
         image: 'kernel/Image'
       nfsroot: https://storage.chromeos.kernelci.org/images/rootfs/debian/bookworm-cros-flash/20240422.0/{debarch}
-      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240514.0/{debarch}/tast.tgz
+      tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240918.0/{debarch}/tast.tgz
     rules: &arm64-chromebook-device-rules
       defconfig:
         - '!allnoconfig'


### PR DESCRIPTION
The chromeos images are same. The tast images have data files now. Hence update their URL.

TODO: Correct the URL of images after images are generated from https://github.com/kernelci/kernelci-core/pull/2662.