### PR TITLE
config: pipeline: Enable baseline tests for Genio 350 EVK board

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2115,6 +2115,12 @@ platforms:
   # No job is being scheduled on this board as its infrastructure errors need to be fixed first.
   minnowboard-turbot-E3826: *x86_64-device
 
+  mt8365-genio-350-evk:
+    <<: *arm64-device
+    mach: mediatek
+    dtb: dtbs/mediatek/mt8365-evk.dtb
+    compatible: ['mediatek,mt8365-evk', 'mediatek,mt8365']
+
   mt8390-genio-700-evk:
     <<: *arm64-device
     mach: mediatek
@@ -2274,6 +2280,7 @@ scheduler:
     platforms: &collabora-arm64-platforms
       - bcm2711-rpi-4-b
       - meson-g12b-a311d-khadas-vim3
+      - mt8365-genio-350-evk
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
       - rk3399-gru-kevin


### PR DESCRIPTION
Example run: https://lava.collabora.dev/scheduler/job/17504017