### PR TITLE
src/send_kcidb: add new labs to LAVA labs mapping

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -55,6 +55,8 @@ lava_labs = {
     "lava-collabora": "https://lava.collabora.dev",
     "lava-collabora-early-access": "https://staging.lava.collabora.dev",
     "lava-collabora-staging": "https://staging.lava.collabora.dev",
+    "lava-cip": "https://lava.ciplatform.org/",
+    "lava-qualcomm": "https://lava.infra.foundries.io",
 }
 
 
@@ -359,6 +361,9 @@ the test: {sub_path}")
         if lab_url:
             job_url = lab_url + "/scheduler/job/" + data.get('job_id')
             data['job_url'] = job_url
+        elif 'lava' in data.get('runtime'):
+            self.log.warning(f"{node.get('id')} LAVA lab URL not found in the "
+                             f"mapping for runtime: {data.get('runtime')}")
         return data
 
     def _get_error_metadata(self, node):


### PR DESCRIPTION
Add recently enabled labs to LAVA lab mapping of lab name and URL to KCIDB bridge service. 
Also, add a warning print if lab URL mapping is not found for the specific lab.