### PR TITLE
fix(tarball.py): Fix invalid filename

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -239,6 +239,8 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
                 config_branch,
                 describe
             ])
+            # replace / by _ in name
+            tarball_name = tarball_name.replace('/', '_')
             tarball_path = self._make_tarball(
                 self._service_config.kdir,
                 tarball_name


### PR DESCRIPTION
Any of filename components might contain /, which
will create additional directory, instead of filename. Replace / by _.