### PR TITLE
update(docker-compose): Restrict staging trigger to kernelci only

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,6 +143,7 @@ services:
       - './pipeline/trigger.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+      - '--trees=kernelci'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
As we create enormous load on builders and labs, we need to stop staging building all kernels except kernelci "manually" triggered kernel.
If anybody need to test on staging particular tree/branch, he need to use custom checkout API function in pipeline.