### PR TITLE
fix(trigger.py): Fix build config parameter overwrite

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -133,7 +133,8 @@ class Trigger(Service):
                                timeout, trees):
         for name, config in self._build_configs.items():
             if not build_configs_list or name in build_configs_list:
-                self._run_trigger(config, force, timeout, trees)
+                cfg_copy = config.copy()
+                self._run_trigger(cfg_copy, force, timeout, trees)
 
     def _setup(self, args):
         return {


### PR DESCRIPTION
We should not overwrite original build config, so on next iteration we fetch fresh NIPA branch.