### PR TITLE
config: Enable mm selftests on Avenger96

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1601,6 +1601,15 @@ jobs:
       collections: landlock
     kcidb_test_suite: kselftest.landlock
 
+  # No hugepages allocation (for architectures without it)
+  kselftest-mm:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      extra_kernel_args: "secretmem.enable kpti=off"
+      collections: mm
+    kcidb_test_suite: kselftest.mm
+
   # hugepages allocation suitable for machines with 2G of memory
   kselftest-mm-2g:
     <<: *kselftest-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -827,6 +827,14 @@ scheduler:
     platforms:
       - stm32mp157a-dhcor-avenger96
 
+  - job: kselftest-mm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
   - job: kselftest-mm-2g
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The upstream issues which prevented kselftest-mm runs on arm have been
fixed so let's enable the tests, use Avenger96 since it's quite fast and
has a relatively large amount of RAM.  Standard two level page tables
don't support hugepages on 32 bit.

Signed-off-by: Mark Brown <broonie@kernel.org>
