### PR TITLE
config: Enable boot tests on chromiumos tree

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -93,6 +93,27 @@ _anchors:
       version: 6
       patchlevel: 6
 
+  baseline-cros-kernel: &baseline-cros-kernel-job
+    template: baseline.jinja2
+    kind: job
+    kcidb_test_suite: boot
+    params: &baseline-cros-kernel-params
+      extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"
+    rules:
+      tree:
+        - chromiumos
+
+  baseline-nfs-cros-kernel: &baseline-nfs-cros-kernel-job
+    <<: *baseline-cros-kernel-job
+    kcidb_test_suite: boot.nfs
+    params:
+      <<: *baseline-cros-kernel-params
+      boot_commands: nfs
+      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
+    rules:
+      tree:
+        - chromiumos
+
   tast: &tast-job
     template: tast.jinja2
     kind: job
@@ -482,6 +503,16 @@ jobs:
   baseline-x86-amd-chromebook: *baseline-job
   baseline-x86-amd-staging-chromebook: *baseline-job
   baseline-x86-intel-chromebook: *baseline-job
+
+  baseline-arm64-mediatek-cros-kernel: *baseline-cros-kernel-job
+  baseline-arm64-qualcomm-cros-kernel: *baseline-cros-kernel-job
+  baseline-x86-amd-cros-kernel: *baseline-cros-kernel-job
+  baseline-x86-intel-cros-kernel: *baseline-cros-kernel-job
+
+  baseline-nfs-arm64-mediatek-cros-kernel: *baseline-nfs-cros-kernel-job
+  baseline-nfs-arm64-qualcomm-cros-kernel: *baseline-nfs-cros-kernel-job
+  baseline-nfs-x86-amd-cros-kernel: *baseline-nfs-cros-kernel-job
+  baseline-nfs-x86-intel-cros-kernel: *baseline-nfs-cros-kernel-job
 
   kbuild-clang-17-arm64-chromeos-daily-mediatek:
     <<: *kbuild-clang-17-arm64-chromeos-job

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -26,7 +26,7 @@ _anchors:
         url: https://storage.chromeos.kernelci.org/images/kernel/cros-20230815-amd64/clang-14
         image: 'kernel/bzImage'
       tast_tarball: https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-{base_name}/20240918.0/{debarch}/tast.tgz
-    rules:
+    rules: &x86-chromebook-device-rules
       <<: *arm64-chromebook-device-rules
       fragments:
         - 'x86-board'
@@ -35,52 +35,148 @@ platforms:
   acer-R721T-grunt: &chromebook-grunt-device
     <<: *x86-chromebook-device
     base_name: grunt
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-5.10.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.10.y'
+        - 'stable-rc:linux-6.12.y'
 
   acer-cb317-1h-c3z6-dedede:
     <<: *x86-chromebook-device
     base_name: dedede
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.1'
+        - 'stable:linux-6.1.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.1.y'
+        - 'stable-rc:linux-6.12.y'
 
   acer-cbv514-1h-34uz-brya:
     <<: *x86-chromebook-device
     base_name: brya
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   acer-chromebox-cxi4-puff:
     <<: *x86-chromebook-device
     base_name: puff
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'stable:linux-5.15.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.15.y'
+        - 'stable-rc:linux-6.12.y'
 
   acer-cp514-2h-1130g7-volteer: &chromebook-volteer-device
     <<: *x86-chromebook-device
     base_name: volteer
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.4'
+        - 'stable:linux-5.4.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.4.y'
+        - 'stable-rc:linux-6.12.y'
 
   acer-cp514-2h-1160g7-volteer: *chromebook-volteer-device
 
   acer-cp514-3wh-r0qs-guybrush:
     <<: *x86-chromebook-device
     base_name: guybrush
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   asus-C433TA-AJ0005-rammus:
     <<: *x86-chromebook-device
     base_name: rammus
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-5.10.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.10.y'
+        - 'stable-rc:linux-6.12.y'
 
   asus-C436FA-Flip-hatch:
     <<: *x86-chromebook-device
     base_name: hatch
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'stable:linux-5.15.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.15.y'
+        - 'stable-rc:linux-6.12.y'
 
   asus-C523NA-A20057-coral:
     <<: *x86-chromebook-device
     base_name: coral
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-5.10.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.10.y'
+        - 'stable-rc:linux-6.12.y'
 
   asus-CM1400CXA-dalboz: &chromebook-zork-device
     <<: *x86-chromebook-device
     base_name: zork
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.4'
+        - 'stable:linux-5.4.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.4.y'
+        - 'stable-rc:linux-6.12.y'
 
   dell-latitude-3445-7520c-skyrim:
     <<: *x86-chromebook-device
     base_name: skyrim
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   dell-latitude-5300-8145U-arcada: &chromebook-sarien-device
     <<: *x86-chromebook-device
     base_name: sarien
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-5.10.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.10.y'
+        - 'stable-rc:linux-6.12.y'
 
   dell-latitude-5400-4305U-sarien: *chromebook-sarien-device
   dell-latitude-5400-8665U-sarien: *chromebook-sarien-device
