### PR TITLE
fluster-debian: Rename from v4l2-decoder-conformance to fluster-debian

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -357,11 +357,11 @@ _anchors:
         - ui.HotseatAnimation.shelf_with_navigation_widget_lacros
         - ui.WindowControl
 
-  v4l2-decoder-conformance: &v4l2-decoder-conformance-job
+  fluster-debian: &fluster-debian-job
     template: 'generic.jinja2'
     kind: job
-    params: &v4l2-decoder-conformance-params
-      test_method: v4l2-decoder-conformance
+    params: &fluster-debian-params
+      test_method: fluster-debian
       boot_commands: nfs
       nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240703.0/{debarch}/'
       job_timeout: 30
@@ -617,68 +617,68 @@ jobs:
   tast-ui-x86-amd: *tast-ui-job
   tast-ui-x86-intel: *tast-ui-job
 
-  v4l2-decoder-conformance-av1:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-av1:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'AV1-TEST-VECTORS'
       decoders:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_av1
 
-  v4l2-decoder-conformance-av1-chromium-10bit:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-av1-chromium-10bit:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'CHROMIUM-10bit-AV1-TEST-VECTORS'
       decoders:
         - 'GStreamer-AV1-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_av1_chromium
 
-  v4l2-decoder-conformance-h264:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-h264:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'JVT-AVC_V1'
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_h264
 
-  v4l2-decoder-conformance-h264-frext:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-h264-frext:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'JVT-FR-EXT'
       decoders:
         - 'GStreamer-H.264-V4L2-Gst1.0'
         - 'GStreamer-H.264-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_h264_frext
 
-  v4l2-decoder-conformance-h265:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-h265:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'JCT-VC-HEVC_V1'
       decoders:
         - 'GStreamer-H.265-V4L2-Gst1.0'
         - 'GStreamer-H.265-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_h265
 
-  v4l2-decoder-conformance-vp8:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-vp8:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'VP8-TEST-VECTORS'
       decoders:
         - 'GStreamer-VP8-V4L2-Gst1.0'
         - 'GStreamer-VP8-V4L2SL-Gst1.0'
     kcidb_test_suite: fluster.v4l2.gstreamer_vp8
 
-  v4l2-decoder-conformance-vp9:
-    <<: *v4l2-decoder-conformance-job
+  fluster-debian-vp9:
+    <<: *fluster-debian-job
     params:
-      <<: *v4l2-decoder-conformance-params
+      <<: *fluster-debian-params
       testsuite: 'VP9-TEST-VECTORS'
       decoders:
         - 'GStreamer-VP9-V4L2-Gst1.0'

--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -719,85 +719,85 @@ all-android-builds:
         repos:
           - tree: android
 
-#### Failures and regressions in v4l2-decoder-conformance tests
+#### Failures and regressions in fluster-debian tests
 
-monitor-v4l2-decoder-conformance-regressions:
+monitor-fluster-debian-regressions:
   metadata:
     action: monitor
-    title: "KernelCI v4l2-decoder-conformance regressions"
+    title: "KernelCI fluster-debian regressions"
     template: "generic-regression-report.html.jinja2"
-    output_file: "v4l2-decoder-conformance-regressions.html"
+    output_file: "fluster-debian-regressions.html"
   preset:
     regression:
       - data.error_code: null
-        group__re: v4l2-decoder-conformance
+        group__re: fluster-debian
         repos:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
 
-monitor-v4l2-decoder-conformance-failures__runtime-errors:
+monitor-fluster-debian-failures__runtime-errors:
   metadata:
     action: monitor
-    title: "KernelCI v4l2-decoder-conformance failures due to runtime errors"
+    title: "KernelCI fluster-debian failures due to runtime errors"
     template: "generic-test-results.html.jinja2"
-    output_file: "v4l2-decoder-conformance-failures__runtime-errors.html"
+    output_file: "fluster-debian-failures__runtime-errors.html"
   preset:
     job:
       - data.error_code__ne: null
         result: fail
-        name__re: v4l2-decoder-conformance
+        name__re: fluster-debian
         repos:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
 
-summary-v4l2-decoder-conformance-regressions:
+summary-fluster-debian-regressions:
   metadata:
     action: summary
-    title: "KernelCI v4l2-decoder-conformance regressions"
+    title: "KernelCI fluster-debian regressions"
     template: "generic-regressions.html.jinja2"
