### PR TITLE
docker-compose: remove obsolete 'version' attribute

### DIFF
--- a/docker-compose-kcidb.yaml
+++ b/docker-compose-kcidb.yaml
@@ -3,8 +3,6 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-version: '3'
-
 services:
 
   kcidb:

--- a/docker-compose-lava.yaml
+++ b/docker-compose-lava.yaml
@@ -3,8 +3,6 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-version: '3'
-
 services:
 
   lava-callback:

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -3,8 +3,6 @@
 # Copyright (C) 2023 Collabora Limited
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 
-version: '3'
-
 services:
 
   lava-callback:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,6 @@
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
-version: '3'
-
 services:
 
   monitor: &base-service


### PR DESCRIPTION
Fix this warning:
WARN[0000] kernelci-pipeline/docker-compose.yaml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion