### PR TITLE
Enable kvm-unit-tests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -60,6 +60,17 @@ _anchors:
       fragments:
         - 'kselftest'
 
+  kvm-unit-tests-job: &kvm-unit-tests-job
+    template: kvm-unit-tests.jinja2
+    kind: job
+    params: &kvm-unit-tests-params
+      boot_commands: nfs
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kvm-unit-tests/20240129.0/{debarch}'
+    kcidb_test_suite: kvm-unit-tests
+    rules:
+      fragments:
+        - '!kselftest'
+
   ltp-job: &ltp-job
     template: ltp.jinja2
     kind: job
@@ -1819,6 +1830,14 @@ jobs:
       tree:
         - '!omap'
         - '!chromiumos'
+
+  kvm-unit-tests:
+    <<: *kvm-unit-tests-job
+
+  kvm-unit-tests-pkvm:
+    <<: *kvm-unit-tests-job
+    params:
+      extra_kernel_args: "kvm-arm.mode=protected"
 
   ltp-cap-bounds:
     <<: *ltp-job

--- a/config/runtime/kvm-unit-tests.jinja2
+++ b/config/runtime/kvm-unit-tests.jinja2
@@ -1,0 +1,4 @@
+{%- set boot_commands = 'nfs' %}
+{%- set test_method = 'kvm-unit-tests' %}
+{%- set base_template = 'base/' + runtime + '.jinja2' %}
+{%- extends base_template %}

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -948,7 +948,7 @@ scheduler:
       <<: *node-event-kbuild
       name: kbuild-gcc-12-arm64-kselftest
     runtime: *lava-broonie-runtime
-    platforms:
+    platforms: &lava-broonie-pkvm
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
 
@@ -1217,6 +1217,20 @@ scheduler:
     event: *checkout-event
     runtime:
       name: k8s-gke-eu-west4
+
+  - job: kvm-unit-tests
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm64
+
+  - job: kvm-unit-tests-pkvm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-pkvm
 
   - job: ltp-cap-bounds
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
kvm-unit-tests provide some lower level tests for KVM, this hooks up the
pipeline parts of enabling it, initially only for boards in my lab.

The LAVA templates are in https://github.com/kernelci/kernelci-core/pull/2895
which also includes changes to support building a rootfs including the suite.

- config: Provide kvm-unit-tests jobs
- config: Enable kvm-unit-tests in my lab
