### PR TITLE
Minor updates for netdev git and ddp testing

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1575,6 +1575,7 @@ jobs:
     rules:
       tree:
         - aaptel
+        - netdev-testing
     kcidb_test_suite: blktests-ddp
 
   # Named so it sorts before all the actual kselftests, we need to

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -3926,7 +3926,7 @@ build_configs:
 
   netdev-testing:
     tree: netdev-testing
-    branch: 'https://netdev.bots.linux.dev/static/nipa/branches.json'
+    branch: 'https://netdev.bots.linux.dev/static/nipa/branches-hw.json'
 
   next_master:
     tree: next


### PR DESCRIPTION
We update URL where branches retrieved and also enable blktest-ddp (nvme-tcp offload) to netdev testing.