### PR TITLE
config: Enable proc selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1695,6 +1695,13 @@ jobs:
       collections: perf_events
     kcidb_test_suite: kselftest.perf_events
 
+  kselftest-proc:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: proc
+    kcidb_test_suite: kselftest.proc
+
   kselftest-ptrace:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -987,6 +987,22 @@ scheduler:
       - bcm2711-rpi-4-b
       - sun50i-h5-libretech-all-h3-cc
 
+  - job: kselftest-proc
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
+  - job: kselftest-proc
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-rlimits
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The proc selftests are software only, enable them for one board per
platform in my lab.  While there is a config fragment for these it only
has PROC_FS in it which is going to be in all defconfigs so just use the
standard defconfig.

Signed-off-by: Mark Brown <broonie@kernel.org>
