### PR TITLE
config: Enable LTP smoketest on AT91SAM9G20-EK

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -112,7 +112,7 @@ scheduler:
       - stm32mp157c-lxa-tac-gen1
 
   - job: baseline-arm
-    event:
+    event: &kbuild-gcc-12-armv5-node-event
       <<: *node-event-kbuild
       name: kbuild-gcc-12-arm-multi_v5_defconfig
     runtime: *lava-broonie-runtime
@@ -1319,6 +1319,12 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - beaglebone-black
+
+  - job: ltp-smoketest
+    event: *kbuild-gcc-12-armv5-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - at91sam9g20ek
 
   - job: ltp-smoketest
     event: *kbuild-gcc-12-arm64-node-event


### PR DESCRIPTION
We currently have no LTP coverage for ARMv5, but we can and do build
rootfs images for Debian's armel architecture.  Start making use of
these to provide LTP coverage for this architecture variant using the
AT91SAM9G20-EK in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
