### PR TITLE
config: Enable zram selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1876,6 +1876,13 @@ jobs:
       collections: vDSO
     kcidb_test_suite: kselftest.vdso
 
+  kselftest-zram:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: zram
+    kcidb_test_suite: kselftest.zram
+
   kunit: &kunit-job
     template: kunit.jinja2
     kind: job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1248,6 +1248,22 @@ scheduler:
     platforms:
       - meson-gxl-s905x-libretech-cc
 
+  - job: kselftest-zram
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - stm32mp157a-dhcor-avenger96
+
+  - job: kselftest-zram
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2711-rpi-4-b
+
   - job: kselftest-cpufreq
     event: *kbuild-gcc-12-arm64-node-event
     runtime: *lava-collabora-runtime


### PR DESCRIPTION
The zram selftests are software only, enable them on a couple of
boards in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
