### PR TITLE
upd(pipeline.yaml): Add aaptel tree for NVME-TCP offload

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1916,6 +1916,9 @@ jobs:
 
 trees:
 
+  aaptel:
+    url: "https://github.com/aaptel/linux.git"
+
   amlogic:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git"
 
@@ -3308,6 +3311,10 @@ build_variants:
 
 
 build_configs:
+
+  aaptel:
+    tree: aaptel
+    branch: 'nvme-rx-offload-v25'
 
   amlogic:
     tree: amlogic


### PR DESCRIPTION
We need to test nvme-tcp offload feature, but until we integrate latest netdev trees, let's use this specific tree where latest version published.