### PR TITLE
v4l2-decoder: Remove media tree monitoring, add stable-rc_6.6

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -61,7 +61,8 @@ _anchors:
       <<: *min-5_4-rules
       tree:
         - mainline
-        - stable-rc
+        - collabora-chromeos-kernel
+        - stable
 
   tast-debian: &tast-debian-job
     template: 'generic.jinja2'
@@ -77,9 +78,8 @@ _anchors:
     rules:
       tree:
         - mainline
-        - next
         - collabora-chromeos-kernel
-        - media
+        - stable
 
   tast-basic: &tast-basic-job
     <<: *tast-job
@@ -464,7 +464,6 @@ _anchors:
         - mainline
         - next
         - collabora-chromeos-kernel
-        - media
 
   fluster-chromeos: &fluster-chromeos-job
     template: 'fluster-chromeos.jinja2'
@@ -479,7 +478,6 @@ _anchors:
         - mainline
         - next
         - collabora-chromeos-kernel
-        - media
 
   watchdog-reset: &watchdog-reset-job
     template: generic.jinja2

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -119,6 +119,7 @@ _anchors:
     - 'rppt'
     - 'sashal-next'
     - 'soc'
+    - 'stable'
     - 'tegra'
     - 'thermal'
     - 'tip'
@@ -1960,6 +1961,9 @@ trees:
   soc:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
 
+  stable:
+    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git'
+
   stable-rc:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git'
 
@@ -3474,6 +3478,10 @@ build_configs:
   soc_for-next:
     tree: soc
     branch: 'for-next'
+
+  stable_6.6:
+    tree: stable
+    branch: 'linux-6.6.y'
 
   stable-rc_4.19: &stable-rc
     tree: stable-rc

--- a/config/result-summary.yaml
+++ b/config/result-summary.yaml
@@ -870,7 +870,6 @@ monitor-fluster-debian-regressions:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
-          - tree: media
 
 monitor-fluster-debian-failures__runtime-errors:
   metadata:
@@ -887,7 +886,6 @@ monitor-fluster-debian-failures__runtime-errors:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
-          - tree: media
 
 summary-fluster-debian-regressions:
   metadata:
@@ -903,7 +901,6 @@ summary-fluster-debian-regressions:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
-          - tree: media
 
 summary-fluster-debian-failures__runtime-errors:
   metadata:
@@ -920,7 +917,6 @@ summary-fluster-debian-failures__runtime-errors:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
-          - tree: media
 
 summary-fluster-debian-failures:
   metadata:
@@ -937,7 +933,6 @@ summary-fluster-debian-failures:
           - tree: mainline
           - tree: next
           - tree: collabora-chromeos-kernel
-          - tree: media
 
 #### Failures and regressions in watchdog reset test
 


### PR DESCRIPTION
As per internal discussion (ref: https://issuetracker.google.com/issues/371638530 ), we will not monitor `media` branch for fluster/tast v4l2 decoder tests neither for ChromeOS or Debian rootfs. We will keep monitoring `next` branch for fluster tests for now and evaluate its value later. In addition, ChromeOS will stay in `stable-rc_6.6` and eventually `stable-rc_6.12`, so we will keep monitoring this branch.