### PR TITLE
config/scheduler.yaml: Offload some arm64 jobs onto Raspberry Pi 3+

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -866,8 +866,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2711-rpi-4-b
-      - meson-gxl-s905x-libretech-cc
-      - sun50i-h5-libretech-all-h3-cc
+      - bcm2837-rpi-3-b-plus
 
   - job: kselftest-seccomp
     event:
@@ -883,7 +882,7 @@ scheduler:
       name: kbuild-gcc-12-arm64-kselftest
     runtime: *lava-broonie-runtime
     platforms:
-      - sun50i-h5-libretech-all-h3-cc
+      - bcm2837-rpi-3-b-plus
 
   - job: kselftest-signal
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
Since the NFS issues have a fix on their way to -next offload some of the
longer running test jobs from other boards to the Raspberry Pi 3+s in my
lab to balance out capacity. The boards concerned are all four cour Cortex
A53s so there should be no meaningful coverage impact when everything is
running.

Signed-off-by: Mark Brown <broonie@kernel.org>
