### PR TITLE
Enable device error logs kselftest on Genio 700 and 1200 EVK boards

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -3076,6 +3076,13 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm64
 
+  - job: kselftest-device-error-logs-main
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-collabora-runtime
+    platforms:
+      - mt8390-genio-700-evk
+      - mt8395-genio-1200-evk
+
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1653,6 +1653,13 @@ jobs:
         - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.devices-exist
 
+  kselftest-device-error-logs-main:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: devices/error_logs
+    kcidb_test_suite: kselftest.device_error_logs
+
   kselftest-devices-probe:
     <<: *kselftest-job
     params:


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2786.

Genio 700: https://lava.collabora.dev/scheduler/job/17515212
Genio 1200: https://lava.collabora.dev/scheduler/job/17515224