### PR TITLE
fix(k8s): Allocate memory for pods

### DIFF
--- a/kube/aks/monitor.yaml
+++ b/kube/aks/monitor.yaml
@@ -34,6 +34,10 @@ spec:
                 secretKeyRef:
                   name: kernelci-api-token
                   key: token
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "500m"
           volumeMounts:
             - name: secrets
               mountPath: /secrets

--- a/kube/aks/nodehandlers.yaml
+++ b/kube/aks/nodehandlers.yaml
@@ -35,6 +35,10 @@ spec:
                 secretKeyRef:
                   name: kernelci-api-token
                   key: token
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "500m"
           volumeMounts:
             - name: secrets
               mountPath: /secrets

--- a/kube/aks/pipeline-kcidb.yaml
+++ b/kube/aks/pipeline-kcidb.yaml
@@ -32,6 +32,10 @@ spec:
                   key: token
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/kcidb-credentials.json
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
           volumeMounts:
             - name: secrets
               mountPath: /secrets

--- a/kube/aks/regression.yaml
+++ b/kube/aks/regression.yaml
@@ -28,6 +28,10 @@ spec:
                 secretKeyRef:
                   name: kernelci-api-token
                   key: token
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
           volumeMounts:
             - name: secrets
               mountPath: /secrets

--- a/kube/aks/scheduler-k8s.yaml
+++ b/kube/aks/scheduler-k8s.yaml
@@ -38,6 +38,10 @@ spec:
                 secretKeyRef:
                   name: kernelci-api-token
                   key: token
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
           volumeMounts:
             - name: secrets
               mountPath: /secrets


### PR DESCRIPTION
Allocating (request) memory for pod will help to prevent unnecessary evictions.