### PR TITLE
config/pipeline.yaml: Enable more LTP on my Beaglebone Blacks

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1865,6 +1865,18 @@ jobs:
       <<: *ltp-params
       tst_cmdfiles: "cap_bounds"
 
+  ltp-containers:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "containers"
+
+  ltp-controllers:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "controllers"
+
   ltp-cpuhotplug:
     <<: *ltp-job
     params:
@@ -1880,6 +1892,13 @@ jobs:
       fragments:
         - 'crypto'
         - '!kselftest'
+
+  ltp-cve:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "cve"
+      job_timeout: 45
 
   ltp-dio:
     <<: *ltp-job
@@ -1898,6 +1917,30 @@ jobs:
     params:
       <<: *ltp-params
       tst_cmdfiles: "filecaps"
+
+  ltp-fs:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "fs"
+
+  ltp-fs-bind:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "fs_bind"
+
+  ltp-fs-perms-simple:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "fs_perms_simple"
+
+  ltp-fs-readonly:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "fs_readonly"
 
   ltp-fsx:
     <<: *ltp-job
@@ -1920,6 +1963,12 @@ jobs:
       fragments:
         - 'ima'
         - '!kselftest'
+
+  ltp-input:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "input"
 
   ltp-io:
     <<: *ltp-job
@@ -1966,6 +2015,12 @@ jobs:
       tst_cmdfiles: "syscalls"
       job_timeout: 120
 
+  ltp-syscalls-ipc:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "syscalls"
+
   ltp-timers:
     <<: *ltp-job
     params:
@@ -1985,6 +2040,12 @@ jobs:
         - 'defconfig'
       fragments:
         - '!kselftest'
+
+  ltp-watchqueue:
+    <<: *ltp-job
+    params:
+      <<: *ltp-params
+      tst_cmdfiles: "watchqueue"
 
   rt-tests: &rt-tests
     template: rt-tests.jinja2
@@ -3439,6 +3500,18 @@ scheduler:
     platforms:
       - beaglebone-black
 
+  - job: ltp-containers
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: ltp-controllers
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: ltp-crypto
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime
@@ -3450,6 +3523,12 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - imx6q-sabrelite
+
+  - job: ltp-cve
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: ltp-dio
     event: *kbuild-gcc-12-arm-node-event
@@ -3463,6 +3542,12 @@ scheduler:
     platforms:
       - rk3399-gru-kevin
 
+  - job: ltp-fs-bind
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: ltp-fsx
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime
@@ -3474,6 +3559,12 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: ltp-input
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: ltp-ipc
     event: *kbuild-gcc-12-arm-node-event
@@ -3511,6 +3602,12 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
 
+  - job: ltp-syscalls-ipc
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: ltp-timers
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime
@@ -3529,6 +3626,12 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - qemu-x86
+
+  - job: ltp-watchqueue
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
 
   - job: rt-tests-cyclicdeadline
     event: &kbuild-gcc-12-arm64-preempt_rt-node-event


### PR DESCRIPTION
Add job stanzas for a lot of LTP suites we don't already cover and use the
spare capacity we have on Beaglebone Black in my lab to run a lot more of
LTP. Since the boards use NFS root, have only one CPU and limited memory
there are a bunch of suites that aren't appropriate but this is most of
them.

Signed-off-by: Mark Brown <broonie@kernel.org>
