### PR TITLE
config: Update to current kselftest rootfs

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1466,7 +1466,7 @@ jobs:
     params: &kselftest-params
       test_method: kselftest
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250619.0/{debarch}'
       job_timeout: 10
     rules: &kselftest-rules
       tree:


### PR DESCRIPTION
We've not updated the kselftest rootfs since January but there have been
plenty of changes since then, including fixing the mm selftests so they
don't hang.  Update to a current build.

Signed-off-by: Mark Brown <broonie@kernel.org>
