### PR TITLE
docker/kcidb: fix logspec to a specific version

### DIFF
--- a/docker/kcidb/Dockerfile
+++ b/docker/kcidb/Dockerfile
@@ -10,4 +10,4 @@ MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 RUN pip install git+https://github.com/kernelci/kcidb.git
 
 # Install logspec
-RUN pip install git+https://github.com/kernelci/logspec.git
+RUN pip install git+https://github.com/kernelci/logspec.git@3ca649a4237aaed7ee8be3a8486f53301daeb109


### PR DESCRIPTION
Some cases will require the kcidb bridge to interpret results from logspec before creating issues and incidents. Fix logspec to a specific commit so we can control when to upgrade it. This allow us to upgrade logspec in the same commit we upgrade kcidb bridge to keep them in sync.