### PR TITLE
config: trees: Add media-committers tree with next and fixes branches

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -81,6 +81,9 @@ trees:
   media:
     url: 'https://git.linuxtv.org/media.git'
 
+  media-committers:
+    url: 'https://gitlab.freedesktop.org/linux-media/media-committers.git'
+
   mediatek:
     url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git'
 
@@ -457,6 +460,14 @@ build_configs:
 
   media_next:
     tree: media
+    branch: 'next'
+
+  media-committers_fixes:
+    tree: media-committers
+    branch: 'fixes'
+
+  media-committers_next:
+    tree: media-committers
     branch: 'next'
 
   mediatek_for_next:


### PR DESCRIPTION
Trees added by this PR were requested to be tested with `fluster-debian` Jobs. Currently there are up to 7 of them (depending on the hardware the tests are executed on):
```
$ grep -r "job: fluster.debian" config/ | sort -u
scheduler-chromeos.yaml:  - job: fluster-debian-av1
scheduler-chromeos.yaml:  - job: fluster-debian-av1-chromium-10bit
scheduler-chromeos.yaml:  - job: fluster-debian-h264
scheduler-chromeos.yaml:  - job: fluster-debian-h264-frext
scheduler-chromeos.yaml:  - job: fluster-debian-h265
scheduler-chromeos.yaml:  - job: fluster-debian-vp8
scheduler-chromeos.yaml:  - job: fluster-debian-vp9
```

All these Jobs are triggered by a KBuild Event `kbuild-gcc-12-arm64-chromebook` which has no run restrictions (`rules:` section) as of writing this comment.

Checkout Events on newly added trees should trigger `fluster.debian*` Jobs automatically.