### PR TITLE
config: Add Radxa Orion O6

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -85,6 +85,11 @@ platforms:
     dtb: dtbs/am335x-boneblack.dtb
     compatible: ['ti,am335x-bone-black', 'ti,am335x-bone', 'ti,am33xx']
 
+  cd8180-orion-o6:
+    <<: *arm64-device
+    mach: cix
+    boot_method: grub
+
   da850-lcdk:
     <<: *arm-device
     mach: davinci

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -175,6 +175,7 @@ scheduler:
     platforms: &lava-broonie-arm64
       - bcm2711-rpi-4-b
       - bcm2837-rpi-3-b-plus
+      - cd8180-orion-o6
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
       - juno-uboot


### PR DESCRIPTION
I've got a couple of the 8G ones in my lab, they boot using grub from
TianoCore/EDK2 firmware.  Once the board is enabled I'll add a bunch
more tests on it.

Signed-off-by: Mark Brown <broonie@kernel.org>
