### PR TITLE
config: Include jq in the LTP rootfs images

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -120,7 +120,7 @@ _anchors:
     kind: job
     params: &ltp-cros-kernel-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250617.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250618.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -65,7 +65,7 @@ _anchors:
     kind: job
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250617.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250618.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
     kcidb_test_suite: ltp


### PR DESCRIPTION
Since switching to kirk we need jq in the rootfs in order to submit LTP
results, update to a new build of the rootfs which includes it.

Signed-off-by: Mark Brown <broonie@kernel.org>
