### PR TITLE
fix(send_kcidb.py): Fix crash on missing platform

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -450,7 +450,11 @@ the test: {sub_path}")
         platform = test_node['data'].get('platform')
         compatible = None
         if platform:
-            compatible = self._platforms[platform].compatible
+            platformobj = self._platforms.get(platform)
+            if platformobj:
+                compatible = platformobj.compatible
+            else:
+                self.log.error(f"Platform {platform} not found in the platform list")
 
         runtime = test_node['data'].get('runtime')
         misc = test_node['data'].get('misc')


### PR DESCRIPTION
Fix crash:
  File "/home/kernelci/pipeline/src/base.py", line 69, in run
    status = self._run(context)
             ^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/send_kcidb.py", line 717, in _run
    self._get_test_data(node, context['origin'],
  File "/home/kernelci/pipeline/./src/send_kcidb.py", line 529, in _get_test_data
    test_node, build_node = self._parse_test_node(
                            ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/send_kcidb.py", line 453, in _parse_test_node
    compatible = self._platforms[platform].compatible
                 ~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'qcs6490'

And emit error instead.