### PR TITLE
fix(send_kcidb.py): Limit nodes search to 1

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -542,7 +542,7 @@ in {runtime}",
             'state': 'done',
             'processed_by_kcidb_bridge': False,
             'created__gt': datetime.datetime.now() - datetime.timedelta(days=4)
-        })
+        }, limit=1)
         if nodes:
             return nodes[0]
         else:


### PR DESCRIPTION
If there is too many nodes it will significantly impact performance.