### PR TITLE
config/scheduler.yaml: Enable device error log test in my lab

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -837,12 +837,12 @@ scheduler:
     platforms:
       - meson-gxl-s905x-libretech-cc
 
-  - job: kselftest-dt
+  - job: kselftest-device-error-logs-main
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm
 
-  - job: kselftest-dt
+  - job: kselftest-device-error-logs-main
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm64
@@ -853,6 +853,21 @@ scheduler:
     platforms:
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
+
+  - job: kselftest-dt
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm
+
+  - job: kselftest-dt
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm
+
+  - job: kselftest-dt
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms: *lava-broonie-arm64
 
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm64-node-event


### PR DESCRIPTION
Run the device error logs test on all the boards in my lab.  It would
probably be interesting to consider adding this to the end of other test
jobs as boilerplate in case the other tests trigger any issues.

While we're at it sort the existing entry for these tests in the
Collabora lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
