### PR TITLE
config: Enable more tests on the Orion O6

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1720,6 +1720,15 @@ jobs:
       collections: mm
     kcidb_test_suite: kselftest.mm
 
+  # hugepages allocation suitable for machines with 8G and more of memory
+  kselftest-mm-8g:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      extra_kernel_args: "secretmem.enable hugepagesz=1G hugepages=0:4 hugepagesz=32M hugepages=0:4 default_hugepagesz=2M hugepages=0:128 hugepagesz=64K hugepages=0:4 kpti=off"
+      collections: mm
+    kcidb_test_suite: kselftest.mm
+
   kselftest-mqueue:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -794,6 +794,7 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - bcm2837-rpi-3-b-plus
+      - cd8180-orion-o6
       - meson-sm1-s905d3-libretech-cc
 
   - job: kselftest-capabilities
@@ -993,6 +994,14 @@ scheduler:
     platforms:
       - stm32mp157a-dhcor-avenger96
 
+  - job: kselftest-mm-8g
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - cd8180-orion-o6
+
   - job: kselftest-mm-2g
     event:
       <<: *node-event-kbuild
@@ -1139,6 +1148,7 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - bcm2837-rpi-3-b-plus
+      - cd8180-orion-o6
 
   - job: kselftest-seccomp
     event:
@@ -1167,6 +1177,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - sun50i-h5-libretech-all-h3-cc
+      - cd8180-orion-o6
 
   - job: kselftest-ublk
     event:
@@ -1468,6 +1479,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2711-rpi-4-b
+      - cd8180-orion-o6
 
   - job: ltp-syscalls-ipc
     event: *kbuild-gcc-12-arm-node-event


### PR DESCRIPTION
- config: Add Radxa Orion O6
- config: Enable more tests on the Orion O6
