### PR TITLE
(k8s) Add readiness probe

### DIFF
--- a/kube/aks/lava-callback.yaml
+++ b/kube/aks/lava-callback.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: lava-callback
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: lava-callback
           image: kernelci/kernelci:lava-callback@sha256:255fdb9dfd0552f22c50cb60debf5de3ef7f1c675f9bd14231d14a31bc24368f

--- a/kube/aks/monitor.yaml
+++ b/kube/aks/monitor.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: monitor
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: monitor
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb

--- a/kube/aks/nodehandlers.yaml
+++ b/kube/aks/nodehandlers.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: timeout
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: timeout
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb
@@ -67,6 +77,16 @@ spec:
       labels:
         app: closing
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: timeout
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb
@@ -111,7 +131,16 @@ spec:
       labels:
         app: holdoff
     spec:
-      containers:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done      containers:
         - name: timeout
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb
           imagePullPolicy: Always

--- a/kube/aks/pipeline-kcidb.yaml
+++ b/kube/aks/pipeline-kcidb.yaml
@@ -15,6 +15,16 @@ spec:
       labels:
         app: pipeline-kcidb
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: pipeline-kcidb
           image: kernelci/kernelci:pipeline@sha256:0c4a5ca55a7de6788dda0ac869210f8adfc169f1a0509b4c8e44335ac71488e2

--- a/kube/aks/scheduler-k8s.yaml
+++ b/kube/aks/scheduler-k8s.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: scheduler-k8s
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: scheduler
           image: kernelci/kernelci:pipeline@sha256:5ecd9b94a22f064a15a9ded85cbe09ff10018fe7cf6fdfaca794121f3b4a4b5f

--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: scheduler-lava
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: scheduler
           image: kernelci/kernelci:pipeline@sha256:5ecd9b94a22f064a15a9ded85cbe09ff10018fe7cf6fdfaca794121f3b4a4b5f

--- a/kube/aks/scheduler-shell.yaml
+++ b/kube/aks/scheduler-shell.yaml
@@ -20,6 +20,16 @@ spec:
       labels:
         app: scheduler-shell
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: scheduler
           image: kernelci/kernelci:pipeline@sha256:34b13865be01a90b600604b7612f4cc048463d72626c2175ba2d2b40375eee12

--- a/kube/aks/tarball.yaml
+++ b/kube/aks/tarball.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: tarball
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: tarball
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb

--- a/kube/aks/trigger.yaml
+++ b/kube/aks/trigger.yaml
@@ -19,6 +19,16 @@ spec:
       labels:
         app: trigger
     spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl --fail --silent --insecure https://kernelci-api.westus3.cloudapp.azure.com/; do
+                echo "Waiting for API endpoint..."; sleep 5;
+              done
       containers:
         - name: trigger
           image: kernelci/kernelci:pipeline@sha256:bb01424c4dedcd2ffa87cef225b09116cf874bc2b91fc63ed6d993d6fc5c43cb


### PR DESCRIPTION
pipeline services should not start before API is ready, otherwise we might have various side effects, or event pipeline services that are running, but not subscribed to events.