### PR TITLE
Update Ubuntu release to 22.04 for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      # Override version of pycodestyle for Python 3.7 to the
+      # latest available release that can be installed on this
+      # old Python release.
+      - name: Override pycodestyle version
+        if: ${{ matrix.python-version == '3.7' }}
+        run: |
+          echo 'pycodestyle==2.10.0' > requirements-dev.txt
+
       - name: Install Python packages
         run: |
           python --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,10 @@ jobs:
         run: |
           pycodestyle src/*.py
 
-      - name: Install python yaml package
+      - name: Install Python YAML package
         run: |
           pip install pyyaml
 
-      - name: Run basic yaml validation
+      - name: Run basic YAML validation
         run: |
           python tests/validate_yaml.py
-        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
 
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.10']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,10 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version:
+          - '3.7'
+          - '3.10'
+          - '3.13'
 
     steps:
 
@@ -30,6 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install Python packages
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-pycodestyle==2.8.0
+pycodestyle==2.13.0


### PR DESCRIPTION
The support for the Ubuntu release **20.04** is being retired, and runners that use it are to be deprecated, too. See:

- [GitHub Actions: Ubuntu 20 runner image brownout dates and other breaking changes](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes)
- https://github.com/actions/runner-images/issues/11101

Related:

- [GitHub Actions: Ubuntu-latest workflows will use Ubuntu-22.04](https://github.blog/changelog/2022-11-08-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04)
- [GitHub Actions: Ubuntu-latest workflows will use Ubuntu-20.04](https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04)

> [!NOTE]  
> Note that Canonical will not retire 20.04 and mark it as EOL (_End of Life_) until April 2032, since 20.04 is an LTS (_Long Term Support_) release. See [The Ubuntu lifecycle and release cadence](https://ubuntu.com/about/release-cycle).