### PR TITLE
config/pipeline.yaml: Enable the KVM selftests on my arm64 boards

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1648,6 +1648,13 @@ jobs:
       collections: iommu
     kcidb_test_suite: kselftest.iommu
 
+  kselftest-kvm:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: kvm
+    kcidb_test_suite: kselftest.kvm
+
   kselftest-net:
     <<: *kselftest-job
     params:
@@ -2867,6 +2874,13 @@ scheduler:
       - bcm2711-rpi-4-b
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
+
+  - job: kselftest-kvm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm64
 
 #  - job: kselftest-net
 #    event: *kbuild-gcc-12-x86-node-event


### PR DESCRIPTION
We should really refine this to cover pKVM on at least some of the
systems that support this (currently just the i.MX8MP platforms), that
requires extra command line options and potentially some work on
reporting.

Signed-off-by: Mark Brown <broonie@kernel.org>
