### PR TITLE
tools/kci-maintainer: remove unused package

### DIFF
--- a/tools/kci-maintainer
+++ b/tools/kci-maintainer
@@ -14,7 +14,6 @@ import json
 import os
 import argparse
 import sys
-import git
 import subprocess
 import re
 


### PR DESCRIPTION
Remove `git` as it's an unused package in the tool script.