### PR TITLE
config: jobs-chromeos: disable power.UtilCheck test

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -416,7 +416,6 @@ _anchors:
       tests:
         - power.CheckStatus
         - power.CpufreqConf
-        - power.UtilCheck
 
   tast-sound: &tast-sound-job
     <<: *tast-job


### PR DESCRIPTION
Initially I started investigating as it was failing only on Qualcomm targets. But as I investigated and made temporary fix in hardware_probe, I found out that this test fails on all the targets. Its just that its status gets marked as pass even though there are several warnings and missing directory structures for all other boards.

Let's disable this test as it only checks the hardware info which is closely tied with the chromeos. It doesn't run correctly on chromiumos.