### PR TITLE
config: trees: Remove self reference for stable-rc

### DIFF
--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -691,7 +691,6 @@ build_configs:
     branch: 'for-next'
 
   stable-rc_5.4: &stable-rc
-    <<: *stable-rc
     <<: *base
     tree: stable-rc
     branch: 'linux-5.4.y'


### PR DESCRIPTION
For some reason the stable-rc tree definition references itself.  I'm
surprised this is valid, and can't imagine it's helpful (I do note that
we're not currently generating test jobs for stable-rc...), so let's
remove it.

Signed-off-by: Mark Brown <broonie@kernel.org>
