### PR TITLE
Add dedicated KernelCI branch to the Linux PCI tree configuration

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -532,7 +532,7 @@ build_configs:
     <<: *linusw
     branch: 'for-next'
 
-  linux-pci: &linux-pci
+  linux-pci_next: &linux-pci
     tree: linux-pci
     branch: 'next'
     architectures:
@@ -543,6 +543,10 @@ build_configs:
   linux-pci_for-linus:
     <<: *linux-pci
     branch: 'for-linus'
+
+  linux-pci_for-kernelci:
+    <<: *linux-pci
+    branch: 'for-kernelci'
 
   mainline:
     <<: *base


### PR DESCRIPTION
Add a dedicated KernelCI branch called `for-kernelci` to the Linux PCI tree configuration.

This will open the possibility for more testing to be carried out using this new branch, especially as the previously added `next` and `for-linus` branches are somewhat special to the official PCI tree, and should not be used for ad hoc tests, etc.

This new branch will also be excluded from the Intel 0-day Bot tests.

While at it, update the existing `linux-pci` property to add the name of the branch to it.

Related:

- https://github.com/intel/lkp-tests/pull/507