### PR TITLE
config: Enable tmpfs selftest

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1875,6 +1875,13 @@ jobs:
       collections: timers
     kcidb_test_suite: kselftest.timers
 
+  kselftest-tmpfs:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: tmpfs
+    kcidb_test_suite: kselftest.tmpfs
+
   kselftest-tpm2:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1234,6 +1234,18 @@ scheduler:
       - bcm2837-rpi-3-b-plus
       - cd8180-orion-o6
 
+  - job: kselftest-tmpfs
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-tmpfs
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-seccomp
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
Currently this is just a simple software only test for a single tmpfs
bug, enable it on a couple of boards in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
