### PR TITLE
config: pipeline: Update CONFIG_FRAME_WARN for i386

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1131,6 +1131,8 @@ jobs:
       defconfig:
         - i386_defconfig
         - allmodconfig
+      fragments:
+        - 'CONFIG_FRAME_WARN=2048'
     rules:
       tree:
       - 'mainline'


### PR DESCRIPTION
    config: pipeline: Update CONFIG_FRAME_WARN for i386
    
    CONFIG_FRAME_WARN is set to 1024 by default for i386. The allowed value
    for this is 0 to 8192. Let's increase it to 2048 to avoid getting the
    warning when stack size is more than default 1024. As all warnings are
    being treated as errors, our allmodconfig build fails.
    
    Example of a build failure:
    https://kcidb.kernelci.org/d/build/build?var-datasource=edquppk2ghfcwc&var-origin=maestro&var-build_architecture=$__all&var-build_config_name=$__all&var-id=maestro:6772ceda423acf18d263ca6b&var-test-path=boot&from=now-100y&to=now&timezone=browser&var-test_path=&var-issue_presence=yes
    
    Related https://github.com/kernelci/kernelci-pipeline/pull/870
    Close https://github.com/kernelci/kernelci-project/issues/482
    Signed-off-by: Muhammad Usama Anjum <usama.anjum@collabora.com>