### PR TITLE
config: jobs-chromeos: Remove LowPowerStateResidence

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -411,7 +411,6 @@ _anchors:
         - platform.Mtpd
         - platform.TPMResponsive
         - storage.HealthInfo
-        - storage.LowPowerStateResidence
 
   tast-power: &tast-power-job
     <<: *tast-job


### PR DESCRIPTION
This tests expects that the disk activity would be less 50%. But it is hard to guarantee this even in normal circumstances. I've confirmed that even in sanely booted chromiumos, there is disk activity. I've tried discussing it with the owner of this test, but no conclusion there as well. I've discussed with Denis and he agrees and suggest that we should disable this test.