### PR TITLE
fix(send_kcidb): Do not crash if optional field is missing

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -600,7 +600,8 @@ async def checkout(data: ManualCheckout, request: Request,
                 "tree": treename,
                 "branch": branch,
                 "commit": commit,
-                "url": treeurl
+                "url": treeurl,
+                "tip_of_branch": False
             }
         },
         "timeout": checkout_timeout.isoformat(),

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -141,11 +141,11 @@ class KCIDBBridge(Service):
             'git_repository_branch':
                 checkout_node['data']['kernel_revision']['branch'],
             'git_commit_tags':
-                checkout_node['data']['kernel_revision']['commit_tags'],
+                checkout_node['data']['kernel_revision'].get('commit_tags'),
             'git_commit_message':
-                checkout_node['data']['kernel_revision']['commit_message'],
+                checkout_node['data']['kernel_revision'].get('commit_message'),
             'git_repository_branch_tip':
-                checkout_node['data']['kernel_revision']['tip_of_branch'],
+                checkout_node['data']['kernel_revision'].get('tip_of_branch'),
             'start_time': self._set_timezone(checkout_node['created']),
             'patchset_hash': '',
             'misc': {


### PR DESCRIPTION
Some fields might be not present, as they are optional in model. Also add this field in custom checkout, even it is not mandatory, it is better to have it for consistency.