### PR TITLE
config: Enable parallel LTP execution

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -79,6 +79,7 @@ _anchors:
       nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250618.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
+      workers: max
     kcidb_test_suite: ltp
     rules:
       fragments:


### PR DESCRIPTION
The Kirk LTP runner which we are using supports parallel execution of
tests, this is fortunately able to identify and appropriately handle
tests that have to be run single threaded making it relatively easy to
use.  It does unfortunately make the console output a bit less helpful
but they're still there, and Kirk does report per-test logs.

With the test-definitions integration we can specify the number of
workers as "max" in order to allow one worker per CPU in the system, do
that by default.  There is some risk that tests might interfere with
each other and become less stable, if this becomes an issue we can
revisit and use this only for suites that particularly benefit.

Signed-off-by: Mark Brown <broonie@kernel.org>
