### PR TITLE
config: Split 32 and 64 bit Arm jobs in the Baylibre lab

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -125,6 +125,7 @@ jobs:
   baseline-arm-pengutronix: *baseline-job
   baseline-arm64: *baseline-job
   baseline-arm64-android: *baseline-job
+  baseline-arm64-baylibre: *baseline-job
   baseline-arm64-broonie: *baseline-job
   baseline-arm64-clabbe: *baseline-job
   baseline-arm64-kcidebug-mediatek: *baseline-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -52,19 +52,8 @@ scheduler:
       - beagle-xm
       - beaglebone-black
       - da850-lcdk
-      - k3-j721e-sk
-      - k3-j721e-beagleboneai64
       - jetson-tk1
-      - meson-axg-s400
-      - meson-g12a-u200
-      - meson-g12a-x96-max
-      - meson-g12b-odroid-n2
-      - meson-gxl-s905d-p230
-      - meson-gxl-s905x-libretech-cc
-      - meson-sm1-khadas-vim3l
-      - meson-sm1-sei610
       - mt7629-rfb
-      - sun50i-a64-pine64-plus
       - sun7i-a20-cubieboard2
 
   - job: baseline-arm-broonie
@@ -160,6 +149,23 @@ scheduler:
       name: kbuild-gcc-12-arm64-android
     runtime: *lava-collabora-runtime
     platforms: *collabora-arm64-platforms
+
+  - job: baseline-arm64-baylibre
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-baylibre-runtime
+    platforms:
+      - k3-j721e-sk
+      - k3-j721e-beagleboneai64
+      - meson-g12a-u200
+      - meson-g12a-x96-max
+      - meson-g12b-odroid-n2
+      - meson-axg-s400
+      - meson-gxl-s905x-libretech-cc
+      - meson-gxl-s905d-p230
+      - meson-sm1-khadas-vim3l
+      - meson-sm1-sei610
+      - sun50i-a64-pine64-plus
+
 
   - job: baseline-arm64-broonie
     event: *kbuild-gcc-12-arm64-node-event


### PR DESCRIPTION
The configuration has a single baseline job for the 32 and 64 bit Arm
boards in the Baylibre lab, tied to the 32 bit Arm builds.  This
obviously doesn't work for the 64 bit boards, resulting in inconclusive
boots as the 64 bit boards don't understand zImage.  Split into a
separate baseline job like the other labs.

Signed-off-by: Mark Brown <broonie@kernel.org>
