### PR TITLE
Enable baseline test for Genio 700 and 1200 EVK boards

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2104,6 +2104,12 @@ platforms:
   # No job is being scheduled on this board as its infrastructure errors need to be fixed first.
   minnowboard-turbot-E3826: *x86_64-device
 
+  mt8390-genio-700-evk:
+    <<: *arm64-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8390-genio-700-evk.dtb
+    compatible: ['mediatek,mt8390-evk', 'mediatek,mt8390', 'mediatek,mt8188']
+
   odroid-xu3:
     <<: *arm-device
     mach: samsung
@@ -2251,6 +2257,7 @@ scheduler:
     platforms: &collabora-arm64-platforms
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
+      - mt8390-genio-700-evk
       - rk3399-gru-kevin
       - rk3399-rock-pi-4b
       - rk3588-rock-5b

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -60,6 +60,8 @@ _anchors:
       compiler: gcc-12
       cross_compile: 'aarch64-linux-gnu-'
       defconfig: defconfig
+      fragments:
+        - 'lab-setup'
 
   kbuild-gcc-12-x86-job: &kbuild-gcc-12-x86-job
     <<: *kbuild-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2110,6 +2110,12 @@ platforms:
     dtb: dtbs/mediatek/mt8390-genio-700-evk.dtb
     compatible: ['mediatek,mt8390-evk', 'mediatek,mt8390', 'mediatek,mt8188']
 
+  mt8395-genio-1200-evk:
+    <<: *arm64-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8395-genio-1200-evk.dtb
+    compatible: ['mediatek,mt8395-evk', 'mediatek,mt8395', 'mediatek,mt8195']
+
   odroid-xu3:
     <<: *arm-device
     mach: samsung
@@ -2258,6 +2264,7 @@ scheduler:
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
       - mt8390-genio-700-evk
+      - mt8395-genio-1200-evk
       - rk3399-gru-kevin
       - rk3399-rock-pi-4b
       - rk3588-rock-5b


### PR DESCRIPTION
This PR describes the Genio 700 and 1200 EVK boards and enables the baseline test for them.

Additionally, it adds the 'lab-setup' configuration fragment to the `kbuild-gcc-12-arm64-job` in order to avoid deferred probe timeout issues that make the boot fail on those boards. The fragment is added in the generic arm64 build since it should avoid similar issues on other platforms as well.

Genio 700 EVK boot on linux-next: https://lava.collabora.dev/scheduler/job/17371995
Genio 1200 EVK boot on linux-next: https://lava.collabora.dev/scheduler/job/17372467
