### PR TITLE
fix(lava_callback.py): Fix crash of lava_callback.py

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -277,7 +277,13 @@ async def callback(node_id: str, request: Request):
         item['message'] = 'Unauthorized'
         return JSONResponse(content=item, status_code=401)
 
-    data = await request.json()
+    try:
+        data = await request.json()
+    except Exception as e:
+        logging.error(f'Error decoding JSON: {e}')
+        item = {}
+        item['message'] = 'Error decoding JSON'
+        return JSONResponse(content=item, status_code=400)
     job_callback = kernelci.runtime.lava.Callback(data)
     api_config_name = job_callback.get_meta('api_config_name')
     api_token = os.getenv('KCI_API_TOKEN')


### PR DESCRIPTION
Stacktrace observed in production:
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/src/lava_callback.py", line 280, in callback
    data = await request.json()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/starlette/requests.py", line 251, in json
    body = await self.body()
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/starlette/requests.py", line 244, in body
    async for chunk in self.stream():
  File "/usr/local/lib/python3.11/site-packages/starlette/requests.py", line 238, in stream
    raise ClientDisconnect()
starlette.requests.ClientDisconnect

This should fix it and return error properly.