### PR TITLE
src/logspec_api: ignore errors of type linux.kernel.error_return_code

### DIFF
--- a/docker/kcidb/Dockerfile
+++ b/docker/kcidb/Dockerfile
@@ -10,4 +10,4 @@ MAINTAINER "KernelCI TSC" <kernelci-tsc@groups.io>
 RUN pip install git+https://github.com/kernelci/kcidb.git
 
 # Install logspec
-RUN pip install git+https://github.com/kernelci/logspec.git@e9316545d73877c301336656d06c18dad36d1e17
+RUN pip install git+https://github.com/kernelci/logspec.git@3421f63da61d80d00a4497a915d19520285f5020

--- a/src/kernelci_pipeline/logspec_api.py
+++ b/src/kernelci_pipeline/logspec_api.py
@@ -227,6 +227,11 @@ def generate_issues_and_incidents(result_id, log_url, object_type, oo_client):
     error_list, new_status = process_log(log_url, parser, start_state)
     for error in error_list:
         if error and error['error'].get('signature'):
+            # do not generate issues for error_return_code since they are not
+            # fatal, avoid noise.
+            if error['error'].get('error_type') == 'linux.kernel.error_return_code':
+                continue
+
             issue = new_issue(error, object_type)
             parsed_data['issue_node'].append(issue)
             issue_id = issue["id"]


### PR DESCRIPTION
 do not generate issues for error_return_code since they are not
fatal, avoid noise.