### PR TITLE
config: Fix name of juno-uboot

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -113,7 +113,7 @@ platforms:
                  'toradex,verdin-imx8mp-nonwifi',
                  'toradex,verdin-imx8mp',
                  'fsl,imx8mp']
-  juno:
+  juno-uboot:
     <<: *arm64-device
     mach: vexpress
     dtb: dtbs/arm/juno.dtb

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -119,7 +119,7 @@ scheduler:
       - bcm2837-rpi-3-b-plus
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
-      - juno
+      - juno-uboot
       - meson-g12b-a311d-libretech-cc
       - meson-gxl-s905x-libretech-cc
       - meson-sm1-s905d3-libretech-cc


### PR DESCRIPTION
The entry for Juno is not actually causing any jobs to be scheduled on the
Juno in my lab since due to a hardware failure that stops EDK2 working it
has fixed u-boot firmware and is registered as 'juno-uboot'. Since KernelCI
matches on this name using 'juno' results in no jobs being scheduled. Fix
that, adjust to say 'juno-uboot'. A 'juno' entry can be re-added if we get
any fully flexible Junos.
