### PR TITLE
config: pipeline: Limit target trees/branches for Chromebook tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -491,6 +491,10 @@ _anchors:
       test_method: watchdog-reset
       bl_message: 'coreboot-'
       wdt_dev: 'watchdog0'
+    rules:
+      tree:
+        - mainline
+        - stable-rc
     kcidb_test_suite: kernelci_watchdog_reset
 
   wifi-basic: &wifi-basic-job
@@ -503,7 +507,7 @@ _anchors:
     rules:
       tree:
         - mainline
-        - next
+        - stable-rc
     kcidb_test_suite: kernelci_wifi_basic
 
 jobs:
@@ -512,6 +516,10 @@ jobs:
     template: baseline.jinja2
     kind: job
     kcidb_test_suite: boot
+    rules:
+      tree:
+        - mainline
+        - stable-rc
 
   baseline-arm64-qualcomm-chromebook: *baseline-job
 
@@ -522,6 +530,10 @@ jobs:
       boot_commands: nfs
       nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
     kcidb_test_suite: boot.nfs
+    rules:
+      tree:
+        - mainline
+        - stable-rc
 
   baseline-nfs-arm64-qualcomm-chromebook: *baseline-nfs-job
   baseline-nfs-x86-amd-chromebook: *baseline-nfs-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -508,14 +508,14 @@ _anchors:
 
 jobs:
 
-  baseline-arm64-mediatek: &baseline-job
+  baseline-arm64-mediatek-chromebook: &baseline-job
     template: baseline.jinja2
     kind: job
     kcidb_test_suite: boot
 
-  baseline-arm64-qualcomm: *baseline-job
+  baseline-arm64-qualcomm-chromebook: *baseline-job
 
-  baseline-nfs-arm64-mediatek: &baseline-nfs-job
+  baseline-nfs-arm64-mediatek-chromebook: &baseline-nfs-job
     template: baseline.jinja2
     kind: job
     params:
@@ -523,12 +523,12 @@ jobs:
       nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
     kcidb_test_suite: boot.nfs
 
-  baseline-nfs-arm64-qualcomm: *baseline-nfs-job
-  baseline-nfs-x86-amd: *baseline-nfs-job
-  baseline-nfs-x86-intel: *baseline-nfs-job
-  baseline-x86-amd: *baseline-job
-  baseline-x86-amd-staging: *baseline-job
-  baseline-x86-intel: *baseline-job
+  baseline-nfs-arm64-qualcomm-chromebook: *baseline-nfs-job
+  baseline-nfs-x86-amd-chromebook: *baseline-nfs-job
+  baseline-nfs-x86-intel-chromebook: *baseline-nfs-job
+  baseline-x86-amd-chromebook: *baseline-job
+  baseline-x86-amd-staging-chromebook: *baseline-job
+  baseline-x86-intel-chromebook: *baseline-job
 
   kbuild-gcc-12-arm64-chromebook:
     <<: *kbuild-gcc-12-arm64-chromeos-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1518,9 +1518,10 @@ jobs:
       nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20241007.0/{debarch}'
       collections: cpufreq
       job_timeout: 10
-    rules:
+    rules: &kselftest-rules
       tree:
-      - '!android'
+        - mainline
+        - stable-rc
     kcidb_test_suite: kselftest.cpufreq
 
   kselftest-cpufreq-hibernate:
@@ -1530,8 +1531,10 @@ jobs:
       collections: cpufreq
       env: 'KSELFTEST_MAIN_SH_ARGS="-t hibernate_rtc"'
     rules:
-      tree:
-      - 'kernelci:staging-next'
+      <<: *kselftest-rules
+      min_version:
+        version: 6
+        patchlevel: 12
     kcidb_test_suite: kselftest.cpufreq.hibernate
 
   kselftest-cpufreq-suspend:
@@ -1541,8 +1544,10 @@ jobs:
       collections: cpufreq
       env: 'KSELFTEST_MAIN_SH_ARGS="-t suspend_rtc"'
     rules:
