### PR TITLE
config: Enable AM62 Mallow in my lab

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -183,6 +183,13 @@ platforms:
     dtb: dtbs/arm/juno.dtb
     compatible: ['arm,juno', 'arm,vexpress']
 
+  k3-am625-verdin-wifi-mallow:
+    <<: *arm64-device
+    mach: ti
+    dtb: dtbs/ti/k3-am625-verdin-wifi-mallow.dtb
+    compatible: ['toradex,verdin-am62-wifi-mallow', 'toradex,verdin-am62-wifi',
+                 'toradex,verdin-am62', 'ti,am625']
+
   k3-j721e-sk:
     <<: *arm64-device
     mach: ti

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -179,6 +179,7 @@ scheduler:
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
       - juno-uboot
+      - k3-am625-verdin-wifi-mallow
       - meson-g12b-a311d-libretech-cc
       - meson-gxl-s905x-libretech-cc
       - meson-sm1-s905d3-libretech-cc
@@ -948,6 +949,7 @@ scheduler:
       - bcm2837-rpi-3-b-plus
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
+      - k3-am625-verdin-wifi-mallow
       - meson-sm1-s905d3-libretech-cc
       - sun50i-a64-pine64-plus
 
@@ -959,6 +961,7 @@ scheduler:
     platforms: &lava-broonie-pkvm
       - imx8mp-evk
       - imx8mp-verdin-nonwifi-dahlia
+      - k3-am625-verdin-wifi-mallow
 
   - job: kselftest-landlock
     event:


### PR DESCRIPTION
Toradex have been kind enough to send me an AM62 Mallow system, enable
some basic tests on it in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
