### PR TITLE
config: pipeline: Add compatible information for Raspberry Pi 4

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1992,6 +1992,7 @@ platforms:
     <<: *arm64-device
     mach: broadcom
     dtb: dtbs/broadcom/bcm2711-rpi-4-b.dtb
+    compatible: ['raspberrypi,4-model-b', 'brcm,bcm2711']
 
   # No job is being scheduled on these board as its infrastructure errors need to be fixed first.
   bcm2836-rpi-2-b:


### PR DESCRIPTION
Add compatible information for the Raspberry Pi 4.

Signed-off-by: Mark Brown <broonie@kernel.org>
