### PR TITLE
Add devices-exist-kselftest and enable it on mt8195-cherry-tomato-r2

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1493,6 +1493,18 @@ jobs:
       - 'kernelci:staging-next'
     kcidb_test_suite: kselftest.cpufreq.suspend
 
+  kselftest-devices-exist:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      test_method: kselftest-platform-parameters
+      collections: devices/exist
+      env: "KSELFTEST_TEST_DEV_EXIST_PY_ARGS=--reference-dir=/opt/platform-test-parameters-main/kselftest/devices/exist/"
+    rules:
+      tree:
+        - collabora-next:for-kernelci
+    kcidb_test_suite: kselftest.devices-exist
+
   kselftest-devices-probe:
     <<: *kselftest-job
     params:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -196,6 +196,15 @@ scheduler:
       - sc7180-trogdor-kingoftown
       - sc7180-trogdor-lazor-limozeen
 
+  - job: kselftest-devices-exist
+    <<: *lava-job-collabora
+    event:
+      channel: node
+      name: kbuild-gcc-12-arm64-chromebook
+      result: pass
+    platforms:
+      - mt8195-cherry-tomato-r2
+
   - job: kselftest-device-error-logs
     <<: *lava-job-collabora
     event:


### PR DESCRIPTION
Add the devices-exist kselftest and enable it on mt8195-cherry-tomato-r2.

Depends on https://github.com/kernelci/kernelci-core/pull/2695.