### PR TITLE
config: Enable the fchmodat2 selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1598,6 +1598,13 @@ jobs:
       collections: exec
     kcidb_test_suite: kselftest.exec
 
+  kselftest-fchmodat2:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: fchmodat2
+    kcidb_test_suite: kselftest.fchmodat2
+
   kselftest-ftrace:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -811,6 +811,22 @@ scheduler:
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
 
+  - job: kselftest-fchmodat2
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
+  - job: kselftest-fchmodat2
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: kselftest-ftrace
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
These are again small, software only tests.

Signed-off-by: Mark Brown <broonie@kernel.org>
