### PR TITLE
fix(scheduler-chromeos.yaml): disable chromestack-debian tasks

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -345,20 +345,22 @@ scheduler:
 #  - job: tast-basic-x86-intel
 #    <<: *test-job-chromeos-intel
 
-  - job: tast-decoder-chromestack-arm64-mediatek
-    <<: *test-job-chromeos-mediatek
 
-  - job: tast-debian-decoder-chromestack-arm64-mediatek
-    <<: *test-job-chromeos-mediatek
+# Some of this tests running too long, must be max 30 min
+#  - job: tast-decoder-chromestack-arm64-mediatek
+#    <<: *test-job-chromeos-mediatek
 
-  - job: tast-decoder-chromestack-arm64-qualcomm
-    <<: *test-job-chromeos-qualcomm
+#  - job: tast-debian-decoder-chromestack-arm64-mediatek
+#    <<: *test-job-chromeos-mediatek
 
-  - job: tast-debian-decoder-chromestack-arm64-qualcomm
-    <<: *test-job-chromeos-qualcomm
+#  - job: tast-decoder-chromestack-arm64-qualcomm
+#    <<: *test-job-chromeos-qualcomm
 
-  - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
-    <<: *test-job-chromeos-qualcomm
+#  - job: tast-debian-decoder-chromestack-arm64-qualcomm
+#    <<: *test-job-chromeos-qualcomm
+
+#  - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
+#    <<: *test-job-chromeos-qualcomm
 
 # Disabled as per daniels request to reduce load on LAVA
 #  - job: tast-decoder-chromestack-x86-amd


### PR DESCRIPTION
This tasks taking too long time. Disabling until they are fixed.