### PR TITLE
config: Enable GPIO selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1619,6 +1619,13 @@ jobs:
       collections: futex
     kcidb_test_suite: kselftest.futex
 
+  kselftest-gpio:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: gpio
+    kcidb_test_suite: kselftest.gpio
+
   kselftest-iommu:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -855,6 +855,22 @@ scheduler:
     platforms:
       - beaglebone-black
 
+  - job: kselftest-gpio
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
+  - job: kselftest-gpio
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
   - job: kselftest-ipc
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
This is actually a software only suite, it validates the core using a
software simulation of GPIOs rather than interacting with hardware.

Signed-off-by: Mark Brown <broonie@kernel.org>
