### PR TITLE
Drop Runtimes filter on LAVA Scheduler in Kubernetes deployment

### DIFF
--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -29,10 +29,6 @@ spec:
             - --yaml-config=/config
             - loop
             - --name=scheduler_lava
-            - --runtimes
-            - lava-collabora
-            - lava-broonie
-            - lava-baylibre
           env:
             - name: KCI_API_TOKEN
               valueFrom:


### PR DESCRIPTION
Scheduler is able to filter out Runtimes it will submit Jobs to with a "--runtimes" option. The filter currently in use for Kubernetes deployment got out-of-sync with the LAVA Runtimes enabled in the Pipeline config.

This patch drops this option to fall back to the default behaviour which is submitting Jobs to all the Runtimes available in the Pipeline config.

Fixes: #925