### PR TITLE
config/pipeline.yaml: Add user_events selftests in my lab

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1800,6 +1800,13 @@ jobs:
       collections: timers
     kcidb_test_suite: kselftest.timers
 
+  kselftest-user-events:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: user_events
+    kcidb_test_suite: kselftest.user_events
+
   kselftest-vdso:
     <<: *kselftest-job
     params:
@@ -3282,6 +3289,22 @@ scheduler:
 
   - job: kselftest-signal
     event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - sun50i-h5-libretech-all-h3-cc
+
+  - job: kselftest-user-events
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-user-events
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
     runtime: *lava-broonie-runtime
     platforms:
       - sun50i-h5-libretech-all-h3-cc


### PR DESCRIPTION
Yet more software only selftests, enabled on one board per architecture.

Signed-off-by: Mark Brown <broonie@kernel.org>
