### PR TITLE
(platforms.yaml) Add support for Qualcomm x1e80100-crd platform

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -418,6 +418,13 @@ platforms:
     dtb: dtbs/rockchip/rk3588-rock-5b.dtb
     compatible: ['radxa,rock-5b', 'rockchip,rk3588']
 
+  x1e80100:
+    <<: *arm64-device
+    boot_method: fastboot
+    mach: qcom
+    dtb: dtbs/qcom/x1e80100-crd.dtb
+    compatible: ['qcom,x1e80100-crd', 'qcom,x1e80100']
+
   shell:
 
   stm32mp157a-dhcor-avenger96:


### PR DESCRIPTION
Extend pipeline to support Qualcomm platform x1e80100-crd.