### PR TITLE
src/send_kcidb: handle incomplete test nodes

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -296,6 +296,8 @@ the test: {sub_path}")
                 return 'ERROR'
             if error_code in MISSED_TEST_CODES:
                 return 'MISS'
+            self.log.debug(f"Error code is not set for {test_node['id']}")
+            return None
         return test_node['result'].upper()
 
     def _get_parent_build_node(self, node):


### PR DESCRIPTION
We map incomplete test node result to `ERROR` or `MISS` based on error code set. In some cases, we
have `null` as error code. Handle such situations by setting KCIDB test status to `None` as in this
situation we can't decide if the test actually could run or not.