### PR TITLE
(architectures): Add option to limit build variants to specific architectures

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -519,10 +519,14 @@ build_configs:
   riscv_fixes:
     tree: riscv
     branch: 'fixes'
+    architectures:
+      - riscv
 
   riscv_for-next:
     tree: riscv
     branch: 'for-next'
+    architectures:
+      - riscv
 
   robh:
     tree: robh

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -160,6 +160,9 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
             'commit_message': commit_message,
             'tip_of_branch': branch_tip,
         })
+        if 'architecture_filter' in checkout_node['data']:
+            node['data']['architecture_filter'] = checkout_node['data']['architecture_filter']
+
         node.update({
             'state': 'available',
             'artifacts': {

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -112,6 +112,9 @@ class Trigger(Service):
             'timeout': checkout_timeout.isoformat(),
             'treeid': treeid,
         }
+        if current_config.architectures:
+            node['architecture_filter'] = current_config.architectures
+
         if self._current_user['username'] in ('staging.kernelci.org',
                                               'production'):
             node['submitter'] = 'service:pipeline'

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -113,7 +113,8 @@ class Trigger(Service):
             'treeid': treeid,
         }
         if current_config.architectures:
-            node['architecture_filter'] = current_config.architectures
+            self.log.info(f"Architecture filter: {current_config.architectures}")
+            node['data']['architecture_filter'] = current_config.architectures
 
         if self._current_user['username'] in ('staging.kernelci.org',
                                               'production'):


### PR DESCRIPTION
Some trees need to be limited to listed architectures. Add option to config, that will allow to restrict build variants, and when present create in checkout node architecture_filter parameter.