### PR TITLE
config: pipeline: Run tast test only on mainline and stable-rc only

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -58,6 +58,10 @@ _anchors:
     kind: job
     rules: *min-5_4-rules
     kcidb_test_suite: tast
+    rules:
+      tree:
+        - mainline
+        - stable-rc
 
   tast-debian: &tast-debian-job
     template: 'generic.jinja2'


### PR DESCRIPTION
Let's reduce the number of trees on which we execute tast tests. The stable-rc and mainline are of interest to us only. This'll help us getting cleaner data and devices would be more free to execute other tests.

Close: https://github.com/kernelci/kernelci-pipeline/issues/878