### PR TITLE
config: jobs-chromeos: update rootfs for fluster tests on Debian

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -363,7 +363,7 @@ _anchors:
     params: &v4l2-decoder-conformance-params
       test_method: v4l2-decoder-conformance
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240703.0/{debarch}/'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240926.0/{debarch}/'
       job_timeout: 30
       videodec_parallel_jobs: 1
       videodec_timeout: 90


### PR DESCRIPTION
https://github.com/kernelci/kernelci-core/pull/2673 introduced some changes in the fluster_parser.py script, including an additional `--run` flag. 

Update the rootfs for fluster decoder tests on Debian, to incorporate the latest changes in the fluster_parser.py script and fix the  `fluster_parser.py: error: unrecognized arguments: --run` errors currently reported (see e.g.: https://lava.collabora.dev/scheduler/job/15780360#L10829).

The new rootfs image was generated using the [kernelci-core rootfs build action](https://github.com/kernelci/kernelci-core/actions/workflows/rootfs.yml).