### PR TITLE
docker-compose-lava: Comply with the new Staging deployment process

### DIFF
--- a/docker-compose-lava.yaml
+++ b/docker-compose-lava.yaml
@@ -10,8 +10,9 @@ services:
   lava-callback:
     container_name: 'kernelci-pipeline-lava-callback'
     networks: ['lava-callback']
-    build:
-      context: 'docker/lava-callback'
+    image: 'kernelci/staging-kernelci:lava-callback'
+    #build:
+    #  context: 'docker/lava-callback'
     env_file: ['.env']
     ports:
       - '${LAVA_CALLBACK_PORT:-8100}:8000'


### PR DESCRIPTION
Docker image for Service "lava_callback" had previously been built on-demand during Staging instance deployment. This has been changed in the new Staging deployment workflow.

This patch uses prebuilt Docker image for "lava_callback" Service. Docker image build context will be dropped in the future if it's deemed unnecessary from development point of view as well.