### PR TITLE
(kbuild.jinja2) Get return code properly

### DIFF
--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -12,6 +12,8 @@
 from kernelci.kbuild import KBuild
 import os
 import sys
+import subprocess
+
 {%- endblock %}
 
 {%- block python_globals %}
@@ -61,10 +63,11 @@ def main(args):
     build.set_storage_config(STORAGE_CONFIG_YAML)
     build.write_script("build.sh")
     build.serialize("_build.json")
-    r = os.system("bash -e build.sh")
+    result = subprocess.run(["bash", "-e", "build.sh"])
+    exit_code = result.returncode
     build2 = KBuild.from_json("_build.json")
     build2.verify_build()
-    results = build2.submit(r)
+    results = build2.submit(exit_code)
     return results
 
 {% endblock %}


### PR DESCRIPTION
In Python, os.system() returns the exit status in a platform-specific format. On Unix-like systems, it returns the exit status shifted left by 8 bits. Here's what's happening:
- My shell script exits with code 1 (build failure)
- os.system() returns 256 (1 << 8)