### PR TITLE
config: scheduler-chromeos: Add intel platforms for fault injection testing

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -293,6 +293,10 @@ scheduler:
 
   - job: fault-injection-x86-intel-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
+    platforms:
+      - acer-cbv514-1h-34uz-brya
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
     event:
       <<: *test-job-x86-event
       name: kbuild-gcc-12-x86-chromeos-daily-intel-fault-injection


### PR DESCRIPTION
Currently, fault injection test is only running on one platform, add specific platforms for the test to run on them.