### PR TITLE
(send_kcidb.py) Fix logspec trigger by status

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -833,7 +833,7 @@ in {runtime}",
         """Handle failed builds and tests by generating issues/incidents"""
         # Handle failed builds
         for parsed_node in parsed_data['build_node']:
-            if parsed_node.get('valid') is False and parsed_node.get('log_url'):
+            if parsed_node.get("status") == "FAIL" and parsed_node.get('log_url'):
                 parsed_fail = self._parse_fail_node(parsed_node, context, 'build')
                 self._add_to_batch(batch, parsed_fail)
 


### PR DESCRIPTION
Due deprecation of field 'valid' in kcidb schema, we lost trigger condition when 'valid' == false was triggering logspec. We can trigger same as on tests, by status == FAIL, which was equivalent to `valid` retrieved by status map.