### PR TITLE
config: Enable efivars test

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1657,6 +1657,13 @@ jobs:
         patchlevel: 7
     kcidb_test_suite: kselftest.dt
 
+  kselftest-efivars:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: efivars
+    kcidb_test_suite: kselftest.efivars
+
   kselftest-exec:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -847,6 +847,14 @@ scheduler:
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
 
+  - job: kselftest-efivars
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - cd8180-orion-o6
+
   - job: kselftest-fchmodat2
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The Orion O6 has a TianoCore based firmware so supports EFI variables,
enable the efivars selftest on it.

Signed-off-by: Mark Brown <broonie@kernel.org>
