### PR TITLE
config: pipeline: Update CONFIG_FRAME_WARN for arm

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -301,6 +301,8 @@ jobs:
       defconfig:
         - defconfig
         - allmodconfig
+      fragments:
+        - 'CONFIG_FRAME_WARN=2048'
     rules:
       tree:
         - 'mainline'


### PR DESCRIPTION
CONFIG_FRAME_WARN is set to 1024 by default for arm. The allowed value for this is 0 to 8192. Let's increase it to 2048 to avoid getting the warning when stack size is more than default 1024. As all warnings are being treated as errors, our allmodconfig build fails on arm.

Close: https://github.com/kernelci/kernelci-project/issues/482