### PR TITLE
feat(service-names): Add service names for some pipeline services

### DIFF
--- a/docker-compose-kcidb.yaml
+++ b/docker-compose-kcidb.yaml
@@ -20,6 +20,7 @@ services:
       - '/home/kernelci/pipeline/send_kcidb.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+      - '--name=pipeline_kcidb'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,6 +126,7 @@ services:
       - './pipeline/tarball.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+      - '--name=tarball'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'
@@ -144,6 +145,7 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
       - '--trees=kernelci'
+      - '--name=trigger'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -217,6 +219,7 @@ services:
       - './pipeline/patchset.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
+      - '--name=patchset'
     volumes:
       - './src:/home/kernelci/pipeline'
       - './config:/home/kernelci/config'

--- a/kube/aks/pipeline-kcidb.yaml
+++ b/kube/aks/pipeline-kcidb.yaml
@@ -23,6 +23,7 @@ spec:
             - ./src/send_kcidb.py
             - --settings=/secrets/kernelci.toml
             - run
+            - --name=pipeline_kcidb
           env:
             - name: KCI_API_TOKEN
               valueFrom:

--- a/kube/aks/tarball.yaml
+++ b/kube/aks/tarball.yaml
@@ -35,6 +35,7 @@ spec:
             - --settings=/secrets/kernelci.toml
             - --yaml-config=/config
             - run
+            - --name=tarball
           env:
             - name: KCI_API_TOKEN
               valueFrom:

--- a/kube/aks/trigger.yaml
+++ b/kube/aks/trigger.yaml
@@ -29,7 +29,7 @@ spec:
             - --yaml-config=/config
             - run
             - --trees=!kernelci
-            #            - --force
+            - --name=trigger
           env:
             - name: KCI_API_TOKEN
               valueFrom:

--- a/src/patchset.py
+++ b/src/patchset.py
@@ -316,6 +316,10 @@ class cmd_run(Command):
     ]
     opt_args = [
         Args.verbose, Args.storage_cred,
+        {
+            'name': '--name',
+            'help': "Name of pipeline instance",
+        },
     ]
 
     def __call__(self, configs, args):

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -543,6 +543,10 @@ class cmd_run(Command):
             'help': "KCIDB project ID",
         },
         {
+            'name': '--name',
+            'help': "Name of pipeline instance",
+        },
+        {
             'name': '--origin',
             'help': "CI system identifier",
         },

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -257,6 +257,10 @@ class cmd_run(Command):
     ]
     opt_args = [
         Args.verbose, Args.storage_cred,
+        {
+            'name': '--name',
+            'help': "Name of pipeline instance",
+        },
     ]
 
     def __call__(self, configs, args):

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -163,6 +163,10 @@ class cmd_run(Command):
             'help': "List of build configurations to monitor",
         },
         {
+            'name': '--name',
+            'help': "Name of pipeline instance",
+        },
+        {
             'name': '--startup-delay',
             'type': int,
             'help': "Delay loop at startup by a number of seconds",


### PR DESCRIPTION
We have already defined name for some of services for logging purposes, and we can add more names and use it for namespace-enabled key-value API storage.