### PR TITLE
src/tarball.py: set new checkout fields

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -129,6 +129,12 @@ class KCIDBBridge(Service):
                 checkout_node['data']['kernel_revision'].get('describe'),
             'git_repository_branch':
                 checkout_node['data']['kernel_revision']['branch'],
+            'git_commit_tags':
+                checkout_node['data']['kernel_revision']['commit_tags'],
+            'git_commit_message':
+                checkout_node['data']['kernel_revision']['commit_message'],
+            'git_repository_branch_tip':
+                checkout_node['data']['kernel_revision']['tip_of_branch'],
             'start_time': self._set_timezone(checkout_node['created']),
             'patchset_hash': '',
             'misc': {
@@ -504,7 +510,7 @@ in {runtime}",
                 'tests': parsed_test_node,
                 'version': {
                     'major': 4,
-                    'minor': 4
+                    'minor': 5
                 }
             }
             self._send_revision(context['client'], revision)


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2688

Set recently added checkout fields such as git commit tags, commit message, and flag denoting if the commit is at the tip of the branch.