### PR TITLE
Update jobs for the OMAP tree

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -58,6 +58,7 @@ _anchors:
       tree:
       - '!android'
       - '!chromiumos'
+      - '!omap'
 
   kbuild-gcc-12-x86-chromeos: &kbuild-gcc-12-x86-chromeos-job
     <<: *kbuild-gcc-12-arm64-chromeos-job

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -200,6 +200,9 @@ jobs:
     params:
       <<: *kbuild-clang-17-arm-android-params
       defconfig: omap2plus_defconfig
+    rules:
+      tree:
+      - 'omap'
 
   kbuild-clang-17-arm-android-vexpress_defconfig:
     <<: *kbuild-clang-17-arm-android-job
@@ -617,6 +620,9 @@ jobs:
     params:
       <<: *kbuild-gcc-12-arm-android-params
       defconfig: omap2plus_defconfig
+    rules:
+      tree:
+      - 'omap'
 
   kbuild-gcc-12-arm-android-vexpress_defconfig:
     <<: *kbuild-gcc-12-arm-android-job
@@ -740,17 +746,9 @@ jobs:
       tree:
       - 'chrome-platform'
       - 'kernelci'
-      - 'stable-rc'
-      - 'stable'
-
-  kbuild-gcc-12-arm-omap1_defconfig:
-    <<: *kbuild-gcc-12-arm-job
-    params:
-      <<: *kbuild-gcc-12-arm-params
-      defconfig: omap1_defconfig
-    rules:
-      tree:
       - 'omap'
+      - 'stable'
+      - 'stable-rc'
 
   kbuild-gcc-12-arm-omap2plus_defconfig:
     <<: *kbuild-gcc-12-arm-job
@@ -759,10 +757,7 @@ jobs:
       defconfig: omap2plus_defconfig
     rules:
       tree:
-      - 'kernelci'
       - 'omap'
-      - 'stable-rc'
-      - 'stable'
 
   kbuild-gcc-12-arm-preempt_rt:
     <<: *kbuild-gcc-12-arm-job

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -793,6 +793,9 @@ jobs:
         - 'lab-setup'
         - 'kselftest'
         - 'arm64-chromebook'
+    rules:
+      tree:
+      - '!omap'
 
   kbuild-gcc-12-arm64-allnoconfig:
     <<: *kbuild-gcc-12-arm64-job
@@ -889,6 +892,9 @@ jobs:
       fragments:
         - 'arm64-chromebook'
         - 'kselftest'
+    rules:
+      tree:
+      - '!omap'
 
   # Default config and build only job
   kbuild-gcc-12-arm64-build-only:
@@ -915,6 +921,9 @@ jobs:
         - arm64-chromebook
         - kcidebug
         - lab-setup
+    rules:
+      tree:
+      - '!omap'
 
   kbuild-gcc-12-arm64-dtbscheck:
     <<: *kbuild-gcc-12-arm64-job
@@ -933,6 +942,8 @@ jobs:
         - 'kselftest'
     rules:
       <<: *kbuild-kselftest-rules
+      tree:
+      - '!omap'
 
   kbuild-gcc-12-arm64-mainline: &kbuild-gcc-12-arm64-mainline-job
     <<: *kbuild-gcc-12-arm64-job
@@ -965,6 +976,9 @@ jobs:
         - 'debug'
         - 'kselftest'
         - 'tinyconfig'
+    rules:
+      tree:
+      - '!omap'
 
   kbuild-gcc-12-arm64-mfd:
     <<: *kbuild-gcc-12-arm64-job
@@ -1248,6 +1262,9 @@ jobs:
         - 'lab-setup'
         - 'x86-board'
         - 'kselftest'
+    rules:
+      tree:
+      - '!omap'
 
   kbuild-gcc-12-x86-allnoconfig:
     <<: *kbuild-gcc-12-x86-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -509,9 +509,6 @@ scheduler:
   - job: kbuild-gcc-12-arm-multi_v7_defconfig
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-arm-omap1_defconfig
-    <<: *build-k8s-all
-
   - job: kbuild-gcc-12-arm-omap2plus_defconfig
     <<: *build-k8s-all
 

--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -601,9 +601,10 @@ build_configs:
     branch: 'pending-fixes'
 
   omap:
-    <<: *base-arm
     tree: omap
     branch: 'for-next'
+    architectures:
+      - arm
 
   padovan:
     <<: *base-standard


### PR DESCRIPTION
Update jobs for the OMAP tree:

- Only run jobs on the 32-bit ARM
- Remove no longer needed `omap1_defconfig` job
- Remove from some jobs e.g., ChromeOS, Chromebook, etc.

Additionally, limit the `omap2plus_defconfig` job to only run for the OMAP tree.