### PR TITLE
config: pipeline: Enable kselftest-dt on Genio 700 and 1200 EVK boards

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2820,6 +2820,8 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+      - mt8390-genio-700-evk
+      - mt8395-genio-1200-evk
 
   - job: kselftest-net
     event: *kbuild-gcc-12-x86-node-event


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2786

Genio 700: https://lava.collabora.dev/scheduler/job/17514678
Genio 1200: https://lava.collabora.dev/scheduler/job/17514841