### PR TITLE
config/pipeline.yaml: Enable the LTP smoke tests on BeagleBone Black

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -3062,6 +3062,12 @@ scheduler:
       - rk3399-gru-kevin
 
   - job: ltp-smoketest
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: ltp-smoketest
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:


### PR DESCRIPTION
Add coverage of the LTP smoke tests on 32 bit Arm using the BeagleBone
Blacks in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
