### PR TITLE
config: pipeline: Remove timeout and duration

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1422,8 +1422,6 @@ jobs:
     params: &rt-tests-params
       boot_commands: nfs
       nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-rt/20240806.0/{debarch}'
-      job_timeout: 10
-      duration: '60s'
     kcidb_test_suite: rt-tests
     rules:
       fragments:


### PR DESCRIPTION
Add default timeout and duration to the lava template instead of putting default values here in pipeline.

Pre-requisite PR: https://github.com/kernelci/kernelci-core/pull/2665