### PR TITLE
Move entries for anchors correctly into the _anchors section

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -1,7 +1,28 @@
-trees:
+_anchors:
 
-  _base:
-    url: 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
+  # Includes all supported architectures.
+  base: &base
+    tree: mainline
+    branch: 'master'
+
+  # Includes most common and/or widely deployed architectures.
+  # The 32-bit x86 architecture is considered legacy nowadays,
+  # and as such, not included here.
+  base-standard: &base-standard
+    <<: *base
+    architectures:
+      - x86_64
+      - arm64
+      - arm
+
+  # Includes ARM-specific architectures only.
+  base-arm: &base-arm
+    <<: *base
+    architectures:
+      - arm64
+      - arm
+
+trees:
 
   # NOTE: Please keep the trees list below in sorted order.
 
@@ -195,28 +216,6 @@ build_variants:
 
 
 build_configs:
-
-  # Includes all supported architectures.
-  _base: &base
-    tree: _base
-    branch: 'master'
-
-  # Includes most common and/or widely deployed architectures.
-  # The 32-bit x86 architecture is considered legacy nowadays,
-  # and as such, not included here.
-  _base-standard: &base-standard
-    <<: *base
-    architectures:
-      - x86_64
-      - arm64
-      - arm
-
-  # Includes ARM-specific architectures only.
-  _base-arm: &base-arm
-    <<: *base
-    architectures:
-      - arm64
-      - arm
 
   # NOTE: Please keep the trees list below in sorted order.
 


### PR DESCRIPTION
Commit cfe037a ("Add architectures filter to various trees") added architectures filters to a variety of trees and, while doing so, also introduced a utility tree called `_base`, which is then used to provide configuration anchors to facilitate reuse.

However, this utility tree will also trigger jobs to be run, which is not desired, as these extra anchors are only used to reduce configuration duplication.

Thus, move the `base`, `base-standard`, and `base-arm` anchors into the `_anchros` section, which will only be used to assemble the configuration and, as such, will prevent any extra jobs from being run.