### PR TITLE
config: jobs-chromeos: Fix rules override for Tast decoder tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -742,25 +742,35 @@ jobs:
 
   tast-decoder-chromestack-arm64-qualcomm:
     <<: *tast-decoder-chromestack-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-debian-decoder-chromestack-arm64-qualcomm:
     <<: *tast-debian-decoder-chromestack-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-decoder-chromestack-verification-arm64-qualcomm:
     <<: *tast-decoder-chromestack-verification-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-debian-decoder-chromestack-verification-arm64-qualcomm:
     <<: *tast-debian-decoder-chromestack-verification-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-decoder-chromestack-arm64-qualcomm-pre6_7:
     <<: *tast-decoder-chromestack-job
     params:
       <<: *tast-decoder-chromestack-params
-    rules: *max-6_6-rules
+      rules:
+        <<: *tast-decoder-rules
+        <<: *max-6_6-rules
 
   tast-decoder-chromestack-verification-arm64-qualcomm-pre6_7:
     <<: *tast-decoder-chromestack-verification-job
@@ -773,27 +783,35 @@ jobs:
         # Qualcomm-specific: those always fail with pre-6.7 kernels
         - video.ChromeStackDecoderVerification.vp9_0_group1_frm_resize
         - video.ChromeStackDecoderVerification.vp9_0_group1_sub8x8_sf
-    rules: *max-6_6-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
 
   tast-debian-decoder-chromestack-arm64-qualcomm-pre6_7:
     <<: *tast-debian-decoder-chromestack-job
     params:
       <<: *tast-decoder-chromestack-params
-    rules: *max-6_6-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
 
   tast-debian-decoder-chromestack-verification-arm64-qualcomm-pre6_7:
     <<: *tast-debian-decoder-chromestack-verification-job
     params:
       <<: *tast-decoder-chromestack-verification-params
       excluded_tests: *tast-decoder-chromestack-verification-arm64-qualcomm-pre6_7-excluded_tests
-    rules: *max-6_6-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
 
   tast-debian-decoder-chromestack-verification-arm64-qualcomm-pre6_7:
     <<: *tast-debian-decoder-chromestack-verification-job
     params:
       <<: *tast-decoder-chromestack-verification-params
       excluded_tests: *tast-decoder-chromestack-verification-arm64-qualcomm-pre6_7-excluded_tests
-    rules: *max-6_6-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
 
   tast-decoder-chromestack-x86-amd: *tast-decoder-chromestack-job
   tast-decoder-chromestack-x86-intel: *tast-decoder-chromestack-job
@@ -817,11 +835,15 @@ jobs:
 
   tast-decoder-v4l2-sf-vp9-arm64-qualcomm:
     <<: *tast-decoder-v4l2-sf-vp9-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-debian-decoder-v4l2-sf-vp9-arm64-qualcomm:
     <<: *tast-debian-decoder-v4l2-sf-vp9-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7:
     <<: *tast-decoder-v4l2-sf-vp9-job
@@ -836,23 +858,31 @@ jobs:
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group3_sub8x8_sf
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_frm_resize
         - video.PlatformDecoding.v4l2_stateful_vp9_0_group4_sub8x8_sf
-    rules: *max-6_6-rules
-
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
+  
   tast-debian-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7:
     <<: *tast-debian-decoder-v4l2-sf-vp9-job
     params:
       <<: *tast-decoder-v4l2-sf-vp9-params
       excluded_tests: *tast-decoder-v4l2-sf-vp9-arm64-qualcomm-pre6_7-excluded_tests
-    rules: *max-6_6-rules
-
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
+  
   tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm:
     <<: *tast-decoder-v4l2-sf-vp9-extra-job
-    rules: *min-6_7-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
 
   tast-debian-decoder-v4l2-sf-vp9-extra-arm64-qualcomm:
     <<: *tast-debian-decoder-v4l2-sf-vp9-extra-job
-    rules: *min-6_7-rules
-
+    rules:
+      <<: *tast-decoder-rules
+      <<: *min-6_7-rules
+    
   tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7:
     <<: *tast-decoder-v4l2-sf-vp9-extra-job
     params:
@@ -860,14 +890,18 @@ jobs:
       excluded_tests: &tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7-excluded_tests
         - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_0_frm_resize
         - video.PlatformDecoding.v4l2_stateful_vp9_0_level5_0_sub8x8_sf
-    rules: *max-6_6-rules
-
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
+    
   tast-debian-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7:
     <<: *tast-decoder-v4l2-sf-vp9-extra-job
     params:
       <<: *tast-decoder-v4l2-sf-vp9-extra-params
       excluded_tests: *tast-decoder-v4l2-sf-vp9-extra-arm64-qualcomm-pre6_7-excluded_tests
-    rules: *max-6_6-rules
+    rules:
+      <<: *tast-decoder-rules
+      <<: *max-6_6-rules
 
   tast-decoder-v4l2-sl-av1-arm64-mediatek: *tast-decoder-v4l2-sl-av1-job
   tast-decoder-v4l2-sl-h264-arm64-mediatek: *tast-decoder-v4l2-sl-h264-job


### PR DESCRIPTION
The current rules override in the Tast decoder test job definition only considers the minimum kernel version, ignoring the existing tree-specific rules. Reintroduce the tree rules.