### PR TITLE
feat(pipeline.yaml): Add more k8s clusters for builds

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -186,6 +186,11 @@ runtimes:
     lab_type: kubernetes
     context:
       - 'aks-kbuild-medium-1'
+      - 'gke_android-kernelci-external_europe-west1-d_kci-eu-west1'
+      - 'gke_android-kernelci-external_europe-west4-c_kci-eu-west4'
+      - 'gke_android-kernelci-external_us-central1-c_kci-us-central1'
+      - 'gke_android-kernelci-external_us-east4-c_kci-big-us-east4'
+      - 'gke_android-kernelci-external_us-west1-a_kci-us-west1'
 
   k8s-gke-eu-west4:
     lab_type: kubernetes


### PR DESCRIPTION
As legacy builds disabled, we can use more build clusters.