### PR TITLE
Add brask, nissa, hana and cherry-r3 Chromebooks

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -80,6 +80,18 @@ platforms:
         - 'stable-rc:linux-5.15.y'
         - 'stable-rc:linux-6.12.y'
 
+  acer-chromebox-cxi5-brask:
+    <<: *x86-chromebook-device
+    base_name: brask
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
+
   acer-cp514-2h-1130g7-volteer: &chromebook-volteer-device
     <<: *x86-chromebook-device
     base_name: volteer
@@ -97,6 +109,18 @@ platforms:
   acer-cp514-3wh-r0qs-guybrush:
     <<: *x86-chromebook-device
     base_name: guybrush
+    rules:
+      <<: *x86-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-6.6'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
+
+  acer-n20q11-r856ltn-p1s2-nissa:
+    <<: *x86-chromebook-device
+    base_name: nissa
     rules:
       <<: *x86-chromebook-device-rules
       branch:
@@ -211,14 +235,32 @@ platforms:
   hp-x360-14a-cb0001xx-zork: *chromebook-zork-device
   lenovo-TPad-C13-Yoga-zork: *chromebook-zork-device
 
-  mt8183-kukui-jacuzzi-juniper-sku16: &mediatek-chromebook-device
+  mt8173-elm-hana: &mediatek-chromebook-device
     <<: *arm64-chromebook-device
-    base_name: jacuzzi
+    base_name: hana
     mach: mediatek
-    dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
-    compatible: ['google,juniper-sku16', 'google,juniper', 'mediatek,mt8183']
+    dtb: dtbs/mediatek/mt8173-elm-hana.dtb
+    compatible: ['google,hana-rev6', 'google,hana-rev5', 'google,hana-rev4', 'google,hana-rev3', 'google,hana', 'mediatek,mt8173']
     context:
       test_character_delay: 10
+    rules:
+      <<: *arm64-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'stable:linux-5.15.y'
+        - 'stable:linux-6.1.y'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-5.15.y'
+        - 'stable-rc:linux-6.1.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
+
+  mt8183-kukui-jacuzzi-juniper-sku16:
+    <<: *mediatek-chromebook-device
+    base_name: jacuzzi
+    dtb: dtbs/mediatek/mt8183-kukui-jacuzzi-juniper-sku16.dtb
+    compatible: ['google,juniper-sku16', 'google,juniper', 'mediatek,mt8183']
     rules:
       <<: *arm64-chromebook-device-rules
       branch:
@@ -263,11 +305,27 @@ platforms:
 
   mt8195-cherry-tomato-r2:
     <<: *mediatek-chromebook-device
-    base_name: cherry
+    base_name: cherry-r2
     dtb:
       - 'dtbs/mediatek/mt8195-cherry-tomato-r2.dtb'
       - 'dtbs/mediatek/mt8195-tomato-rev2.dtb'
     compatible: ['google,tomato-rev2', 'google,tomato', 'mediatek,mt8195']
+    rules:
+      <<: *arm64-chromebook-device-rules
+      branch:
+        - 'chromiumos:chromeos-5.10'
+        - 'stable:linux-6.6.y'
+        - 'stable:linux-6.12.y'
+        - 'stable-rc:linux-6.6.y'
+        - 'stable-rc:linux-6.12.y'
+
+  mt8195-cherry-tomato-r3:
+    <<: *mediatek-chromebook-device
+    base_name: cherry-r3
+    dtb:
+      - 'dtbs/mediatek/mt8195-cherry-tomato-r3.dtb'
+      - 'dtbs/mediatek/mt8195-tomato-rev3.dtb'
+    compatible: ['google,tomato-rev4', 'google,tomato-rev3','google,tomato', 'mediatek,mt8195']
     rules:
       <<: *arm64-chromebook-device-rules
       branch:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -151,11 +151,23 @@ scheduler:
   - job: baseline-arm64-mediatek-chromebook
     <<: *test-job-arm64-mediatek
 
+  - job: baseline-arm64-mediatek-chromebook
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r3
+      - mt8173-elm-hana
+
   - job: baseline-arm64-qualcomm-chromebook
     <<: *test-job-arm64-qualcomm
 
   - job: baseline-arm64-mediatek-chromebook
     <<: *test-job-chromeos-mediatek
+
+  - job: baseline-arm64-mediatek-chromebook
+    <<: *test-job-chromeos-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r3
+      - mt8173-elm-hana
 
   - job: baseline-arm64-qualcomm-chromebook
     <<: *test-job-chromeos-qualcomm
@@ -164,7 +176,19 @@ scheduler:
     <<: *test-job-arm64-mediatek
 
   - job: baseline-nfs-arm64-mediatek-chromebook
+    <<: *test-job-arm64-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r3
+      - mt8173-elm-hana
+
+  - job: baseline-nfs-arm64-mediatek-chromebook
     <<: *test-job-chromeos-mediatek
+
+  - job: baseline-nfs-arm64-mediatek-chromebook
+    <<: *test-job-chromeos-mediatek
+    platforms:
+      - mt8195-cherry-tomato-r3
+      - mt8173-elm-hana
 
   - job: baseline-nfs-arm64-qualcomm-chromebook
     <<: *test-job-arm64-qualcomm
@@ -182,7 +206,19 @@ scheduler:
     <<: *test-job-chromeos-intel
 
   - job: baseline-nfs-x86-intel-chromebook
+    <<: *test-job-chromeos-intel
+    platforms:
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
+
+  - job: baseline-nfs-x86-intel-chromebook
     <<: *test-job-x86-intel
+
+  - job: baseline-nfs-x86-intel-chromebook
+    <<: *test-job-x86-intel
+    platforms:
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
 
   - job: baseline-x86-amd-chromebook
     <<: *test-job-chromeos-amd
@@ -200,6 +236,12 @@ scheduler:
 
   - job: baseline-x86-intel-chromebook
     <<: *test-job-chromeos-intel
+
+  - job: baseline-x86-intel-chromebook
+    <<: *test-job-chromeos-intel
+    platforms:
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
 
   - job: baseline-x86-intel-chromebook
     <<: *test-job-x86-intel
@@ -227,6 +269,12 @@ scheduler:
 
   - job: baseline-nfs-x86-intel-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
+
+  - job: baseline-x86-intel-chromebook
+    <<: *test-job-x86-intel
+    platforms:
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
 
   - job: kbuild-clang-17-arm64-chromeos-daily-mediatek
     <<: *build-k8s-all


### PR DESCRIPTION
Add support for brask, nissa, hana and cherry-r3 Chromebooks. Enable baseline/baseline-nfs tests only for starters.