### PR TITLE
Drop Runtimes filter on LAVA Scheduler in Docker-compose deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -94,13 +94,6 @@ services:
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'loop'
       - '--name=scheduler_lava'
-      - '--runtimes'
-      - 'lava-collabora'
-      - 'lava-collabora-staging'
-      - 'lava-broonie'
-      - 'lava-baylibre'
-      - 'lava-qualcomm'
-      - 'lava-cip'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
Scheduler is able to filter out Runtimes it will submit Jobs to with a "--runtimes" option. Even though the filter currently in use covers all the LAVA Runtimes available in the Pipeline config, using this filter may lead to missing some Job submissions in the future (if a new Runtime is not added to this list).

This patch drops this option to fall back to the default behaviour which is submitting Jobs to all the Runtimes available in the Pipeline config.

Docker-compose deployment is currently used on the Staging instance which limits its submissions by trigerring Jobs only on "kernelci" trees: https://github.com/kernelci/kernelci-pipeline/blob/54436dfff9786c4f5a827e94d8c9b7fe6fda12af/docker-compose.yaml#L147