### PR TITLE
config/pipelie.yaml: Enable signal selftests in my lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1684,6 +1684,13 @@ jobs:
       skipfile: https://storage.kernelci.org/skipfile-net.yaml
     kcidb_test_suite: kselftest.net
 
+  kselftest-signal:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: signal
+    kcidb_test_suite: kselftest.signal
+
   kselftest-timers:
     <<: *kselftest-job
     params:
@@ -3001,6 +3008,18 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - meson-gxl-s905x-libretech-cc
+      - sun50i-h5-libretech-all-h3-cc
+
+  - job: kselftest-signal
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-signal
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
       - sun50i-h5-libretech-all-h3-cc
 
   - job: kselftest-cpufreq


### PR DESCRIPTION
The signal selftests are pure software tests, enable them on one board
with reasonable capacity for each architecture.

Signed-off-by: Mark Brown <broonie@kernel.org>
