### PR TITLE
config: pipeline: Add minimum kernel version for nommu_k210_defconfig

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1274,6 +1274,9 @@ jobs:
       <<: *kbuild-gcc-12-riscv-params
       defconfig: nommu_k210_defconfig
     rules:
+      min_version:
+        version: 5
+        patchlevel: 10
       tree:
       - 'kernelci'
       - 'stable-rc'


### PR DESCRIPTION
The nommu_k210_defconfig config isn't present in two oldest stable kernels. Hence we get build errors. Add minimum version of the kernel to be 5.10 in which this configuration is present. I've only investigated this configuration option on stable kernels as this config is only being built on stable kernels.

close: https://github.com/kernelci/kernelci-pipeline/issues/857