### PR TITLE
Fix architectures filter for Android tree

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -230,9 +230,15 @@ build_configs:
     branch: 'for-next'
 
   android_mainline: &android
-    <<: *base-arm
     tree: android
     branch: 'android-mainline'
+    architectures:
+      - x86_64
+      - i386
+      - arm64
+      - arm
+      - riscv
+      - um
 
   android_mainline_tracking:
     <<: *android


### PR DESCRIPTION
Ensure that Android trees run on the following architectures:

  - `x86_64`
  - `i386` (32-bit x86)
  - `ARM64`
  - `ARM`
  - `RISC-V`
  - `UM` (User-Mode Linux)

Note that at this time `MIPS` architecture is not included.