### PR TITLE
Mark nodes as processed even if empty

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -761,12 +761,12 @@ in {runtime}",
                     batch['checkouts'], batch['builds'], batch['tests'],
                     batch['issues'], batch['incidents'], context['client']
                 )
-                self._nodes_processed(batch['nodes'])
             except Exception as exc:
                 self.log.error(f"Failed to submit data to KCIDB: {str(exc)}")
                 # Don't mark as processed since they were not sent to KCIDB
                 batch['nodes'] = []
                 return False
+        self._nodes_processed(batch['nodes'])
         return True
 
     def _reset_batch_data(self):


### PR DESCRIPTION
Some nodes are not eligible to be sent to KCIDB,
for example custom user supplied nodes, but we need to mark them as processed, otherwise they will keep wasting cpu cycles and appear in new findfast queries.