### PR TITLE
Add python requirements to the root

### DIFF
--- a/requirements-lava-callback.txt
+++ b/requirements-lava-callback.txt
@@ -1,0 +1,4 @@
+uwsgi==2.0.22
+uvicorn==0.30.1
+fastapi==0.111.0
+pyjwt==2.8.0


### PR DESCRIPTION
We have now requirements buried in the docker directory, which is planned to be deleted. Let's move it to root directory. We still need them for kernelci-core recipes.