### PR TITLE
(platforms.yaml): Add fake qcs6490 entry, due error in kcidb bridge

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -179,6 +179,15 @@ platforms:
     dtb: dtbs/exynos5422-odroidxu3.dtb
     compatible: ['hardkernel,odroid-xu3', 'samsung,exynos5800', 'samsung,exynos5']
 
+  # TODO: verify why this platform appears in test results
+  # probably mistake and its same as qcs6490-rb3gen2
+  qcs6490:
+    <<: *arm64-device
+    boot_method: fastboot
+    mach: qcom
+    dtb: dtbs/qcom/qcs6490-rb3gen2.dtb
+    compatible: ['qcom,qcs6490-rb3gen2', 'qcom,qcm6490']
+
   qcs6490-rb3gen2:
     <<: *arm64-device
     boot_method: fastboot


### PR DESCRIPTION
We have error:
03/08/2025 10:49:50 AM UTC [ERROR] Platform qcs6490 not found in the platform list

Probably someone submitting alias name of device or like that, as we have similar entry in platforms. For now i will just copy this entry, to remove error.