### PR TITLE
send_kcidb: add 'lab' field to misc data submitted

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -277,6 +277,7 @@ class KCIDBBridge(Service):
             'misc': {
                 'platform': node['data'].get('platform'),
                 'runtime': node['data'].get('runtime'),
+                'lab': node['data'].get('runtime'),
                 'job_id': node['data'].get('job_id'),
                 'job_context': node['data'].get('job_context'),
                 'kernel_type': node['data'].get('kernel_type'),


### PR DESCRIPTION
Today the Maestro lab is sent through the 'runtime' field, but that name is not that great for labs. Let's add a 'lab' field, but wait a bit to remove the 'runtime' field, so we can transition some KCIDB queries without any trouble.