### PR TITLE
config: Run more tests on Orion O6

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -870,6 +870,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2711-rpi-4-b
+      - cd8180-orion-o6
 
   - job: kselftest-ftrace
     event:
@@ -884,6 +885,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - meson-gxl-s905x-libretech-cc
+      - cd8180-orion-o6
 
   - job: kselftest-futex
     event: *kbuild-gcc-12-arm-node-event
@@ -1078,6 +1080,7 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2711-rpi-4-b
+      - cd8180-orion-o6
       - sun50i-h5-libretech-all-h3-cc
 
   - job: kselftest-proc


### PR DESCRIPTION
The Orion O6 is a v9 system so there's some benefit in running tests
that might exercise new architecture features.

Signed-off-by: Mark Brown <broonie@kernel.org>
