### PR TITLE
Enable Pengutronix lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2065,6 +2065,13 @@ platforms:
     dtb: dtbs/imx6dl-udoo.dtb
     compatible: ['udoo,imx6dl-udoo', 'fsl,imx6dl']
 
+  imx6dl-riotboard:
+    <<: *arm-device
+    boot_method: barebox
+    mach: imx
+    dtb: dtbs/imx6dl-riotboard.dtb
+    compatible: ['riot,imx6s-riotboard', 'fsl,imx6dl']
+
   imx6q-sabrelite:
     <<: *arm-device
     mach: imx
@@ -2311,6 +2318,7 @@ scheduler:
       type: lava
       name: lava-pengutronix
     platforms:
+      - imx6dl-riotboard
       - stm32mp157c-lxa-tac-gen1
 
   - job: baseline-arm64

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -287,6 +287,7 @@ jobs:
   baseline-arm-broonie: *baseline-job
   baseline-arm-baylibre: *baseline-job
   baseline-arm-mfd: *baseline-job
+  baseline-arm-pengutronix: *baseline-job
   baseline-arm64: *baseline-job
   baseline-arm64-android: *baseline-job
   baseline-arm64-broonie: *baseline-job
@@ -2230,6 +2231,13 @@ platforms:
     compatible: ['arrow,stm32mp157a-avenger96', 'dh,stm32mp157a-dhcor-som',
                      'st,stm32mp157']
 
+  stm32mp157c-lxa-tac-gen1:
+    <<: *arm-device
+    boot_method: barebox
+    mach: st
+    dtb: dtbs/stm32mp157c-lxa-tac-gen1.dtb
+    compatible: ['lxa,stm32mp157c-tac-gen1', 'oct,stm32mp15xx-osd32', 'st,stm32mp157']
+
   sun7i-a20-cubieboard2:
     <<: *arm-device
     mach: allwinner
@@ -2296,6 +2304,14 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - imx6q-sabrelite
+
+  - job: baseline-arm-pengutronix
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: &lava-pengutronix-runtime
+      type: lava
+      name: lava-pengutronix
+    platforms:
+      - stm32mp157c-lxa-tac-gen1
 
   - job: baseline-arm64
     event: &kbuild-gcc-12-arm64-node-event
@@ -2365,9 +2381,7 @@ scheduler:
 
   - job: baseline-arm64-pengutronix
     event: *kbuild-gcc-12-arm64-node-event
-    runtime:
-      type: lava
-      name: lava-pengutronix
+    runtime: *lava-pengutronix-runtime
     platforms:
       - imx8mm-innocomm-wb15-evk
       - imx8mp-tqma8mpql-mba8mpxl

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2089,6 +2089,13 @@ platforms:
     dtb: dtbs/freescale/imx8mp-evk.dtb
     compatible: ["fsl,imx8mp-evk", "fsl,imx8mp"]
 
+  imx8mp-tqma8mpql-mba8mpxl:
+    <<: *arm64-device
+    boot_method: barebox
+    mach: imx
+    dtb: dtbs/freescale/imx8mp-tqma8mpql-mba8mpxl.dtb
+    compatible: ['tq,imx8mp-tqma8mpql-mba8mpxl', 'tq,imx8mp-tqma8mpql', 'fsl,imx8mp']
+
   imx8mp-verdin-nonwifi-dahlia:
     <<: *arm64-device
     mach: imx
@@ -2363,6 +2370,7 @@ scheduler:
       name: lava-pengutronix
     platforms:
       - imx8mm-innocomm-wb15-evk
+      - imx8mp-tqma8mpql-mba8mpxl
 
   - job: baseline-arm64-qualcomm
     event: *kbuild-gcc-12-arm64-node-event

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -2059,6 +2059,13 @@ platforms:
 
   docker:
 
+  imx53-qsrb:
+    <<: *arm-device
+    boot_method: barebox
+    mach: imx
+    dtb: dtbs/imx53-qsrb.dtb
+    compatible: ['fsl,imx53-qsrb', 'fsl,imx53']
+
   imx6dl-udoo:
     <<: *arm-device
     mach: imx
@@ -2318,6 +2325,7 @@ scheduler:
       type: lava
       name: lava-pengutronix
     platforms:
+      - imx53-qsrb
       - imx6dl-riotboard
       - stm32mp157c-lxa-tac-gen1
 

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -293,6 +293,7 @@ jobs:
   baseline-arm64-kcidebug-mediatek: *baseline-job
   baseline-arm64-kcidebug-qualcomm: *baseline-job
   baseline-arm64-mfd: *baseline-job
+  baseline-arm64-pengutronix: *baseline-job
   baseline-arm64-qualcomm: *baseline-job
   baseline-x86: *baseline-job
   baseline-x86-baylibre: *baseline-job
@@ -2075,6 +2076,13 @@ platforms:
     dtb: dtbs/imx6q-udoo.dtb
     compatible: ['udoo,imx6q-udoo', 'fsl,imx6q']
 
+  imx8mm-innocomm-wb15-evk:
+    <<: *arm64-device
+    boot_method: barebox
+    mach: imx
+    dtb: dtbs/freescale/imx8mm-innocomm-wb15-evk.dtb
+    compatible: ['innocomm,wb15-evk', 'fsl,imx8mm']
+
   imx8mp-evk:
     <<: *arm64-device
     mach: imx
@@ -2347,6 +2355,14 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: baseline-arm64-pengutronix
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-pengutronix
+    platforms:
+      - imx8mm-innocomm-wb15-evk
 
   - job: baseline-arm64-qualcomm
     event: *kbuild-gcc-12-arm64-node-event

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -254,6 +254,15 @@ runtimes:
       callback:
         token: kernelci-api-token-lava-staging
 
+  lava-pengutronix:
+    lab_type: lava
+    url: 'https://lava.pengutronix.de'
+    priority_min: 10
+    priority_max: 40
+    notify:
+      callback:
+        token: kernel-ci-callback
+
   lava-qualcomm:
     lab_type: lava
     url: 'https://lava.infra.foundries.io'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -101,6 +101,7 @@ services:
       - 'lava-baylibre'
       - 'lava-qualcomm'
       - 'lava-cip'
+      - 'lava-pengutronix'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
This is an updated version of #673.

What I have changed:

- Rebase on top of recent `origin/main`.
- Use `https://lava.pengutronix.de` instead of `https://hekla.openlab.pengutronix.de`. They point to the same host, but the former is more descriptive.
- Add a `compatible:` entry to `platform:` `imx8mm-innocomm-wb15-evk:` since the other platforms have it.

Fixes: https://github.com/kernelci/kernelci-project/issues/387
Closes: https://github.com/kernelci/kernelci-pipeline/pull/673

This is just a minimalistic PR to revive the Pengutronix Lab at all. I will also open a follow-up PR soon that adds other devices from our lab, like `stm32mp157c-lxa-tac-gen1`, which is also mentioned in #673.