### PR TITLE
kube: aks: add lava-pengutronix runtime

### DIFF
--- a/kube/aks/scheduler-lava.yaml
+++ b/kube/aks/scheduler-lava.yaml
@@ -47,6 +47,7 @@ spec:
             - lava-clabbe
             - lava-qualcomm
             - lava-cip
+            - lava-pengutronix
           env:
             - name: KCI_API_TOKEN
               valueFrom:


### PR DESCRIPTION
This Runtime has been in use only by Maestro Staging instance so far (docker-compose-based deployment). Add it to Kubernetes deployment defaults to enable LAVA TestJob submissions from Maestro Production instance as well.