### PR TITLE
Align LAVA Runtimes in Kubernetes deployment

### DIFF
--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -31,8 +31,11 @@ spec:
             - --name=scheduler_lava
             - --runtimes
             - lava-collabora
+            - lava-collabora-staging
             - lava-broonie
             - lava-baylibre
+            - lava-qualcomm
+            - lava-cip
           env:
             - name: KCI_API_TOKEN
               valueFrom:


### PR DESCRIPTION
This patch adds missing LAVA Labs to the LAVA Runtime Scheduler in Kubernetes deployment.

This approach is prone to get desynced again in future and will be replaced by a "lab_type" filter for Schedulers as a long-term solution.