### PR TITLE
Ensure that kbuild-clang-17-arm build job is scheduled

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -326,6 +326,9 @@ scheduler:
     platforms:
       - supermicro-as-2015hr-tnr
 
+  - job: kbuild-clang-17-arm
+    <<: *build-k8s-all
+
   - job: kbuild-clang-17-arm-allmodconfig
     <<: *build-k8s-all
 


### PR DESCRIPTION
To execute the `kbuild-clang-17-arm` build job, it has to be scheduled.

Thus, add a missing scheduler entry for it.