### PR TITLE
src: lava_callback: handle artifacts uploaded from test jobs

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -233,6 +233,16 @@ def async_job_submit(api_helper, node_id, job_callback):
         job_node['error_msg'] = None
     if device_id:
         job_node['data']['device'] = device_id
+    # add artifacts uploaded from the running LAVA job
+    upload_result = results.pop('upload', {})
+    for (name, state) in upload_result.items():
+        if name.startswith("artifact-upload:") and state == 'pass':
+            artifact = name.split(':', 2)
+            if len(artifact) != 3:
+                logger.warn(f"Failed to extract artifact name and URL from {result}")
+                continue
+            job_node['artifacts'][artifact[1]] = artifact[2]
+            logger.info(f"Artifact {artifact[1]} added with URL {artifact[2]}")
     hierarchy = job_callback.get_hierarchy(results, job_node)
     api_helper.submit_results(hierarchy, job_node)
 


### PR DESCRIPTION
Test jobs might need to upload artifacts directly from LAVA (this is needed e.g. for GCOV data when checking for code coverage), but we currently have no way to add those artifacts to the corresponding node.

Add such a feature in a rather generic way, so jobs can provide both the artifact name and its URL through a specially-formatted result entry:

  `artifact-upload:<artifact name>:<artifact URL>`

Therefore, all test results starting with `artifact-upload:` will be processed and stored in the corresponding node's `artifacts` dict, with `<artifact name>` being the entry key and `<artifact URL>` being its value.

Depends on #1159 & https://github.com/kernelci/kernelci-core/pull/2878