### PR TITLE
Don't run KUnit job on x86_64 architecture for OMAP tree

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1735,6 +1735,9 @@ jobs:
     <<: *kunit-job
     params:
       arch: x86_64
+    rules:
+      tree:
+        - '!omap'
 
   ltp-cap-bounds:
     <<: *ltp-job


### PR DESCRIPTION
The OMAP tree target architecture is 32-bit ARM, so running a KUnit job for the `x86_64` architecture for this specific tree does not make much sense and unnecessarily consumes resources.

Thus, turn off this specific KUnit job for the OMAP tree.

> [!NOTE]  
> The architecture filters added to a specific tree configuration are not currently applied against jobs other than kernel builds.