### PR TITLE
KCIDB: Send `misc.measurement` for tast tests

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -393,6 +393,7 @@ the test: {sub_path}")
             compatible = self._platforms[platform].compatible
 
         runtime = test_node['data'].get('runtime')
+        misc = test_node['data'].get('misc')
         parsed_test_node = {
             'build_id': build_id,
             'id': f"{origin}:{test_node['id']}",
@@ -405,6 +406,7 @@ in {runtime}",
                 'compatible': compatible,
                 'misc': {
                     'platform': platform,
+                    'measurement': misc.get('measurement') if misc else None
                 }
             },
             'waived': False,

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -389,6 +389,7 @@ the test: {sub_path}")
             build_id = f"{origin}:{build_node['id']}"
 
         platform = test_node['data'].get('platform')
+        compatible = None
         if platform:
             compatible = self._platforms[platform].compatible
 


### PR DESCRIPTION
Tast test `os-release` will contain chromeos version information in `node.data.misc.measurement` field.
Send the information to KCIDB.