### PR TITLE
config: Lower the frequency of chromiumos builds to 1/day

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -5,6 +5,7 @@ _anchors:
       defconfig: 'cros://chromeos-{krev}/{crosarch}/chromiumos-{flavour}.flavour.config'
       flavour: '{crosarch}-generic'
       kselftest: disable
+      frequency: 1d
 
   kbuild-clang-17-arm64-chromeos: &kbuild-clang-17-arm64-chromeos-job
     template: kbuild.jinja2
@@ -56,6 +57,7 @@ _anchors:
     rules: &kbuild-gcc-12-arm64-chromeos-rules
       tree:
       - '!android'
+      - '!chromiumos'
 
   kbuild-gcc-12-x86-chromeos: &kbuild-gcc-12-x86-chromeos-job
     <<: *kbuild-gcc-12-arm64-chromeos-job
@@ -73,6 +75,7 @@ _anchors:
     rules: &kbuild-gcc-12-x86-chromeos-rules
       tree:
       - '!android'
+      - '!chromiumos'
 
   min-5_4-rules: &min-5_4-rules
     min_version:
@@ -609,7 +612,7 @@ jobs:
   baseline-x86-amd-staging-chromebook: *baseline-job
   baseline-x86-intel-chromebook: *baseline-job
 
-  kbuild-clang-17-arm64-chromeos-mediatek:
+  kbuild-clang-17-arm64-chromeos-daily-mediatek:
     <<: *kbuild-clang-17-arm64-chromeos-job
     params:
       <<: *kbuild-clang-17-arm64-chromeos-params
@@ -620,7 +623,7 @@ jobs:
         - '!chromiumos:chromeos-5.4'
         - '!chromiumos:chromeos-6.6'
 
-  kbuild-clang-17-arm64-chromeos-qualcomm:
+  kbuild-clang-17-arm64-chromeos-daily-qualcomm:
     <<: *kbuild-clang-17-arm64-chromeos-job
     params:
       <<: *kbuild-clang-17-arm64-chromeos-params
@@ -630,7 +633,7 @@ jobs:
       branch:
         - 'chromeos-6.6'
 
-  kbuild-clang-17-x86-chromeos-amd:
+  kbuild-clang-17-x86-chromeos-daily-amd:
     <<: *kbuild-clang-17-x86-chromeos-job
     params:
       <<: *kbuild-clang-17-x86-chromeos-params
@@ -642,7 +645,7 @@ jobs:
         - '!chromiumos:chromeos-6.1'
         - '!chromiumos:chromeos-6.12'
 
-  kbuild-clang-17-x86-chromeos-intel:
+  kbuild-clang-17-x86-chromeos-daily-intel:
     <<: *kbuild-clang-17-x86-chromeos-job
     params:
       <<: *kbuild-clang-17-x86-chromeos-params
@@ -662,7 +665,7 @@ jobs:
 
   kbuild-gcc-12-arm64-chromeos-mediatek:
     <<: *kbuild-gcc-12-arm64-chromeos-job
-    params:
+    params: &kbuild-gcc-12-arm64-chromeos-mediatek-params
       <<: *kbuild-gcc-12-arm64-chromeos-params
       flavour: mediatek
     rules:
@@ -670,26 +673,53 @@ jobs:
       min_version:
         version: 6
         patchlevel: 1
+  
+  kbuild-gcc-12-arm64-chromeos-daily-mediatek:
+    <<: *kbuild-gcc-12-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-arm64-chromeos-mediatek-params
+      frequency: 1d
+    rules:
+      <<: *kbuild-gcc-12-arm64-chromeos-rules
+      tree:
+        - 'chromiumos'
       branch:
-      - '!chromiumos:chromeos-6.6'
+        - '!chromiumos:chromeos-5.4'
+        - '!chromiumos:chromeos-6.6'
 
   kbuild-gcc-12-arm64-chromeos-qualcomm:
     <<: *kbuild-gcc-12-arm64-chromeos-job
-    params:
+    params: &kbuild-gcc-12-arm64-chromeos-qualcomm-params
       <<: *kbuild-gcc-12-arm64-chromeos-params
       flavour: qualcomm
+
+  kbuild-gcc-12-arm64-chromeos-daily-qualcomm:
+    <<: *kbuild-gcc-12-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-arm64-chromeos-qualcomm-params
+      frequency: 1d
     rules:
       <<: *kbuild-gcc-12-arm64-chromeos-rules
+      tree:
+        - 'chromiumos'
       branch:
-      - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.6'
 
   kbuild-gcc-12-x86-chromeos-amd:
     <<: *kbuild-gcc-12-x86-chromeos-job
-    params:
+    params: &kbuild-gcc-12-x86-chromeos-amd-params
       <<: *kbuild-gcc-12-x86-chromeos-params
       flavour: amd-stoneyridge
+
+  kbuild-gcc-12-x86-chromeos-daily-amd:
+    <<: *kbuild-gcc-12-x86-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-x86-chromeos-amd-params
+      frequency: 1d
     rules:
       <<: *kbuild-gcc-12-x86-chromeos-rules
+      tree:
+        - 'chromiumos'
       branch:
         - '!chromiumos:chromeos-5.15'
         - '!chromiumos:chromeos-6.1'
@@ -697,9 +727,19 @@ jobs:
 
   kbuild-gcc-12-x86-chromeos-intel:
     <<: *kbuild-gcc-12-x86-chromeos-job
-    params:
+    params: &kbuild-gcc-12-x86-chromeos-intel-params
       <<: *kbuild-gcc-12-x86-chromeos-params
       flavour: intel-pineview
+
+  kbuild-gcc-12-x86-chromeos-daily-intel:
+    <<: *kbuild-gcc-12-x86-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-x86-chromeos-intel-params
+      frequency: 1d
+    rules:
+      <<: *kbuild-gcc-12-x86-chromeos-rules
+      tree:
+        - 'chromiumos'
 
   kselftest-acpi:
     template: generic.jinja2

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -170,16 +170,16 @@ scheduler:
   - job: baseline-x86-intel-chromebook
     <<: *test-job-x86-intel
 
-  - job: kbuild-clang-17-arm64-chromeos-mediatek
+  - job: kbuild-clang-17-arm64-chromeos-daily-mediatek
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-arm64-chromeos-qualcomm
+  - job: kbuild-clang-17-arm64-chromeos-daily-qualcomm
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-x86-chromeos-amd
+  - job: kbuild-clang-17-x86-chromeos-daily-amd
     <<: *build-k8s-all
 
-  - job: kbuild-clang-17-x86-chromeos-intel
+  - job: kbuild-clang-17-x86-chromeos-daily-intel
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm64-chromebook
@@ -188,13 +188,25 @@ scheduler:
   - job: kbuild-gcc-12-arm64-chromeos-mediatek
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm64-chromeos-daily-mediatek
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm64-chromeos-qualcomm
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-chromeos-daily-qualcomm
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-chromeos-amd
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-x86-chromeos-daily-amd
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86-chromeos-intel
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-x86-chromeos-daily-intel
     <<: *build-k8s-all
 
   - job: kselftest-acpi


### PR DESCRIPTION
Lower the frequency of chromiumos builds to 1/day, both for GCC-12 and Clang-17 builds.