### PR TITLE
config: runtime: kunit: download kernel source in job

### DIFF
--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -88,6 +88,7 @@ cd {src_path}
         return artifacts
 
     def _run(self, src_path):
+        src_path = self._get_kernel_source()
         job_log = 'job.txt'
         kunit_json = 'kunit.json'
         job_log_path, kunit_json_path = (


### PR DESCRIPTION
Due to changes in the top-level `python` template, the kernel source is now only downloaded and unpacked for `kbuild` nodes. Let's add the needed bits to `kunit` jobs so we get the full source as well.

Depends on https://github.com/kernelci/kernelci-core/pull/2909