### PR TITLE
(events): Add re-subscribe mechanism

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -59,12 +59,12 @@ class Monitor(Service):
             try:
                 event = self._api.receive_event(sub_id)
             except Exception as e:
-                self.log.error(f"Error receiving event: {e}")
+                self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
                 time.sleep(10)
                 sub_id = self._api.subscribe('node')
                 subscribe_retries += 1
                 if subscribe_retries > 3:
-                    self.log.error("Failed to subscribe to node events")
+                    self.log.error("Failed to re-subscribe to node events")
                     return False
                 continue
             subscribe_retries = 0

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -312,7 +312,7 @@ class Scheduler(Service):
             try:
                 event = self._api_helper.receive_event_data(sub_id)
             except Exception as e:
-                self.log.error(f"Error receiving event: {e}")
+                self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
                 time.sleep(10)
                 sub_id = self._api.subscribe('node')
                 subscribe_retries += 1

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -670,7 +670,7 @@ in {runtime}",
                 try:
                     node, is_hierarchy = self._api_helper.receive_event_node(context['sub_id'])
                 except Exception as e:
-                    self.log.error(f"Error receiving event: {e}")
+                    self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
                     time.sleep(10)
                     context['sub_id'] = self._api_helper.subscribe_filters({
                         'op': 'created',

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -213,7 +213,7 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
             try:
                 checkout_node, _ = self._api_helper.receive_event_node(sub_id)
             except Exception as e:
-                self.log.error(f"Error receiving event: {e}")
+                self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
                 time.sleep(10)
                 # try to resubscribe
                 sub_id = self._api_helper.subscribe_filters({


### PR DESCRIPTION
If we got HTTP error, likely we lost subscription due remote server restart. Instead of crashing, try to resubscribe several times, with delay, to allow remote server restart.