### PR TITLE
config: runtime: baseline: drop running dmesg.sh script

### DIFF
--- a/config/runtime/baseline.jinja2
+++ b/config/runtime/baseline.jinja2
@@ -3,5 +3,5 @@
 {%- extends base_template %}
 
 {% block commands %}
-KERNELCI_LAVA=y /bin/sh /opt/kernelci/dmesg.sh
+echo 'Hello World!'
 {%- endblock %}


### PR DESCRIPTION
Baseline tests will now just indicate reaching the state of successful boot. No other test case will be executed there (for the time being).

String: "Hello World!" as a mark of successful boot was chosen to comply with programming tradition but can be safely replaced with anything else (easily distinguishable from boot logs).