### PR TITLE
Add h26forge tests in pipeline and scheduler

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1850,6 +1850,18 @@ jobs:
       sleep_params: mem freeze
     kcidb_test_suite: kernelci_sleep
 
+  h26forge-debian:
+    template: generic.jinja2
+    kind: job
+    params:
+      test_method: h26forge-debian
+      boot_commands: nfs
+      nfsroot: 'https://storage.staging.kernelci.org/rootfs/bookworm-gst-h26forge/20250109.0/{debarch}/'
+    rules:
+      tree:
+        - media
+    kcidb_test_suite: h26forge.debian
+
 trees:
 
   amlogic:
@@ -3137,6 +3149,13 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - acer-chromebox-cxi4-puff
+
+  - job: h26forge-debian
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - rk3399-gru-kevin
+      - rk3399-rock-pi-4b
 
 # -----------------------------------------------------------------------------
 # Legacy configuration data (still used by trigger service)


### PR DESCRIPTION
The goal is to run h26forge on platforms with h264 stateless decoders. So far only rk3399 and i.mx8mq got this kind of decoders. Only rk3399 is available in LAVA labs so limit the test to this device.