### PR TITLE
config: pipeline: Disable baseline tests for arm android builds

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -268,7 +268,6 @@ jobs:
 
   baseline-arm: *baseline-job
   baseline-arm-broonie: *baseline-job
-  baseline-arm-android: *baseline-job
   baseline-arm-baylibre: *baseline-job
   baseline-arm-mfd: *baseline-job
   baseline-arm64: *baseline-job
@@ -2168,13 +2167,6 @@ scheduler:
       - odroid-xu3
       - rk3288-rock2-square
       - rk3288-veyron-jaq
-
-  - job: baseline-arm-android
-    event:
-      <<: *node-event
-      name: kbuild-gcc-12-arm-android
-    runtime: *lava-collabora-runtime
-    platforms: *collabora-arm-platforms
 
   - job: baseline-arm-baylibre
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
The arm android builds always fail to boot on arm targets. If we want to test this, we should get compatible devices first.

Close https://github.com/kernelci/kernelci-pipeline/issues/894
Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>