-      tree:
-      - 'kernelci:staging-next'
+      <<: *kselftest-rules
+      min_version:
+        version: 6
+        patchlevel: 12
     kcidb_test_suite: kselftest.cpufreq.suspend
 
   kselftest-devices-exist:
@@ -1564,8 +1569,7 @@ jobs:
       collections: devices/probe
       env: "KSELFTEST_TEST_DISCOVERABLE_DEVICES_PY_ARGS=--boards-dir=/opt/platform-test-parameters/kselftest/test_discoverable_devices/boards/"
     rules:
-      tree:
-      - '!android'
+      <<: *kselftest-rules
       min_version:
         version: 6
         patchlevel: 11
@@ -1584,8 +1588,7 @@ jobs:
       <<: *kselftest-params
       collections: dt
     rules:
-      tree:
-      - '!android'
+      <<: *kselftest-rules
       min_version:
         version: 6
         patchlevel: 7

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -108,46 +108,46 @@ _anchors:
 
 scheduler:
 
-  - job: baseline-arm64-mediatek
+  - job: baseline-arm64-mediatek-chromebook
     <<: *test-job-arm64-mediatek
 
-  - job: baseline-arm64-qualcomm
+  - job: baseline-arm64-qualcomm-chromebook
     <<: *test-job-arm64-qualcomm
 
-  - job: baseline-arm64-mediatek
+  - job: baseline-arm64-mediatek-chromebook
     <<: *test-job-chromeos-mediatek
 
-  - job: baseline-arm64-qualcomm
+  - job: baseline-arm64-qualcomm-chromebook
     <<: *test-job-chromeos-qualcomm
 
-  - job: baseline-nfs-arm64-mediatek
+  - job: baseline-nfs-arm64-mediatek-chromebook
     <<: *test-job-arm64-mediatek
 
-  - job: baseline-nfs-arm64-mediatek
+  - job: baseline-nfs-arm64-mediatek-chromebook
     <<: *test-job-chromeos-mediatek
 
-  - job: baseline-nfs-arm64-qualcomm
+  - job: baseline-nfs-arm64-qualcomm-chromebook
     <<: *test-job-arm64-qualcomm
 
-  - job: baseline-nfs-arm64-qualcomm
+  - job: baseline-nfs-arm64-qualcomm-chromebook
     <<: *test-job-chromeos-qualcomm
 
-  - job: baseline-nfs-x86-amd
+  - job: baseline-nfs-x86-amd-chromebook
     <<: *test-job-chromeos-amd
 
-  - job: baseline-nfs-x86-amd
+  - job: baseline-nfs-x86-amd-chromebook
     <<: *test-job-x86-amd
 
-  - job: baseline-nfs-x86-intel
+  - job: baseline-nfs-x86-intel-chromebook
     <<: *test-job-chromeos-intel
 
-  - job: baseline-nfs-x86-intel
+  - job: baseline-nfs-x86-intel-chromebook
     <<: *test-job-x86-intel
 
-  - job: baseline-x86-amd
+  - job: baseline-x86-amd-chromebook
     <<: *test-job-chromeos-amd
 
-  - job: baseline-x86-amd-staging
+  - job: baseline-x86-amd-staging-chromebook
     <<: *test-job-chromeos-amd
     runtime:
       type: lava
@@ -155,13 +155,13 @@ scheduler:
     platforms:
     - dell-latitude-3445-7520c-skyrim
 
-  - job: baseline-x86-amd
+  - job: baseline-x86-amd-chromebook
     <<: *test-job-x86-amd
 
-  - job: baseline-x86-intel
+  - job: baseline-x86-intel-chromebook
     <<: *test-job-chromeos-intel
 
-  - job: baseline-x86-intel
+  - job: baseline-x86-intel-chromebook
     <<: *test-job-x86-intel
 
   - job: kbuild-gcc-12-arm64-chromebook


### PR DESCRIPTION
Currently, most tests on Chromebooks run across all available tree/branch combinations. Restrict these tests to stable-rc and mainline trees to simplify monitoring while still identifying relevant regressions.