### PR TITLE
config: Enable LTP syscalls suite

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1358,6 +1358,18 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
 
+  - job: ltp-syscalls
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
+  - job: ltp-syscalls
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2711-rpi-4-b
+
   - job: ltp-syscalls-ipc
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime


### PR DESCRIPTION
The LTP syscalls suite is one of the larger ones, put it on some faster
boards in my lab (with multiple cores so we'll get a bit of a speedup
when the parallel workers stuff lands).

Signed-off-by: Mark Brown <broonie@kernel.org>
