### PR TITLE
config/pipeline.yaml: Enable LTP coverage on my BeagleBone Blacks

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -3314,6 +3314,18 @@ scheduler:
     runtime:
       type: shell
 
+  - job: ltp-cap-bounds
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: ltp-crypto
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: ltp-crypto
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-collabora-runtime
@@ -3333,16 +3345,40 @@ scheduler:
       - rk3399-gru-kevin
 
   - job: ltp-fsx
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: ltp-fsx
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: ltp-ipc
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: ltp-pty
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: ltp-pty
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:
       - rk3399-gru-kevin
+
+  - job: ltp-sched
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: ltp-smoketest
     event: *kbuild-gcc-12-arm-node-event
@@ -3355,6 +3391,12 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: ltp-timers
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: ltp-timers
     event: *kbuild-gcc-12-arm64-node-event


### PR DESCRIPTION
I've got a lot of BeagleBone Black boards in my lab with plenty of spare
capacity, enable a lot of the LTP suites on them to give us more 32 bit
Arm coverage. There are some suites like the hugetlb one which don't make
sense on this architecture, and the board has relatively little memory so
the mm suite might also be an issue.

Signed-off-by: Mark Brown <broonie@kernel.org>
