### PR TITLE
KVM job scheduling improvements

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1258,16 +1258,12 @@ scheduler:
       name: k8s-gke-eu-west4
 
   - job: kvm-unit-tests
-    event:
-      <<: *node-event-kbuild
-      name: kbuild-gcc-12-arm64
+    event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-kvm
 
   - job: kvm-unit-tests-pkvm
-    event:
-      <<: *node-event-kbuild
-      name: kbuild-gcc-12-arm64
+    event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-pkvm
 

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -942,7 +942,13 @@ scheduler:
       <<: *node-event-kbuild
       name: kbuild-gcc-12-arm64-kselftest
     runtime: *lava-broonie-runtime
-    platforms: *lava-broonie-arm64
+    platforms: &lava-broonie-kvm
+      - bcm2711-rpi-4-b
+      - bcm2837-rpi-3-b-plus
+      - imx8mp-evk
+      - imx8mp-verdin-nonwifi-dahlia
+      - meson-sm1-s905d3-libretech-cc
+      - sun50i-a64-pine64-plus
 
   - job: kselftest-kvm-pkvm
     event:
@@ -1256,7 +1262,7 @@ scheduler:
       <<: *node-event-kbuild
       name: kbuild-gcc-12-arm64
     runtime: *lava-broonie-runtime
-    platforms: *lava-broonie-arm64
+    platforms: *lava-broonie-kvm
 
   - job: kvm-unit-tests-pkvm
     event:


### PR DESCRIPTION
- config: Focus scheduling of KVM tests in my lab
- config: Use standard event to trigger kvm-unit-tests jobs
