### PR TITLE
config/pipeline.yaml: Disable KUnit tests on chromiumos tree

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1847,6 +1847,9 @@ jobs:
     kind: job
     image: ghcr.io/kernelci/{image_prefix}gcc-12:x86-kunit-kernelci
     kcidb_test_suite: kunit
+    rules:
+      tree:
+      - '!chromiumos'
 
   kunit-x86_64:
     <<: *kunit-job


### PR DESCRIPTION
KUnit tests are enabled by default on all trees. Since a different set of initial tests will be enabled on the chromiumos tree, disable KUnit tests for now.