### PR TITLE
config: Update to LTP 20250530 release

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -120,7 +120,7 @@ _anchors:
     kind: job
     params: &ltp-cros-kernel-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250523.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250617.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -65,7 +65,7 @@ _anchors:
     kind: job
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250523.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250617.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
     kcidb_test_suite: ltp


### PR DESCRIPTION
Update to the 20250617.0 rootfs build, which switches to (and ensures
that we stick to) the LTP 20250530 release tag.

Signed-off-by: Mark Brown <broonie@kernel.org>
