### PR TITLE
fix(k8s/postgres-proxy): Fix deployment of postgres-proxy

### DIFF
--- a/kube/aks/kcidb-postgres-proxy.yaml
+++ b/kube/aks/kcidb-postgres-proxy.yaml
@@ -41,3 +41,15 @@ spec:
           secret:
             secretName: pipeline-secrets
       restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kernelci-pipeline-postgres
+  namespace: kernelci-pipeline
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: kernelci-pipeline-postgres


### PR DESCRIPTION
We need to define service, to be able to contact it by FQDN.