### PR TITLE
config/pipeline.yaml: Purge lab config for Qualcomm

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -159,13 +159,6 @@ runtimes:
       callback:
         token: kernel-ci-callback
 
-  lava-qualcomm:
-    lab_type: lava
-    url: 'https://lava.infra.foundries.io'
-    notify:
-      callback:
-        token: kernelci-lab-qualcomm
-
   shell:
     lab_type: shell
 


### PR DESCRIPTION
Purge an entry to `runtimes` section for Qualcomm
lab as lab is adopting KernelCI 2.0 model.