### PR TITLE
src/send_kcidb: add `kbuild` failure error code

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -36,6 +36,7 @@ MISSED_TEST_CODES = (
     'RequestBodyTooLarge',
     'submit_error',
     'Unexisting permission codename.',
+    'kbuild_internal_error',
 )
 
 ERRORED_TEST_CODES = (


### PR DESCRIPTION
Add `kbuild_internal_error` to missed test error codes as it means that kernel build failed and test couldn't run.