### PR TITLE
config: Enable LSM selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1684,6 +1684,13 @@ jobs:
       collections: landlock
     kcidb_test_suite: kselftest.landlock
 
+  kselftest-lsm:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: lsm
+    kcidb_test_suite: kselftest.lsm
+
   # No hugepages allocation (for architectures without it)
   kselftest-mm:
     <<: *kselftest-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -968,6 +968,22 @@ scheduler:
     platforms:
       - stm32mp157a-dhcor-avenger96
 
+  - job: kselftest-lsm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2711-rpi-4-b
+
+  - job: kselftest-lsm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
   - job: kselftest-mm
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
Software only tests, enabled for one board per architecture in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
