### PR TITLE
config: Enable sync selftest

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1760,6 +1760,13 @@ jobs:
       collections: signal
     kcidb_test_suite: kselftest.signal
 
+  kselftest-sync:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: sync
+    kcidb_test_suite: kselftest.sync
+
   kselftest-timens:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1077,6 +1077,22 @@ scheduler:
     platforms:
       - bcm2837-rpi-3-b-plus
 
+  - job: kselftest-sync
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
+  - job: kselftest-sync
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-timens
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The sync selftests are software only, this isn't terribly actively
worked on.

Signed-off-by: Mark Brown <broonie@kernel.org>
