### PR TITLE
config: Enable LTP tests on chromiumos tree

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -115,6 +115,22 @@ _anchors:
       tree:
         - chromiumos
 
+  ltp-cros-kernel: &ltp-cros-kernel-job
+    template: ltp.jinja2
+    kind: job
+    params: &ltp-cros-kernel-params
+      boot_commands: nfs
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20240313.0/{debarch}'
+      skip_install: "true"
+      skipfile: skipfile-lkft.yaml
+      extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"
+    kcidb_test_suite: ltp
+    rules:
+      fragments:
+        - '!kselftest'
+      tree:
+        - chromiumos
+
   tast: &tast-job
     template: tast.jinja2
     kind: job
@@ -678,6 +694,87 @@ jobs:
       tree:
         - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.device_error_logs
+
+  ltp-containers-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "containers"
+
+  ltp-controllers-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "controllers"
+
+  ltp-crypto-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "crypto"
+    rules:
+      fragments:
+        - 'crypto'
+
+  ltp-fs-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "fs"
+
+  ltp-input-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "input"
+
+  ltp-io-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "io"
+
+  ltp-ipc-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "ipc"
+
+  ltp-mem-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "mem"
+
+  ltp-pty-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "pty"
+
+  ltp-sched-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "sched"
+
+  ltp-security-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "security"
+
+  ltp-syscalls-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "syscalls"
+
+  ltp-watchqueue-cros-kernel:
+    <<: *ltp-cros-kernel-job
+    params:
+      <<: *ltp-cros-kernel-params
+      tst_cmdfiles: "watchqueue"
 
   tast-decoder-chromestack-arm64-mediatek: *tast-decoder-chromestack-job
 

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -474,13 +474,169 @@ scheduler:
       - asus-C523NA-A20057-coral
       - hp-11A-G6-EE-grunt
 
-  - job: ltp-timers 
+  - job: ltp-timers
     <<: *test-job-x86
     platforms:
       - asus-C433TA-AJ0005-rammus
       - asus-C436FA-Flip-hatch
       - asus-C523NA-A20057-coral
       - hp-11A-G6-EE-grunt
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-controllers-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-controllers-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-controllers-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-controllers-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-fs-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-fs-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-fs-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-fs-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-io-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-io-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-io-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-io-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-mem-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-mem-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-mem-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-mem-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-security-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-security-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-security-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-security-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-syscalls-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-syscalls-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-syscalls-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-syscalls-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
+
+  - job: ltp-watchqueue-cros-kernel
+    <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-watchqueue-cros-kernel
+    <<: *test-job-arm64-qualcomm-cros-kernel
+
+  - job: ltp-watchqueue-cros-kernel
+    <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-watchqueue-cros-kernel
+    <<: *test-job-x86-intel-cros-kernel
 
 # Some of this tests running too long, must be max 30 min
   - job: tast-decoder-chromestack-arm64-mediatek


### PR DESCRIPTION
Enable subset of LTP tests on the ChromeOS Kernel, targeting all available Chromebooks in the Collabora lab.