### PR TITLE
Add kbuild job with coverage enabled and run tests using this kernel

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1315,6 +1315,23 @@ jobs:
       - '!android'
       - '!chromiumos'
 
+  kbuild-gcc-12-x86-coverage:
+    <<: *kbuild-gcc-12-x86-job
+    params:
+      <<: *kbuild-gcc-12-x86-params
+      fragments:
+        - 'coverage'
+        - 'lab-setup'
+        - 'x86-board'
+    rules:
+      tree:
+      - 'chromiumos'
+      - 'collabora-chromeos-kernel:for-kernelci'
+      - 'mainline:master'
+      - 'next:master'
+      - 'stable'
+      - 'stable-rc'
+
   kbuild-gcc-12-x86-kselftest:
     <<: *kbuild-gcc-12-x86-job
     params:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -136,6 +136,12 @@ _anchors:
       <<: *test-job-x86-event
       name: kbuild-gcc-12-x86-chromeos-daily-amd
 
+  test-job-x86-coverage: &test-job-x86-coverage
+    <<: *test-job-x86
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-coverage
+
   test-job-x86-intel: &test-job-x86-intel
     <<: *test-job-x86
     platforms: *intel-platforms
@@ -440,8 +446,22 @@ scheduler:
       - hp-11A-G6-EE-grunt
       - hp-x360-12b-ca0010nr-n4020-octopus
 
+  - job: ltp-crypto
+    <<: *test-job-x86-coverage
+    platforms:
+      - asus-C523NA-A20057-coral
+      - hp-11A-G6-EE-grunt
+      - hp-x360-12b-ca0010nr-n4020-octopus
+
   - job: ltp-fcntl-locktests
     <<: *test-job-x86
+    platforms:
+      - asus-C433TA-AJ0005-rammus
+      - asus-C523NA-A20057-coral
+      - hp-11A-G6-EE-grunt
+
+  - job: ltp-fcntl-locktests
+    <<: *test-job-x86-coverage
     platforms:
       - asus-C433TA-AJ0005-rammus
       - asus-C523NA-A20057-coral
@@ -452,8 +472,21 @@ scheduler:
     platforms:
       - asus-C523NA-A20057-coral
 
+  - job: ltp-ima
+    <<: *test-job-x86-coverage
+    platforms:
+      - asus-C523NA-A20057-coral
+
   - job: ltp-ipc
     <<: *test-job-x86
+    platforms:
+      - acer-cp514-2h-1130g7-volteer
+      - asus-C436FA-Flip-hatch
+      - hp-11A-G6-EE-grunt
+      - hp-x360-12b-ca0010nr-n4020-octopus
+
+  - job: ltp-ipc
+    <<: *test-job-x86-coverage
     platforms:
       - acer-cp514-2h-1130g7-volteer
       - asus-C436FA-Flip-hatch
@@ -467,6 +500,13 @@ scheduler:
       - hp-11A-G6-EE-grunt
       - hp-x360-12b-ca0010nr-n4020-octopus
 
+  - job: ltp-mm
+    <<: *test-job-x86-coverage
+    platforms:
+      - asus-C436FA-Flip-hatch
+      - hp-11A-G6-EE-grunt
+      - hp-x360-12b-ca0010nr-n4020-octopus
+
   - job: ltp-pty
     <<: *test-job-x86
     platforms:
@@ -474,8 +514,23 @@ scheduler:
       - asus-C523NA-A20057-coral
       - hp-11A-G6-EE-grunt
 
-  - job: ltp-timers 
+  - job: ltp-pty
+    <<: *test-job-x86-coverage
+    platforms:
+      - asus-C433TA-AJ0005-rammus
+      - asus-C523NA-A20057-coral
+      - hp-11A-G6-EE-grunt
+
+  - job: ltp-timers
     <<: *test-job-x86
+    platforms:
+      - asus-C433TA-AJ0005-rammus
+      - asus-C436FA-Flip-hatch
+      - asus-C523NA-A20057-coral
+      - hp-11A-G6-EE-grunt
+
+  - job: ltp-timers
+    <<: *test-job-x86-coverage
     platforms:
       - asus-C433TA-AJ0005-rammus
       - asus-C436FA-Flip-hatch

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -697,6 +697,9 @@ scheduler:
   - job: kbuild-gcc-12-x86-build-only
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-x86-coverage
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86-kcidebug
     <<: *build-k8s-all
 


### PR DESCRIPTION
As we're enabling code coverage using GCOV in KernelCI, we must ensure we have a kernel with the corresponding options enabled using the `coverage` fragment, and also run some tests using this kernel.

The LTP tests we run on x86 Chromebooks are good candidates for helping during developement.