### PR TITLE
Revert "config: trees: Drop nonexistent Build configuration for linux-pci tree"

### DIFF
--- a/config/trees/linux-pci.yaml
+++ b/config/trees/linux-pci.yaml
@@ -10,3 +10,7 @@ build_configs:
   linux-pci_for-linus:
     <<: *linux-pci
     branch: 'for-linus'
+
+  linux-pci_for-kernelci:
+    <<: *linux-pci
+    branch: 'for-kernelci'


### PR DESCRIPTION
This reverts commit 346a543548cdcb7462d2bcd4f6af0ebe1b139724.

Branch "for-kernelci" is added on demand and its temporary absence shouldn't be considered as a permanent removal.