### PR TITLE
config/pipeline.yaml: Enable the IPC selftests in my lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1742,6 +1742,13 @@ jobs:
       collections: iommu
     kcidb_test_suite: kselftest.iommu
 
+  kselftest-ipc:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: ipc
+    kcidb_test_suite: kselftest.ipc
+
   kselftest-kvm:
     <<: *kselftest-job
     params:
@@ -3182,6 +3189,22 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - beaglebone-black
+
+  - job: kselftest-ipc
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-ipc
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - sun50i-h5-libretech-all-h3-cc
 
   - job: kselftest-kvm
     event:


### PR DESCRIPTION
More mostly software only selftests so just enabled on one platform per
architecture.

Signed-off-by: Mark Brown <broonie@kernel.org>
