### PR TITLE
fix(trigger.py): Ignore commit created by user

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -48,6 +48,7 @@ class Trigger(Service):
             "kind": "checkout",
             "data.kernel_revision.commit": head_commit,
             "owner": self._current_user['username'],
+            "submitter": "service:pipeline"
         })
 
         if node_count > 0:


### PR DESCRIPTION
Users might trigger tip of tree commit before trigger, ignore them and execute our own test set.