### PR TITLE
config: Enable the timens selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1702,6 +1702,13 @@ jobs:
       collections: signal
     kcidb_test_suite: kselftest.signal
 
+  kselftest-timens:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: timens
+    kcidb_test_suite: kselftest.timens
+
   kselftest-timers:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -955,6 +955,22 @@ scheduler:
     platforms:
       - bcm2837-rpi-3-b-plus
 
+  - job: kselftest-timens
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-timens
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-timers
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime


### PR DESCRIPTION
The time namespace selftests are simple software only tests.

Signed-off-by: Mark Brown <broonie@kernel.org>