-    output_file: "v4l2-decoder-conformance-regressions.html"
+    output_file: "fluster-debian-regressions.html"
   preset:
     regression:
       - data.error_code: null
-        group__re: v4l2-decoder-conformance
+        group__re: fluster-debian
         repos:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
 
-summary-v4l2-decoder-conformance-failures__runtime-errors:
+summary-fluster-debian-failures__runtime-errors:
   metadata:
     action: summary
-    title: "KernelCI v4l2-decoder-conformance failures due to runtime errors"
+    title: "KernelCI fluster-debian failures due to runtime errors"
     template: "generic-test-results.html.jinja2"
-    output_file: "v4l2-decoder-conformance-failures__runtime-errors.html"
+    output_file: "fluster-debian-failures__runtime-errors.html"
   preset:
     job:
       - data.error_code__ne: null
         result: fail
-        name__re: v4l2-decoder-conformance
+        name__re: fluster-debian
         repos:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
           - tree: media
 
-summary-v4l2-decoder-conformance-failures:
+summary-fluster-debian-failures:
   metadata:
     action: summary
-    title: "KernelCI v4l2-decoder-conformance failures"
+    title: "KernelCI fluster-debian failures"
     template: "generic-test-results.html.jinja2"
-    output_file: "v4l2-decoder-conformance-failures.html"
+    output_file: "fluster-debian-failures.html"
   preset:
     test:
       - data.error_code: null
         result: fail
-        group__re: v4l2-decoder-conformance
+        group__re: fluster-debian
         repos:
           - tree: mainline
           - tree: next

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -485,35 +485,35 @@ scheduler:
 #  - job: tast-ui-x86-intel
 #    <<: *test-job-chromeos-intel
 
-  - job: v4l2-decoder-conformance-av1
+  - job: fluster-debian-av1
     <<: *test-job-arm64-mediatek
     platforms:
       - mt8195-cherry-tomato-r2
 
-  - job: v4l2-decoder-conformance-av1-chromium-10bit
+  - job: fluster-debian-av1-chromium-10bit
     <<: *test-job-arm64-mediatek
     platforms:
       - mt8195-cherry-tomato-r2
 
-  - job: v4l2-decoder-conformance-h264
+  - job: fluster-debian-h264
     <<: *test-job-arm64-mediatek
 
-  - job: v4l2-decoder-conformance-h264-frext
+  - job: fluster-debian-h264-frext
     <<: *test-job-arm64-mediatek
 
-  - job: v4l2-decoder-conformance-h265
+  - job: fluster-debian-h265
     <<: *test-job-arm64-mediatek
     platforms:
       - mt8195-cherry-tomato-r2
 
-  - job: v4l2-decoder-conformance-vp8
+  - job: fluster-debian-vp8
     <<: *test-job-arm64-mediatek
     platforms:
       - mt8186-corsola-steelix-sku131072
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
-  - job: v4l2-decoder-conformance-vp9
+  - job: fluster-debian-vp9
     <<: *test-job-arm64-mediatek
     platforms:
       - mt8186-corsola-steelix-sku131072
@@ -555,19 +555,19 @@ scheduler:
       - mt8192-asurada-spherion-r0
       - mt8195-cherry-tomato-r2
 
-  - job: v4l2-decoder-conformance-h264
+  - job: fluster-debian-h264
     <<: *test-job-arm64-qualcomm
 
-  - job: v4l2-decoder-conformance-h264-frext
+  - job: fluster-debian-h264-frext
     <<: *test-job-arm64-qualcomm
 
-  - job: v4l2-decoder-conformance-h265
+  - job: fluster-debian-h265
     <<: *test-job-arm64-qualcomm
 
-  - job: v4l2-decoder-conformance-vp8
+  - job: fluster-debian-vp8
     <<: *test-job-arm64-qualcomm
 
-  - job: v4l2-decoder-conformance-vp9
+  - job: fluster-debian-vp9
     <<: *test-job-arm64-qualcomm
 
   - job: watchdog-reset-arm64-mediatek


### PR DESCRIPTION
Linked to https://github.com/kernelci/kernelci-core/pull/2671

Rename the v4l2 decoder conformance tests using Fluster + Debian tests by replacing strings from `v4l2-decoder-conformance` to `fluster-debian`.

The main reason for the change is to make clear parallel with the `fluster-chromeos` tests wich are the same tests but uses chromeos as file system. This aims to ease future code maintainability of both test sets.