### PR TITLE
config: Fix cut'n'paste errors in the VisionFive2 integration

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -166,11 +166,11 @@ platforms:
     dtb: starfive/jh7100-starfive-visionfive-v1.dtb
     compatible: ["starfive,visionfive-v1", "starfive,jh7100"]
 
-  jh7100-starfive-visionfive-v1-3b:
+  jh7110-starfive-visionfive-2-v1-3b:
     <<: *riscv-device
     mach: starfive
-    dtb: starfive/jh7100-starfive-visionfive-v1.dtb
-    compatible: ["starfive,visionfive-v1.3b", "starfive,jh7100"]
+    dtb: starfive/jh7110-starfive-visionfive-2-v1.3.dtb
+    compatible: ["starfive,visionfive-2-v1.3b", "starfive,jh7110"]
 
   juno-uboot:
     <<: *arm64-device

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -256,7 +256,7 @@ scheduler:
       name: kbuild-gcc-12-riscv
     runtime: *lava-broonie-runtime
     platforms:
-      - jh7100-starfive-visionfive-v1-3b
+      - jh7110-starfive-visionfive-2-v1-3b
 
   - job: baseline-riscv-clabbe
     event: *kbuild-gcc-12-riscv-node-event


### PR DESCRIPTION
The SoC name changed from the original board mainly.

Signed-off-by: Mark Brown <broonie@kernel.org>