@@ -91,10 +187,26 @@ platforms:
   hp-x360-14-G1-sona:
     <<: *x86-chromebook-device
     base_name: nami
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.4'
+        - 'stable:linux-5.4.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.4.y'
+        - 'stable-rc:linux-6.12.y'
 
   hp-x360-12b-ca0010nr-n4020-octopus:
     <<: *x86-chromebook-device
     base_name: octopus
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'stable:linux-5.15.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.15.y'
+        - 'stable-rc:linux-6.12.y'
 
   hp-x360-14a-cb0001xx-zork: *chromebook-zork-device
   lenovo-TPad-C13-Yoga-zork: *chromebook-zork-device
@@ -109,9 +221,14 @@ platforms:
       test_character_delay: 10
     rules:
       <<: *arm64-chromebook-device-rules
-      min_version:
-        version: 6
-        patchlevel: 1
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-6.1.y'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.1.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   mt8186-corsola-steelix-sku131072:
     <<: *mediatek-chromebook-device
@@ -125,9 +242,10 @@ platforms:
         image: 'Image'
     rules:
       <<: *arm64-chromebook-device-rules
-      min_version:
-        version: 6
-        patchlevel: 9
+      branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.12.y'
 
   mt8192-asurada-spherion-r0:
     <<: *mediatek-chromebook-device
@@ -136,20 +254,28 @@ platforms:
     compatible: ['google,spherion-rev3', 'google,spherion-rev2']
     rules:
       <<: *arm64-chromebook-device-rules
-      min_version:
-        version: 6
-        patchlevel: 4
+      branch:
+        - 'chromiumos:chromeos-6.1'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   mt8195-cherry-tomato-r2:
     <<: *mediatek-chromebook-device
     base_name: cherry
-    dtb: dtbs/mediatek/mt8195-cherry-tomato-r2.dtb
+    dtb:
+      - 'dtbs/mediatek/mt8195-cherry-tomato-r2.dtb'
+      - 'dtbs/mediatek/mt8195-tomato-rev2.dtb'
     compatible: ['google,tomato-rev2', 'google,tomato', 'mediatek,mt8195']
     rules:
       <<: *arm64-chromebook-device-rules
-      min_version:
-        version: 6
-        patchlevel: 7
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   sc7180-trogdor-kingoftown: &trogdor-chromebook-device
     <<: *arm64-chromebook-device
@@ -165,6 +291,13 @@ platforms:
         url: https://storage.chromeos.kernelci.org/images/kernel/v6.1-qualcomm
         image: 'kernel/Image'
         dtb: 'dtbs/qcom/sc7180-trogdor-kingoftown-r1.dtb'
+    rules:
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
 
   sc7180-trogdor-lazor-limozeen:
     <<: *trogdor-chromebook-device

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -58,6 +58,12 @@ _anchors:
       kind: kbuild
     platforms: *mediatek-platforms
 
+  test-job-arm64-mediatek-cros-kernel: &test-job-arm64-mediatek-cros-kernel
+    <<: *test-job-arm64-mediatek
+    event:
+      <<: *test-job-arm64-mediatek-event
+      name: kbuild-gcc-12-arm64-chromeos-daily-mediatek
+
   test-job-arm64-mediatek-media-committers: &test-job-arm64-mediatek-media-committers
     <<: *test-job-arm64-mediatek
     event:
@@ -67,6 +73,12 @@ _anchors:
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm
     <<: *test-job-arm64-mediatek
     platforms: *qualcomm-platforms
+
+  test-job-arm64-qualcomm-cros-kernel: &test-job-arm64-qualcomm-cros-kernel
+    <<: *test-job-arm64-qualcomm
+    event:
+      <<: *test-job-arm64-mediatek-event
+      name: kbuild-gcc-12-arm64-chromeos-daily-qualcomm
 
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm-media-committers
     <<: *test-job-arm64-mediatek-media-committers
@@ -108,7 +120,7 @@ _anchors:
 
   test-job-x86: &test-job-x86
     <<: *lava-job-collabora
-    event:
+    event: &test-job-x86-event
       channel: node
       name: kbuild-gcc-12-x86
       result: pass
@@ -118,9 +130,21 @@ _anchors:
     <<: *test-job-x86
     platforms: *amd-platforms
 
+  test-job-x86-amd-cros-kernel: &test-job-x86-amd-cros-kernel
+    <<: *test-job-x86-amd
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-chromeos-daily-amd
+
   test-job-x86-intel: &test-job-x86-intel
     <<: *test-job-x86
     platforms: *intel-platforms
+
+  test-job-x86-intel-cros-kernel: &test-job-x86-intel-cros-kernel
+    <<: *test-job-x86-intel
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-chromeos-daily-intel
 
 scheduler:
 
@@ -179,6 +203,30 @@ scheduler:
 
   - job: baseline-x86-intel-chromebook
     <<: *test-job-x86-intel
+
+  - job: baseline-arm64-mediatek-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: baseline-arm64-qualcomm-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: baseline-x86-amd-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: baseline-x86-intel-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: baseline-nfs-arm64-mediatek-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: baseline-nfs-arm64-qualcomm-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: baseline-nfs-x86-amd-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: baseline-nfs-x86-intel-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
 
   - job: kbuild-clang-17-arm64-chromeos-daily-mediatek
     <<: *build-k8s-all


### PR DESCRIPTION
Enable boot tests on the chromiumos tree and run them on all available Chromebooks. Run the tests on Debian for starters.