### PR TITLE
Add official PCI tree to run tests on the next branch

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -102,6 +102,7 @@ _anchors:
     - 'tip'
     - 'ulfh'
     - 'vireshk'
+    - 'linux-pci'
 
 
 jobs:

--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -153,6 +153,9 @@ trees:
   hyperv:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/hyperv/linux.git"
 
+  linux-pci:
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git"
+
 # -----------------------------------------------------------------------------
 # Legacy configuration data (still used by trigger service)
 #
@@ -683,3 +686,11 @@ build_configs:
   hyperv-fixes:
     tree: hyperv
     branch: 'hyperv-fixes'
+
+  linux-pci:
+    tree: linux-pci
+    branch: 'next'
+    architectures:
+      - x86_64
+      - arm64
+      - arm


### PR DESCRIPTION
Add the official PCI tree such that tests can be run on the `next` branch for the following architectures:

- x86_64
- arm64
- arm

This aims to increase and improve test coverage as part of the PCI sub-system development efforts.