### PR TITLE
Re-enable kontron's lab

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -117,6 +117,7 @@ jobs:
   baseline-arm-broonie: *baseline-job
   baseline-arm-baylibre: *baseline-job
   baseline-arm-clabbe: *baseline-job
+  baseline-arm-kontron: *baseline-job
   baseline-arm-mfd: *baseline-job
   baseline-arm-pengutronix: *baseline-job
   baseline-arm64: *baseline-job
@@ -125,6 +126,7 @@ jobs:
   baseline-arm64-clabbe: *baseline-job
   baseline-arm64-kcidebug-mediatek: *baseline-job
   baseline-arm64-kcidebug-qualcomm: *baseline-job
+  baseline-arm64-kontron: *baseline-job
   baseline-arm64-mfd: *baseline-job
   baseline-arm64-pengutronix: *baseline-job
   baseline-arm64-qualcomm: *baseline-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -143,6 +143,13 @@ runtimes:
       callback:
         token: kernelci-api-token-lava-staging
 
+  lava-kontron:
+    lab_type: lava
+    url: 'https://lavalab.kontron.com'
+    notify:
+      callback:
+        token: kernel-ci-callback
+
   lava-pengutronix:
     lab_type: lava
     url: 'https://lava.pengutronix.de'

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -184,6 +184,36 @@ platforms:
     dtb: dtbs/ti/k3-j721e-beagleboneai64.dtb
     compatible: ['beagle,j721e-beagleboneai64', 'ti,j721e']
 
+  kontron-bl-imx8mm:
+    <<: *arm64-device
+    mach: imx
+    dtb: dtbs/freescale/imx8mm-kontron-bl.dtb
+    compatible: ['kontron,imx8mm-bl', 'kontron,imx8mm-sl', 'fsl,imx8mm']
+
+  kontron-kbox-a-230-ls:
+    <<: *arm64-device
+    mach: freescale
+    dtb: dtbs/freescale/fsl-ls1028a-kontron-kbox-a-230-ls.dtb
+    compatible: ['kontron,kbox-a-230-ls', 'kontron,sl28-var4', 'kontron,sl28', 'fsl,ls1028a']
+
+  kontron-kswitch-d10-mmt-6g-2gs:
+    <<: *arm-device
+    mach: microchip
+    dtb: dtbs/microchip/lan966x-kontron-kswitch-d10-mmt-6g-2gs.dtb
+    compatible: ['kontron,kswitch-d10-mmt-6g-2gs', 'kontron,s1921', 'microchip,lan9668', 'microchip,lan966']
+
+  kontron-kswitch-d10-mmt-8g:
+    <<: *arm-device
+    mach: michrochip
+    dtb: dtbs/microchip/lan966x-kontron-kswitch-d10-mmt-8g.dtb
+    compatible: ['kontron,kswitch-d10-mmt-8g', 'kontron,s1921', 'microchip,lan9668', 'microchip,lan966']
+
+  kontron-sl28-var3-ads2:
+    <<: *arm64-device
+    mach: freescale
+    dtb: dtbs/freescale/fsl-ls1028a-kontron-sl28-var3-ads2.dtb
+    compatible: ['kontron,sl28-var3-ads2', 'kontron,sl28-var3', 'kontron,sl28', 'fsl,ls1028a']
+
   kubernetes:
 
   meson-axg-s400:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -95,6 +95,15 @@ scheduler:
       - sun8i-r40-bananapi-m2-ultra
       - sun9i-a80-cubieboard4
 
+  - job: baseline-arm-kontron
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: &lava-kontron-runtime
+      type: lava
+      name: lava-kontron
+    platforms:
+      - kontron-kswitch-d10-mmt-6g-2gs
+      - kontron-kswitch-d10-mmt-8g
+
   - job: baseline-arm-mfd
     event:
       <<: *node-event-kbuild
@@ -210,6 +219,14 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: baseline-arm64-kontron
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-kontron-runtime
+    platforms:
+      - kontron-bl-imx8mm
+      - kontron-kbox-a-230-ls
+      - kontron-sl28-var3-ads2
 
   - job: baseline-arm64-pengutronix
     event: *kbuild-gcc-12-arm64-node-event

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,7 @@ services:
       - 'lava-qualcomm'
       - 'lava-cip'
       - 'lava-pengutronix'
+      - 'lava-kontron'
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
The lab was not migrated to new pipeline, lets do it.

The callback token is still the same as used with the old pipeline configuration.