### PR TITLE
upd(scheduler-chromeos.yaml): Disable debian decoder chromestack jobs

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -372,11 +372,11 @@ scheduler:
   - job: tast-decoder-chromestack-verification-arm64-mediatek
     <<: *test-job-chromeos-mediatek
 
-  - job: tast-debian-decoder-chromestack-arm64-mediatek
-    <<: *test-job-chromeos-mediatek
+#  - job: tast-debian-decoder-chromestack-arm64-mediatek
+#    <<: *test-job-chromeos-mediatek
 
-  - job: tast-debian-decoder-chromestack-verification-arm64-mediatek
-    <<: *test-job-chromeos-mediatek
+#  - job: tast-debian-decoder-chromestack-verification-arm64-mediatek
+#    <<: *test-job-chromeos-mediatek
 
   - job: tast-decoder-chromestack-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
@@ -384,11 +384,11 @@ scheduler:
   - job: tast-decoder-chromestack-verification-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
 
-  - job: tast-debian-decoder-chromestack-arm64-qualcomm
-    <<: *test-job-chromeos-qualcomm
+#  - job: tast-debian-decoder-chromestack-arm64-qualcomm
+#    <<: *test-job-chromeos-qualcomm
 
-  - job: tast-debian-decoder-chromestack-verification-arm64-qualcomm
-    <<: *test-job-chromeos-qualcomm
+  #- job: tast-debian-decoder-chromestack-verification-arm64-qualcomm
+#    <<: *test-job-chromeos-qualcomm
 
   - job: tast-decoder-chromestack-arm64-qualcomm-pre6_7
     <<: *test-job-chromeos-qualcomm


### PR DESCRIPTION
This jobs need optimization, they run over 7 hours and not completing.