### PR TITLE
config: Enable the ublk selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1654,6 +1654,13 @@ jobs:
       collections: timers
     kcidb_test_suite: kselftest.timers
 
+  kselftest-ublk:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: ublk
+    kcidb_test_suite: kselftest.ublk
+
   kselftest-uevent:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -922,6 +922,22 @@ scheduler:
     platforms:
       - sun50i-h5-libretech-all-h3-cc
 
+  - job: kselftest-ublk
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
+  - job: kselftest-ublk
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-uevent
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
These are software only tests, run them on one board per architecture in
my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
