### PR TITLE
config: platforms-chromeos: Add branch rules for mainline, next and collabora-chromeos-kernel trees

### DIFF
--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -39,6 +39,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.10.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.10.y'
@@ -51,6 +54,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.1'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.1.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.1.y'
@@ -63,6 +69,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -75,6 +84,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.15.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.15.y'
@@ -87,6 +99,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -99,6 +114,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.4.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.4.y'
@@ -113,6 +131,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -125,6 +146,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -137,6 +161,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.10.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.10.y'
@@ -149,6 +176,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.15.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.15.y'
@@ -161,6 +191,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.10.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.10.y'
@@ -173,6 +206,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.4.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.4.y'
@@ -185,6 +221,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -197,6 +236,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.10.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.10.y'
@@ -215,6 +257,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.4.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.4.y'
@@ -227,6 +272,9 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.15.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-5.15.y'
@@ -247,6 +295,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-5.15.y'
         - 'stable:linux-6.1.y'
         - 'stable:linux-6.6.y'
@@ -265,6 +316,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.1.y'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
@@ -286,6 +340,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.12.y'
 
@@ -298,6 +355,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.1'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -314,6 +374,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -330,6 +393,9 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'
@@ -352,6 +418,9 @@ platforms:
     rules:
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'collabora-chromeos-kernel:for-kernelci'
+        - 'mainline:master'
+        - 'next:master'
         - 'stable:linux-6.6.y'
         - 'stable:linux-6.12.y'
         - 'stable-rc:linux-6.6.y'


### PR DESCRIPTION
[1] introduced branch rules for every Chromebook platform, for the chromiumos, stable and stable-rc trees. Add branch rules for remaining target trees tested on Chromebooks too, namely
collabora-chromeos-kernel, mainline and next.

[1] https://github.com/kernelci/kernelci-pipeline/pull/1090