### PR TITLE
Fix timeout services & state machine

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -165,6 +165,7 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
 
         node.update({
             'state': 'available',
+            'result': 'pass',
             'artifacts': {
                 'tarball': tarball_url,
             },


### PR DESCRIPTION
As mentioned in #1163 the current timeout services (`timeout`, `holdoff` & `closing`) cause unwanted state transition for *child nodes* of timed-out nodes.

This PR reworks those services to avoid such unwanted transitions by **never** modifying the state of child nodes while transitioning a given node to a different state, making such transitions more reliable and predictable and allowing us to use this information more widely.

Moreover, handling of `checkout` nodes was special-cased for no good reason, so let's demote it to a not-so-special node, reducing a bit the overall complexity.

Fixes #1163