### PR TITLE
config: scheduler*: change job trigger for available kbuilds

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -44,6 +44,11 @@ _anchors:
     runtime:
       name: k8s-all
 
+  kbuild-event: &kbuild-event
+    channel: node
+    kind: kbuild
+    state: available
+
   lava-job-collabora: &lava-job-collabora
     runtime:
       type: lava
@@ -51,24 +56,21 @@ _anchors:
 
   test-job-arm64-mediatek: &test-job-arm64-mediatek
     <<: *lava-job-collabora
-    event: &test-job-arm64-mediatek-event
-      channel: node
+    event:
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook
-      result: pass
-      kind: kbuild
-      state: available
     platforms: *mediatek-platforms
 
   test-job-arm64-mediatek-cros-kernel: &test-job-arm64-mediatek-cros-kernel
     <<: *test-job-arm64-mediatek
     event:
-      <<: *test-job-arm64-mediatek-event
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromeos-daily-mediatek
 
   test-job-arm64-mediatek-media-committers: &test-job-arm64-mediatek-media-committers
     <<: *test-job-arm64-mediatek
     event:
-      <<: *test-job-arm64-mediatek-event
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook-media-committers
 
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm
@@ -78,7 +80,7 @@ _anchors:
   test-job-arm64-qualcomm-cros-kernel: &test-job-arm64-qualcomm-cros-kernel
     <<: *test-job-arm64-qualcomm
     event:
-      <<: *test-job-arm64-mediatek-event
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromeos-daily-qualcomm
 
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm-media-committers
@@ -88,49 +90,34 @@ _anchors:
   test-job-chromeos-amd: &test-job-chromeos-amd
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-x86-chromeos-amd
-      result: pass
-      kind: kbuild
-      state: available
     platforms: *amd-platforms
 
   test-job-chromeos-intel: &test-job-chromeos-intel
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-x86-chromeos-intel
-      result: pass
-      kind: kbuild
-      state: available
     platforms: *intel-platforms
 
   test-job-chromeos-mediatek: &test-job-chromeos-mediatek
     <<: *test-job-arm64-mediatek
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromeos-mediatek
-      result: pass
-      kind: kbuild
-      state: available
 
   test-job-chromeos-qualcomm: &test-job-chromeos-qualcomm
     <<: *test-job-arm64-qualcomm
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromeos-qualcomm
-      result: pass
-      kind: kbuild
-      state: available
 
   test-job-x86: &test-job-x86
     <<: *lava-job-collabora
     event: &test-job-x86-event
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-x86
-      result: pass
-      kind: kbuild
-      state: available
 
   test-job-x86-amd: &test-job-x86-amd
     <<: *test-job-x86
@@ -342,11 +329,8 @@ scheduler:
   - job: kselftest-dt
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook
-      result: pass
-      kind: kbuild
-      state: available
     platforms:
       - mt8183-kukui-jacuzzi-juniper-sku16
       - mt8186-corsola-steelix-sku131072
@@ -358,32 +342,23 @@ scheduler:
   - job: kselftest-devices-exist
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook
-      result: pass
-      kind: kbuild
-      state: available
     platforms:
       - mt8195-cherry-tomato-r2
 
   - job: kselftest-device-error-logs
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook
-      result: pass
-      kind: kbuild
-      state: available
     platforms: *mediatek-platforms
 
   - job: kselftest-devices-probe
     <<: *lava-job-collabora
     event:
-      channel: node
+      <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromebook
-      result: pass
-      kind: kbuild
-      state: available
     platforms: *mediatek-platforms
 
   - job: kselftest-cpufreq

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -83,7 +83,7 @@ _anchors:
       <<: *kbuild-event
       name: kbuild-gcc-12-arm64-chromeos-daily-qualcomm
 
-  test-job-arm64-qualcomm: &test-job-arm64-qualcomm-media-committers
+  test-job-arm64-qualcomm-media-committers: &test-job-arm64-qualcomm-media-committers
     <<: *test-job-arm64-mediatek-media-committers
     platforms: *qualcomm-platforms
 

--- a/config/scheduler-cip.yaml
+++ b/config/scheduler-cip.yaml
@@ -9,7 +9,6 @@ _anchors:
 
   node-event: &node-event-kbuild
     channel: node
-    result: pass
     kind: kbuild
     state: available
 
@@ -40,4 +39,3 @@ _anchors:
 
     - job: kbuild-gcc-12-arm-cip-allnoconfig
       <<: *build-k8s-all
-

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -17,7 +17,6 @@ _anchors:
 
   node-event: &node-event-kbuild
     channel: node
-    result: pass
     kind: kbuild
     state: available
 


### PR DESCRIPTION
Until now, test jobs were triggered when corresponding `kbuild` nodes
were changed to `result: pass`. This made sense as those nodes would
immediately and always transition to state `done` upon completion.

As they're now going through the `available` state when successful, we
can use this event instead for triggering test jobs.

Make this change throughout all scheduler configs, improving
`scheduler-chromeos` through the use of a corresponding anchor in the
process.

Depends on https://github.com/kernelci/kernelci-core/pull/2882