### PR TITLE
config: Test chromiumos/chromeos-6.12 on all Chromebooks

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -534,6 +534,7 @@ jobs:
       <<: *kbuild-clang-17-arm64-chromeos-rules
       branch:
         - 'chromeos-6.6'
+        - 'chromeos-6.12'
 
   kbuild-clang-17-x86-chromeos-daily-amd:
     <<: *kbuild-clang-17-x86-chromeos-job
@@ -545,7 +546,6 @@ jobs:
       branch:
         - '!chromiumos:chromeos-5.15'
         - '!chromiumos:chromeos-6.1'
-        - '!chromiumos:chromeos-6.12'
 
   kbuild-clang-17-x86-chromeos-daily-intel:
     <<: *kbuild-clang-17-x86-chromeos-job
@@ -583,7 +583,7 @@ jobs:
       min_version:
         version: 6
         patchlevel: 1
-  
+
   kbuild-gcc-12-arm64-chromeos-daily-mediatek:
     <<: *kbuild-gcc-12-arm64-chromeos-job
     params:
@@ -633,7 +633,6 @@ jobs:
       branch:
         - '!chromiumos:chromeos-5.15'
         - '!chromiumos:chromeos-6.1'
-        - '!chromiumos:chromeos-6.12'
 
   kbuild-gcc-12-x86-chromeos-intel:
     <<: *kbuild-gcc-12-x86-chromeos-job

--- a/config/platforms-chromeos.yaml
+++ b/config/platforms-chromeos.yaml
@@ -39,6 +39,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -54,6 +55,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.1'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -69,6 +71,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -84,6 +87,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -99,6 +103,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -114,6 +119,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -131,6 +137,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -146,6 +153,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -161,6 +169,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -176,6 +185,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -191,6 +201,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -206,6 +217,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -221,6 +233,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -236,6 +249,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -257,6 +271,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.4'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -272,6 +287,7 @@ platforms:
       <<: *x86-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -295,6 +311,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -316,6 +333,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -340,6 +358,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -355,6 +374,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-6.1'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -374,6 +394,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -393,6 +414,7 @@ platforms:
       <<: *arm64-chromebook-device-rules
       branch:
         - 'chromiumos:chromeos-5.10'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'
@@ -418,6 +440,7 @@ platforms:
     rules:
       branch:
         - 'chromiumos:chromeos-6.6'
+        - 'chromiumos:chromeos-6.12'
         - 'collabora-chromeos-kernel:for-kernelci'
         - 'mainline:master'
         - 'next:master'


### PR DESCRIPTION
Enable testing for the chromeos-6.12 branch of the ChromeOS kernel on all available Chromebooks.