### PR TITLE
src/send_kcidb: use kcidb postgresql password from TOML

### DIFF
--- a/config/kernelci.toml
+++ b/config/kernelci.toml
@@ -43,6 +43,7 @@ database_name = "playground_kcidb"
 postgresql_host = "kernelci-pipeline-postgres-proxy"
 postgresql_port = 5432
 postgresql_user = "kernelci.org"
+# postgresql_password = "KCIDB-POSTGRESQL-USER-PASSWORD"
 origin = "maestro"
 
 [test_report]

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -69,7 +69,7 @@ class KCIDBBridge(Service):
         db_conn = (
             f"postgresql:dbname={args.database_name} "
             f"user={args.postgresql_user} host={args.postgresql_host} "
-            f"password={os.getenv('KCIDB_POSTGRESQL_PASSWORD')} "
+            f"password={args.postgresql_password} "
             f"port={args.postgresql_port}"
         )
         db_client = kcidb.db.Client(db_conn)
@@ -593,6 +593,26 @@ class cmd_run(Command):
         {
             'name': '--origin',
             'help': "CI system identifier",
+        },
+        {
+            'name': '--database-name',
+            'help': "KCIDB postgresql database instance name",
+        },
+        {
+            'name': '--postgresql-host',
+            'help': "KCIDB postgresql DB host",
+        },
+        {
+            'name': '--postgresql-port',
+            'help': "KCIDB postgresql DB port",
+        },
+        {
+            'name': '--postgresql-user',
+            'help': "Username for connecting to KCIDB postgresql DB",
+        },
+        {
+            'name': '--postgresql-password',
+            'help': "Password for connecting to KCIDB postgresql DB",
         },
     ]
 


### PR DESCRIPTION
In order to avoid using environment variables, use TOML file for KCIDB postgresql DB user password. Also, declare other existing args with `help` options in `cmd_run`.