### PR TITLE
kube/aks/pipeline-kcidb: add `KCIDB_POSTGRESQL_PASSWORD` env

### DIFF
--- a/kube/aks/pipeline-kcidb.yaml
+++ b/kube/aks/pipeline-kcidb.yaml
@@ -32,6 +32,11 @@ spec:
                   key: token
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/kcidb-credentials.json
+            - name: KCIDB_POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kcidb-tokens
+                  key: kcidb-postgresql-password
           volumeMounts:
             - name: secrets
               mountPath: /secrets


### PR DESCRIPTION
Add secret env variable for KCIDB postgresql password used to connect to KCIDB database to fetch existing issues.