### PR TITLE
result_summary: Utility and performance improvements

### DIFF
--- a/config/result_summary_templates/generic-test-results.html.jinja2
+++ b/config/result_summary_templates/generic-test-results.html.jinja2
@@ -120,8 +120,8 @@ expects the following input parameters:
               {% if test['data']['runtime'] %}
                 <li>Runtime: {{ test['data']['runtime'] }}</li>
               {% endif %}
-              {% if test['data']['job_id'] %}
-                <li>Job ID: {{ test['data']['job_id'] }}</li>
+              {% if test['job_id'] %}
+                <li>LAVA job: <a href="{{ test['job_url'] }}" target="_blank" rel="noopener noreferrer">{{ test['job_id'] }}</a></li>
               {% endif %}
               {% if test['data']['error_code'] -%}
                 <li>Error code: <code>{{ test['data']['error_code'] }}</code></li>

--- a/src/result_summary.py
+++ b/src/result_summary.py
@@ -137,9 +137,9 @@ class ResultSummary(Service):
 
     def _run(self, context):
         if context['metadata']['action'] == 'summary':
-            summary.run(self, context)
+            return summary.run(self, context)
         elif context['metadata']['action'] == 'monitor':
-            monitor.run(self, context)
+            return monitor.run(self, context)
         else:
             raise Exception("Undefined or unsupported preset action: "
                             f"{metadata.get('action')}")

--- a/src/result_summary/summary.py
+++ b/src/result_summary/summary.py
@@ -66,6 +66,7 @@ def run(service, context):
         result_summary.logger.debug(f"Query matches found: {len(query_results)}")
         nodes.extend(query_results)
     result_summary.logger.info(f"Total nodes found: {len(nodes)}")
+    utils.node_cache_write(nodes)
 
     # Post-process nodes
     # Filter log files


### PR DESCRIPTION
- Generate links to lava jobs in the html summary outputs
- Use a node cache to reduce the amount of api requests