### PR TITLE
config: jobs: use new LTP rootfs

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -65,7 +65,7 @@ _anchors:
     kind: job
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20240313.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250523.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
     kcidb_test_suite: ltp


### PR DESCRIPTION
We now have GCOV-enabled LTP test runs, which require a new rootfs in order to upload artifacts directly from the DUT in LAVA.