### PR TITLE
config: trees: Drop nonexistent Build configuration for linux-pci tree

### DIFF
--- a/config/trees/linux-pci.yaml
+++ b/config/trees/linux-pci.yaml
@@ -10,7 +10,3 @@ build_configs:
   linux-pci_for-linus:
     <<: *linux-pci
     branch: 'for-linus'
-
-  linux-pci_for-kernelci:
-    <<: *linux-pci
-    branch: 'for-kernelci'


### PR DESCRIPTION
Branch "for-kernelci" does not exist for this tree.