### PR TITLE
Fix overwriting build config for dynamically changing branches

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -7,6 +7,7 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 # Author: Nikolay Yurin <yurinnick@meta.com>
 
+import copy
 from datetime import datetime, timedelta
 import os
 import re
@@ -58,8 +59,9 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
             if config.tree.name == tree and config.branch == branch:
                 return config
             if config.tree.name == tree and config.branch.startswith('http'):
-                config._branch = branch
-                return config
+                current = copy.copy(config)
+                current._branch = branch
+                return current
 
     def _find_build_commit(self, node):
         revision = node['data'].get('kernel_revision')

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -6,6 +6,7 @@
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
+import copy
 from datetime import datetime, timedelta
 import json
 import logging
@@ -44,20 +45,21 @@ class Trigger(Service):
                 return
 
         try:
-            if validate_url(build_config.branch):
-                response = requests.get(build_config.branch)
+            current_config = copy.copy(build_config)
+            if validate_url(current_config.branch):
+                response = requests.get(current_config.branch)
                 # Following extractor supports only NIPA JSON scheme.
                 # Adding support for other schemas will force moving it to a separate function.
                 branches = response.json()
                 latest = sorted(branches, key=lambda x: x['date'], reverse=True)[0]
-                tree = build_config.tree.name
+                tree = current_config.tree.name
                 self.log.info(f"NIPA Latest branch: {latest['branch']} Date: {latest['date']}"
                               f" Tree: {tree}")
-                build_config._branch = latest['branch']
+                current_config._branch = latest['branch']
 
-            head_commit = kernelci.build.get_branch_head(build_config)
+            head_commit = kernelci.build.get_branch_head(current_config)
         except Exception as ex:
-            self.log.error(f"Failed to get branch head for {build_config.name:32s}")
+            self.log.error(f"Failed to get branch head for {current_config.name:32s}")
             self.traceback(ex)
             return
         search_terms = {
@@ -74,7 +76,7 @@ class Trigger(Service):
         # it means we retry the same commit 3 times and it still fails
         if incomplete_node_count >= 3:
             self._log_revision(
-                "Too many incomplete checkouts", build_config, head_commit
+                "Too many incomplete checkouts", current_config, head_commit
             )
             return
 
@@ -82,22 +84,22 @@ class Trigger(Service):
         if node_count > 0 and incomplete_node_count != node_count:
             if force:
                 self._log_revision(
-                    "Resubmitting existing revision", build_config, head_commit
+                    "Resubmitting existing revision", current_config, head_commit
                 )
             else:
                 self._log_revision(
-                    "Existing revision", build_config, head_commit
+                    "Existing revision", current_config, head_commit
                 )
                 return
         else:
             self._log_revision(
-                "New revision", build_config, head_commit
+                "New revision", current_config, head_commit
             )
 
         revision = {
-            'tree': build_config.tree.name,
-            'url': build_config.tree.url,
-            'branch': build_config.branch,
+            'tree': current_config.tree.name,
+            'url': current_config.tree.url,
+            'branch': current_config.branch,
             'commit': head_commit,
         }
         checkout_timeout = datetime.utcnow() + timedelta(minutes=timeout)


### PR DESCRIPTION
This patch creates copies of BuildConfig objects so that the initial values are not changed. This way dynamic branch triggers (external JSON resources) are not replaced with static branch names after first request.

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/1047