### PR TITLE
Add kbuild-gcc-12-arm64-chromebook-media-committers to scheduler entries

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -476,6 +476,9 @@ scheduler:
   - job: kbuild-gcc-12-arm-build-only
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm-cip-allnoconfig
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm-imx_v6_v7_defconfig
     <<: *build-k8s-all
 


### PR DESCRIPTION
To execute kbuild, it needs to be added to scheduler entries.