### PR TITLE
config: Enable TPM2 selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1848,6 +1848,13 @@ jobs:
       collections: timers
     kcidb_test_suite: kselftest.timers
 
+  kselftest-tpm2:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: tpm2
+    kcidb_test_suite: kselftest.tpm2
+
   kselftest-ublk:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1188,6 +1188,14 @@ scheduler:
       - sun50i-h5-libretech-all-h3-cc
       - cd8180-orion-o6
 
+  - job: kselftest-tpm2
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - k3-am625-verdin-wifi-mallow
+
   - job: kselftest-ublk
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The AM62 Mallow board in my lab has a TPM so is able to run the TPM2
selftests, use it to enable them.  I imagine some of the Chromebooks
could also do this.

Signed-off-by: Mark Brown <broonie@kernel.org>
