### PR TITLE
fix(send_kcidb.py): Send full config name to KCIDB

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -272,7 +272,7 @@ class KCIDBBridge(Service):
             'start_time': self._set_timezone(node['created']),
             'architecture': node['data'].get('arch'),
             'compiler': node['data'].get('compiler'),
-            'config_name': node['data'].get('defconfig'),
+            'config_name': node['data'].get('config_full'),
             'valid': valid,
             'misc': {
                 'platform': node['data'].get('platform'),


### PR DESCRIPTION
KCIDB need to be able to see full config name, not just defconfig.

Fixes: https://github.com/kernelci/kernelci-pipeline/issues/1011