### PR TITLE
(send_kcidb.py) Add qualcomm to allowed users

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -761,7 +761,7 @@ in {runtime}",
 
     def _should_skip_node(self, node):
         """Check if node should be skipped based on environment"""
-        if self._current_user['username'] in ('staging.kernelci.org', 'production'):
+        if self._current_user['username'] in ('staging.kernelci.org', 'production', 'qualcomm'):
             return node['submitter'] != 'service:pipeline'
         return False
 


### PR DESCRIPTION
As Qualcomm use Maestro to submit results, we need to allow kcidb bridge to process their records.