### PR TITLE
Enable cpufreq tests on Genio 700 and 1200 EVK

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2844,6 +2844,12 @@ scheduler:
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
 
+  - job: kselftest-cpufreq-suspend
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - mt8390-genio-700-evk
+
 #  - job: kunit
 #    event: *checkout-event
 #    runtime:

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2837,6 +2837,13 @@ scheduler:
       - rk3399-rock-pi-4b
       - sun50i-h6-pine-h64
 
+  - job: kselftest-cpufreq
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - mt8390-genio-700-evk
+      - mt8395-genio-1200-evk
+
 #  - job: kunit
 #    event: *checkout-event
 #    runtime:


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2786.

Enable the kselftest cpufreq on Genio 700 EVK and Genio 1200 EVK.

Also enable the kselftest-cpufreq-suspend test on the Genio 700. The Genio 1200 fails to resume so the test is not enabled there for the time being.

Cpufreq  on genio 1200: https://lava.collabora.dev/scheduler/job/17514853
Cpufreq on genio 700: https://lava.collabora.dev/scheduler/job/17514861
Suspend on genio 700: https://lava.collabora.dev/scheduler/job/17514864