### PR TITLE
config: Run only fluster-debian Jobs on media-committers tree

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -546,7 +546,7 @@ jobs:
       <<: *kbuild-clang-17-x86-chromeos-params
       flavour: intel-pineview
 
-  kbuild-gcc-12-arm64-chromebook:
+  kbuild-gcc-12-arm64-chromebook: &kbuild-gcc-12-arm64-chromebook-job
     <<: *kbuild-gcc-12-arm64-chromeos-job
     params:
       <<: *kbuild-gcc-12-arm64-chromeos-params
@@ -557,6 +557,14 @@ jobs:
       tree:
         - '!android'
         - '!chromiumos'
+        - '!media-committers'
+
+  kbuild-gcc-12-arm64-chromebook-media-committers:
+    <<: *kbuild-gcc-12-arm64-chromebook-job
+    # Don't copy parent Job rules because they would get overwritten anyway
+    rules:
+      tree:
+        - 'media-committers'
 
   kbuild-gcc-12-arm64-chromeos-mediatek:
     <<: *kbuild-gcc-12-arm64-chromeos-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -51,15 +51,25 @@ _anchors:
 
   test-job-arm64-mediatek: &test-job-arm64-mediatek
     <<: *lava-job-collabora
-    event:
+    event: &test-job-arm64-mediatek-event
       channel: node
       name: kbuild-gcc-12-arm64-chromebook
       result: pass
       kind: kbuild
     platforms: *mediatek-platforms
 
+  test-job-arm64-mediatek-media-committers: &test-job-arm64-mediatek-media-committers
+    <<: *test-job-arm64-mediatek
+    event:
+      <<: *test-job-arm64-mediatek-event
+      name: kbuild-gcc-12-arm64-chromebook-media-committers
+
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm
     <<: *test-job-arm64-mediatek
+    platforms: *qualcomm-platforms
+
+  test-job-arm64-qualcomm: &test-job-arm64-qualcomm-media-committers
+    <<: *test-job-arm64-mediatek-media-committers
     platforms: *qualcomm-platforms
 
   test-job-chromeos-amd: &test-job-chromeos-amd
@@ -569,6 +579,56 @@ scheduler:
 
   - job: fluster-debian-vp9
     <<: *test-job-arm64-qualcomm
+
+  - job: fluster-debian-av1
+    <<: *test-job-arm64-mediatek-media-committers
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-debian-av1-chromium-10bit
+    <<: *test-job-arm64-mediatek-media-committers
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-debian-h264
+    <<: *test-job-arm64-mediatek-media-committers
+
+  - job: fluster-debian-h264-frext
+    <<: *test-job-arm64-mediatek-media-committers
+
+  - job: fluster-debian-h265
+    <<: *test-job-arm64-mediatek-media-committers
+    platforms:
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-debian-vp8
+    <<: *test-job-arm64-mediatek-media-committers
+    platforms:
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-debian-vp9
+    <<: *test-job-arm64-mediatek-media-committers
+    platforms:
+      - mt8186-corsola-steelix-sku131072
+      - mt8192-asurada-spherion-r0
+      - mt8195-cherry-tomato-r2
+
+  - job: fluster-debian-h264
+    <<: *test-job-arm64-qualcomm-media-committers
+
+  - job: fluster-debian-h264-frext
+    <<: *test-job-arm64-qualcomm-media-committers
+
+  - job: fluster-debian-h265
+    <<: *test-job-arm64-qualcomm-media-committers
+
+  - job: fluster-debian-vp8
+    <<: *test-job-arm64-qualcomm-media-committers
+
+  - job: fluster-debian-vp9
+    <<: *test-job-arm64-qualcomm-media-committers
 
   - job: watchdog-reset-arm64-mediatek
     <<: *test-job-arm64-mediatek


### PR DESCRIPTION
This patch creates a separate KBuild Job for media-committers tree to exclude it from the base "kbuild-gcc-12-arm64-chromebook" kernel build one.

Duplicated base KBuild Job will run only for media-committers tree and will trigger only fluster-debian tests. Other tests could create noise when verifying media-committers changes.

Scheduler entries had to be duplicated to use the new triggering event.