### PR TITLE
Switch Trigger Service main loop data structure

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -134,27 +134,23 @@ class Trigger(Service):
         except Exception as ex:
             self.traceback(ex)
 
-    def _iterate_build_configs(self, force, build_configs_list,
-                               timeout, trees):
+    def _iterate_build_configs(self, force, timeout, trees):
         for name, config in self._build_configs.items():
-            if not build_configs_list or name in build_configs_list:
-                self._run_trigger(config, force, timeout, trees)
+            self._run_trigger(config, force, timeout, trees)
 
     def _setup(self, args):
         return {
             'poll_period': int(args.poll_period),
             'force': args.force,
-            'build_configs_list': (args.build_configs or '').split(),
             'startup_delay': int(args.startup_delay or 0),
             'timeout': args.timeout,
             'trees': args.trees,
         }
 
     def _run(self, ctx):
-        poll_period, force, build_configs_list, startup_delay, timeout, trees = (
+        poll_period, force, startup_delay, timeout, trees = (
             ctx[key] for key in (
-                'poll_period', 'force', 'build_configs_list', 'startup_delay',
-                'timeout', 'trees'
+                'poll_period', 'force', 'startup_delay', 'timeout', 'trees'
             )
         )
 
@@ -163,8 +159,7 @@ class Trigger(Service):
             time.sleep(startup_delay)
 
         while True:
-            self._iterate_build_configs(force, build_configs_list,
-                                        timeout, trees)
+            self._iterate_build_configs(force, timeout, trees)
             if poll_period:
                 self.log.info(f"Sleeping for {poll_period}s")
                 time.sleep(poll_period)
@@ -190,10 +185,6 @@ class cmd_run(Command):
             'name': '--force',
             'action': 'store_true',
             'help': "Always create a new checkout node",
-        },
-        {
-            'name': '--build-configs',
-            'help': "List of build configurations to monitor",
         },
         {
             'name': '--name',

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -26,6 +26,7 @@ class Trigger(Service):
     def __init__(self, configs, args):
         super().__init__(configs, args, 'trigger')
         self._build_configs = configs['build_configs']
+        self._trees = configs['trees']
         self._current_user = self._api.user.whoami()
 
     def _log_revision(self, message, build_config, head_commit):
@@ -134,9 +135,11 @@ class Trigger(Service):
         except Exception as ex:
             self.traceback(ex)
 
-    def _iterate_build_configs(self, force, timeout, trees):
-        for name, config in self._build_configs.items():
-            self._run_trigger(config, force, timeout, trees)
+    def _iterate_trees(self, force, timeout, trees):
+        for tree in self._trees.keys():
+            build_configs = {name: config for name, config in self._build_configs.items() if config.tree.name == tree}
+            for name, config in build_configs.items():
+                self._run_trigger(config, force, timeout, trees)
 
     def _setup(self, args):
         return {
@@ -159,7 +162,7 @@ class Trigger(Service):
             time.sleep(startup_delay)
 
         while True:
-            self._iterate_build_configs(force, timeout, trees)
+            self._iterate_trees(force, timeout, trees)
             if poll_period:
                 self.log.info(f"Sleeping for {poll_period}s")
                 time.sleep(poll_period)


### PR DESCRIPTION
Build configurations list will not be known up front when external configuration files are enabled in Maestro. Dropping `build_configs` filter will allow simplifying Trigger Service logic taking into account only parameters that are still relevant.