### PR TITLE
Add CIP tree with default builds

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1787,9 +1787,6 @@ jobs:
 
 trees:
 
-  qcom:
-    url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
-
   amlogic:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git"
 
@@ -1826,11 +1823,11 @@ trees:
   clk:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git"
 
-  collabora-next:
-    url: 'https://gitlab.collabora.com/kernel/collabora-next.git'
-
   collabora-chromeos-kernel:
     url: 'https://gitlab.collabora.com/google/chromeos-kernel.git'
+
+  collabora-next:
+    url: 'https://gitlab.collabora.com/kernel/collabora-next.git'
 
   efi:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git"
@@ -1879,6 +1876,9 @@ trees:
 
   pm:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
+
+  qcom:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
 
   renesas:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -104,6 +104,7 @@ _anchors:
     - 'amlogic'
     - 'ardb'
     - 'arnd'
+    - 'cip'
     - 'clk'
     - 'efi'
     - 'khilman'
@@ -1820,6 +1821,9 @@ trees:
   chrome-platform:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git"
 
+  cip:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git"
+
   clk:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git"
 
@@ -3143,6 +3147,42 @@ build_configs:
   chrome-platform-firmware:
     tree: chrome-platform
     branch: 'for-firmware-next'
+
+  cip-4.4:
+    tree: cip
+    branch: 'linux-4.4.y-cip'
+
+  cip-4.4-rt:
+    tree: cip
+    branch: 'linux-4.4.y-cip-rt'
+
+  cip-4.4-st:
+    tree: cip
+    branch: 'linux-4.4.y-cip-st'
+
+  cip-4.19:
+    tree: cip
+    branch: 'linux-4.19.y-cip'
+
+  cip-4.19-rt:
+    tree: cip
+    branch: 'linux-4.19.y-cip-rt'
+
+  cip-5.10:
+    tree: cip
+    branch: 'linux-5.10.y-cip'
+
+  cip-5.10-rt:
+    tree: cip
+    branch: 'linux-5.10.y-cip-rt'
+
+  cip-6.1:
+    tree: cip
+    branch: 'linux-6.1.y-cip'
+
+  cip-6.1-rt:
+    tree: cip
+    branch: 'linux-6.1.y-cip-rt'
 
   clk:
     tree: clk

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2546,7 +2546,7 @@ scheduler:
 
   - job: kbuild-gcc-12-x86
     <<: *build-k8s-all
-  
+
   - job: kbuild-gcc-12-x86-allnoconfig
     <<: *build-k8s-all
 
@@ -2642,13 +2642,13 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - rk3399-gru-kevin
-  
+
   - job: ltp-smoketest
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
-  
+
   - job: ltp-timers
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime


### PR DESCRIPTION
Add CIP tree and the relevant branches as requested in https://github.com/kernelci/kernelci-core/issues/2711.

Currently this PR only adds basic build support.
We'll also need to tailor what is build, and what is tested...

Whilst at it, add in a couple of minor code fixups.