### PR TITLE
Revert "Drop Runtimes filter on LAVA Scheduler in Kubernetes deployment"

### DIFF
--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -29,6 +29,10 @@ spec:
             - --yaml-config=/config
             - loop
             - --name=scheduler_lava
+            - --runtimes
+            - lava-collabora
+            - lava-broonie
+            - lava-baylibre
           env:
             - name: KCI_API_TOKEN
               valueFrom:


### PR DESCRIPTION
Reverts kernelci/kernelci-pipeline#937