### PR TITLE
requirements: Bump uWSGI for LAVA Callback

### DIFF
--- a/requirements-lava-callback.txt
+++ b/requirements-lava-callback.txt
@@ -1,4 +1,4 @@
-uwsgi==2.0.22
+uwsgi==2.0.30
 uvicorn==0.30.1
 fastapi==0.111.0
 pyjwt==2.8.0


### PR DESCRIPTION
This upgrade is required for migrating base Pipeline image to Python 3.12.