### PR TITLE
config/pipeline.yaml: Build the kselftest fragment for more trees

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -442,6 +442,10 @@ jobs:
     rules: &kbuild-kselftest-rules
       tree:
         - 'kselftest'
+        - 'mainline'
+        - 'next'
+        - 'stable'
+        - 'stable-rc'
       fragments:
         - kselftest
 


### PR DESCRIPTION
A lot of the kselftests require config options which are enabled in their
config fragments and incorporated into the kselftest build but currently we
only build that for the kselftest tree, meaning that we don't get the test
coverage for these. Enable build for the main upstream trees too so we can
run these tests.

Signed-off-by: Mark Brown <broonie@kernel.org>
