### PR TITLE
src/logspec_api: set code_culprit True

### DIFF
--- a/src/kernelci_pipeline/logspec_api.py
+++ b/src/kernelci_pipeline/logspec_api.py
@@ -114,6 +114,13 @@ def new_issue(logspec_error, object_type):
         'comment': comment,
         'misc': {
             'logspec': error_copy
+        },
+        # Set culprit_code to True by default
+        # OBS: this needs to be reviewed on every logspec upgrade
+        'culprit': {
+            'code': True,
+            'harness': False,
+            'tool': False
         }
     }
     if 'build_valid' in object_types[object_type]:


### PR DESCRIPTION
After reviewing the current version of logspec we are using, all the errors parsed are of type code, so set culprit_code: True