### PR TITLE
fix(send_kcidb.py): Use faster findfast function

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -538,11 +538,12 @@ in {runtime}",
         if self._last_unprocessed_search and \
                 time.time() - self._last_unprocessed_search < 30 * 60:
             return None
-        nodes = self._api.node.find({
+        nodes = self._api.node.findfast({
             'state': 'done',
             'processed_by_kcidb_bridge': False,
-            'created__gt': datetime.datetime.now() - datetime.timedelta(days=4)
-        }, limit=1)
+            'created__gt': datetime.datetime.now() - datetime.timedelta(days=4),
+            'limit': 1
+        })
         if nodes:
             return nodes[0]
         else:


### PR DESCRIPTION
find() is paginated function using .count that might cause significant load on API server. Use more efficient findfast() call.