### PR TITLE
config: Run the KVM selftests in pKVM on arm64 systems that support it

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1647,6 +1647,14 @@ jobs:
       collections: kvm
     kcidb_test_suite: kselftest.kvm
 
+  kselftest-kvm-pkvm:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      extra_kernel_args: "kvm-arm.mode=protected"
+      collections: pkvm
+    kcidb_test_suite: kselftest.pkvm
+
   kselftest-landlock:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -894,6 +894,15 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm64
 
+  - job: kselftest-kvm-pkvm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - imx8mp-evk
+      - imx8mp-verdin-nonwifi-dahlia
+
   - job: kselftest-landlock
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
Protected KVM is an arm64 KVM feature which provides for hypervisor
protection of some VMs, enable testing of this mode where supported.
The main requirement currently is for GICv3.

Signed-off-by: Mark Brown <broonie@kernel.org>
