### PR TITLE
Add new branch to the Linux PCI tree configuration

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -532,13 +532,17 @@ build_configs:
     <<: *linusw
     branch: 'for-next'
 
-  linux-pci:
+  linux-pci: &linux-pci
     tree: linux-pci
     branch: 'next'
     architectures:
       - x86_64
       - arm64
       - arm
+
+  linux-pci_for-linus:
+    <<: *linux-pci
+    branch: 'for-linus'
 
   mainline:
     <<: *base


### PR DESCRIPTION
Add a new `for-linus` branch to the PCI tree configuration.

This branch is often used as a step before sending a Pull Request to Linus with fixes from the PCI tree that need to be applied during the development cycle of a new kernel version release.

Thus, it's prudent to run tests against it to increase coverage and boost confidence in the changes it carries.