### PR TITLE
(config) Add one more platform, roc/rock confusion

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -227,6 +227,12 @@ platforms:
     dtb: dtbs/rockchip/rk3399-gru-kevin.dtb
     compatible: ['google,kevin-rev15', 'google,kevin-rev14']
 
+  rk3399-roc-pc:
+    <<: *arm64-device
+    mach: rockchip
+    dtb: dtbs/rockchip/rk3399-roc-pc.dtb
+    compatible: ['firefly,roc-rk3399-pc', 'rockchip,rk3399']
+
   rk3399-rock-pc:
     <<: *arm64-device
     mach: rockchip


### PR DESCRIPTION
In some places platform listed as rk3399-rock-pc,
but in some rk3399-roc-pc. Let's have both for now.