### PR TITLE
fix(config): Fix "flasher" kernel for Corsola device

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -120,7 +120,7 @@ platforms:
     params:
       <<: *arm64-chromebook-device-params
       flash_kernel:
-        url: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-corsola/20240514.0/arm64
+        url: https://storage.chromeos.kernelci.org/images/kernel/v6.10-mediatek/
         image: 'Image'
     rules:
       <<: *arm64-chromebook-device-rules


### PR DESCRIPTION
Corsola cannot use kernel supplied with ChromeOS build for installing modules. Use current 6.10-stable kernel for that