### PR TITLE
config/pipeline.yaml: Enable clone3 selftests in my lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1575,6 +1575,13 @@ jobs:
       collections: arm64
     kcidb_test_suite: kselftest.arm64
 
+  kselftest-clone3:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: clone3
+    kcidb_test_suite: kselftest.clone3
+
   kselftest-cpufreq:
     <<: *kselftest-job
     template: generic.jinja2
@@ -2946,6 +2953,18 @@ scheduler:
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm64
+
+  - job: kselftest-clone3
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-clone3
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - meson-gxl-s905x-libretech-cc
 
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
These are pure software tests so just run them on one board per
architecture, picking boards with a reasonable amount of capacity.

Signed-off-by: Mark Brown <broonie@kernel.org>
