### PR TITLE
config: pipeline: Enable omap tree for specific arm configs

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -112,7 +112,6 @@ _anchors:
     - 'linusw'
     - 'net-next'
     - 'next'
-    - 'omap'
     - 'peterz'
     - 'pm'
     - 'renesas'
@@ -777,6 +776,15 @@ jobs:
       - 'kernelci'
       - 'stable-rc'
 
+  kbuild-gcc-12-arm-omap1_defconfig:
+    <<: *kbuild-gcc-12-arm-job
+    params:
+      <<: *kbuild-gcc-12-arm-params
+      defconfig: omap1_defconfig
+    rules:
+      tree:
+      - 'omap'
+
   kbuild-gcc-12-arm-omap2plus_defconfig:
     <<: *kbuild-gcc-12-arm-job
     params:
@@ -785,6 +793,7 @@ jobs:
     rules:
       tree:
       - 'kernelci'
+      - 'omap'
       - 'stable-rc'
 
   kbuild-gcc-12-arm-preempt_rt:
@@ -2242,6 +2251,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm-multi_v7_defconfig
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm-omap1_defconfig
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm-omap2plus_defconfig


### PR DESCRIPTION
The omap tree was enabled in build-only category where minimal builds with mostly only default configs were enabled. The maintainer, Kevin wants the following:

  the omap tree, it should only build for arm arch, and only build
  omap1_defconfig omap2plus_defconfig and multi_v7_defconfig

So disable the build-only configs for omap tree and enable it only for those three configurations.
- The multi_v7_defconfig is the default config which is enabled for all trees by default.
- Add new entry for omap1_defconfig
- Add omap tree to already defined omap2plus config