### PR TITLE
config: pipeline: Update media tree URL and branches

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1798,7 +1798,7 @@ trees:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
 
   media:
-    url: 'https://git.linuxtv.org/media_stage.git'
+    url: 'https://git.linuxtv.org/media.git'
 
   mediatek:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
@@ -3142,9 +3142,9 @@ build_configs:
     tree: media
     branch: 'fixes'
 
-  media_master:
+  media_next:
     tree: media
-    branch: 'master'
+    branch: 'next'
 
   mediatek_for_next:
     tree: mediatek


### PR DESCRIPTION
The "media_stage" and "media_tree" trees have now been unified to a single "media" tree, with "next" and "fixes" branches. Update the URL for the media tree and its branches accordingly.

See: https://lore.kernel.org/linux-media/20241007173146.6a35fa62@foz.lan/T/#u