### PR TITLE
config/pipeline.yaml: Enable the arm64 selftests in my lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1555,6 +1555,15 @@ jobs:
         - stable
     kcidb_test_suite: kselftest.aaa
 
+  kselftest-arm64:
+    <<: *kselftest-job
+    template: generic.jinja2
+    kind: job
+    params:
+      <<: *kselftest-params
+      collections: arm64
+    kcidb_test_suite: kselftest.arm64
+
   kselftest-cpufreq:
     <<: *kselftest-job
     template: generic.jinja2
@@ -2849,6 +2858,11 @@ scheduler:
 
   - job: kbuild-gcc-12-x86-tinyconfig
     <<: *build-k8s-all
+
+  - job: kselftest-arm64
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm64
 
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
Running them on every single board in my lab is probably excessive but
we can deal with that if it gets to be an issue.

Signed-off-by: Mark Brown <broonie@kernel.org>
