### PR TITLE
config: rework all coverage-enabled jobs

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -126,8 +126,6 @@ _anchors:
       extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"
     kcidb_test_suite: ltp
     rules: &ltp-cros-kernel-rules
-      fragments:
-        - '!kselftest'
       tree:
         - chromiumos
 
@@ -811,7 +809,6 @@ jobs:
       <<: *ltp-cros-kernel-rules
       fragments:
         - 'crypto'
-        - '!kselftest'
 
   ltp-ima-cros-kernel:
     <<: *ltp-cros-kernel-job

--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -620,6 +620,26 @@ jobs:
         version: 6
         patchlevel: 1
 
+  kbuild-gcc-12-arm64-chromeos-mediatek-coverage:
+    <<: *kbuild-gcc-12-arm64-chromeos-job
+    params: &kbuild-gcc-12-arm64-chromeos-mediatek-coverage-params
+      <<: *kbuild-gcc-12-arm64-chromeos-mediatek-params
+      fragments:
+        - arm64-chromebook
+        - coverage
+        - crypto
+        - kselftest
+        - lab-setup
+        - CONFIG_MODULE_COMPRESS=n
+        - CONFIG_MODULE_COMPRESS_NONE=y
+    rules:
+      <<: *kbuild-gcc-12-arm64-chromeos-rules
+      min_version:
+        version: 6
+        patchlevel: 1
+      tree:
+        - chromiumos
+
   kbuild-gcc-12-arm64-chromeos-daily-mediatek:
     <<: *kbuild-gcc-12-arm64-chromeos-job
     params:
@@ -639,6 +659,16 @@ jobs:
       <<: *kbuild-gcc-12-arm64-chromeos-params
       flavour: qualcomm
 
+  kbuild-gcc-12-arm64-chromeos-qualcomm-coverage:
+    <<: *kbuild-gcc-12-arm64-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-arm64-chromeos-mediatek-coverage-params
+      flavour: qualcomm
+    rules:
+      <<: *kbuild-gcc-12-arm64-chromeos-rules
+      tree:
+        - 'chromiumos'
+
   kbuild-gcc-12-arm64-chromeos-daily-qualcomm:
     <<: *kbuild-gcc-12-arm64-chromeos-job
     params:
@@ -656,6 +686,24 @@ jobs:
     params: &kbuild-gcc-12-x86-chromeos-amd-params
       <<: *kbuild-gcc-12-x86-chromeos-params
       flavour: amd-stoneyridge
+
+  kbuild-gcc-12-x86-chromeos-amd-coverage:
+    <<: *kbuild-gcc-12-x86-chromeos-job
+    params: &kbuild-gcc-12-x86-chromeos-amd-coverage-params
+      <<: *kbuild-gcc-12-x86-chromeos-params
+      flavour: amd-stoneyridge
+      fragments:
+        - coverage
+        - crypto
+        - kselftest
+        - lab-setup
+        - x86-board
+        - CONFIG_MODULE_COMPRESS=n
+        - CONFIG_MODULE_COMPRESS_NONE=y
+    rules:
+      <<: *kbuild-gcc-12-x86-chromeos-rules
+      tree:
+        - 'chromiumos'
 
   kbuild-gcc-12-x86-chromeos-daily-amd:
     <<: *kbuild-gcc-12-x86-chromeos-job
@@ -675,6 +723,16 @@ jobs:
     params: &kbuild-gcc-12-x86-chromeos-intel-params
       <<: *kbuild-gcc-12-x86-chromeos-params
       flavour: intel-pineview
+
+  kbuild-gcc-12-x86-chromeos-intel-coverage:
+    <<: *kbuild-gcc-12-x86-chromeos-job
+    params:
+      <<: *kbuild-gcc-12-x86-chromeos-amd-coverage-params
+      flavour: intel-pineview
+    rules:
+      <<: *kbuild-gcc-12-x86-chromeos-rules
+      tree:
+        - 'chromiumos'
 
   kbuild-gcc-12-x86-chromeos-daily-intel:
     <<: *kbuild-gcc-12-x86-chromeos-job

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1379,23 +1379,6 @@ jobs:
       - '!android'
       - '!chromiumos'
 
-  kbuild-gcc-12-x86-coverage:
-    <<: *kbuild-gcc-12-x86-job
-    params:
-      <<: *kbuild-gcc-12-x86-params
-      fragments:
-        - 'coverage'
-        - 'lab-setup'
-        - 'x86-board'
-    rules:
-      tree:
-      - 'chromiumos'
-      - 'collabora-chromeos-kernel:for-kernelci'
-      - 'mainline:master'
-      - 'next:master'
-      - 'stable'
-      - 'stable-rc'
-
   kbuild-gcc-12-x86-kselftest:
     <<: *kbuild-gcc-12-x86-job
     params:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -312,10 +312,16 @@ scheduler:
   - job: kbuild-gcc-12-arm64-chromeos-mediatek
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-arm64-chromeos-mediatek-coverage
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-arm64-chromeos-daily-mediatek
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm64-chromeos-qualcomm
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-arm64-chromeos-qualcomm-coverage
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-arm64-chromeos-daily-qualcomm
@@ -324,10 +330,16 @@ scheduler:
   - job: kbuild-gcc-12-x86-chromeos-amd
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-12-x86-chromeos-amd-coverage
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-12-x86-chromeos-daily-amd
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-chromeos-intel
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-12-x86-chromeos-intel-coverage
     <<: *build-k8s-all
 
   - job: kbuild-gcc-12-x86-chromeos-daily-intel

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -61,6 +61,12 @@ _anchors:
       name: kbuild-gcc-12-arm64-chromebook
     platforms: *mediatek-platforms
 
+  test-job-arm64-mediatek-coverage: &test-job-arm64-mediatek-coverage
+    <<: *test-job-arm64-mediatek
+    event:
+      <<: *kbuild-event
+      name: kbuild-gcc-12-arm64-chromeos-mediatek-coverage
+
   test-job-arm64-mediatek-cros-kernel: &test-job-arm64-mediatek-cros-kernel
     <<: *test-job-arm64-mediatek
     event:
@@ -76,6 +82,12 @@ _anchors:
   test-job-arm64-qualcomm: &test-job-arm64-qualcomm
     <<: *test-job-arm64-mediatek
     platforms: *qualcomm-platforms
+
+  test-job-arm64-qualcomm-coverage: &test-job-arm64-qualcomm-coverage
+    <<: *test-job-arm64-qualcomm
+    event:
+      <<: *kbuild-event
+      name: kbuild-gcc-12-arm64-chromeos-qualcomm-coverage
 
   test-job-arm64-qualcomm-cros-kernel: &test-job-arm64-qualcomm-cros-kernel
     <<: *test-job-arm64-qualcomm
@@ -123,6 +135,12 @@ _anchors:
     <<: *test-job-x86
     platforms: *amd-platforms
 
+  test-job-x86-amd-coverage: &test-job-x86-amd-coverage
+    <<: *test-job-x86-amd
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-chromeos-amd-coverage
+
   test-job-x86-amd-cros-kernel: &test-job-x86-amd-cros-kernel
     <<: *test-job-x86-amd
     event:
@@ -132,6 +150,12 @@ _anchors:
   test-job-x86-intel: &test-job-x86-intel
     <<: *test-job-x86
     platforms: *intel-platforms
+
+  test-job-x86-intel-coverage: &test-job-x86-intel-coverage
+    <<: *test-job-x86-intel
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-chromeos-intel-coverage
 
   test-job-x86-intel-cros-kernel: &test-job-x86-intel-cros-kernel
     <<: *test-job-x86-intel
@@ -505,121 +529,241 @@ scheduler:
       - hp-11A-G6-EE-grunt
 
   - job: ltp-capability-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-capability-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-capability-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-capability-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-capability-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-capability-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-capability-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-capability-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-containers-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-containers-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-containers-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-containers-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-containers-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-containers-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-containers-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-crypto-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-crypto-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-crypto-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-crypto-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-crypto-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-crypto-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-crypto-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-ima-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-ima-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-ima-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-ima-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-ima-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-ima-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-ima-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-ima-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-input-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-input-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-input-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-input-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-input-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-input-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-input-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-ipc-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-ipc-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-ipc-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-ipc-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-ipc-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-ipc-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-ipc-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-kernel-misc-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-kernel-misc-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-kernel-misc-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-kernel-misc-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-kernel-misc-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-kernel-misc-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-kernel-misc-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-kernel-misc-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-mm-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-mm-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-mm-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-mm-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-mm-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-mm-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-mm-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-mm-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-pty-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-pty-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-pty-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-pty-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-pty-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-pty-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-pty-cros-kernel
     <<: *test-job-x86-intel-cros-kernel
 
   - job: ltp-sched-cros-kernel
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: ltp-sched-cros-kernel
     <<: *test-job-arm64-mediatek-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-arm64-qualcomm-coverage
 
   - job: ltp-sched-cros-kernel
     <<: *test-job-arm64-qualcomm-cros-kernel
 
   - job: ltp-sched-cros-kernel
+    <<: *test-job-x86-amd-coverage
+
+  - job: ltp-sched-cros-kernel
     <<: *test-job-x86-amd-cros-kernel
+
+  - job: ltp-sched-cros-kernel
+    <<: *test-job-x86-intel-coverage
 
   - job: ltp-sched-cros-kernel
     <<: *test-job-x86-intel-cros-kernel

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -129,12 +129,6 @@ _anchors:
       <<: *test-job-x86-event
       name: kbuild-gcc-12-x86-chromeos-daily-amd
 
-  test-job-x86-coverage: &test-job-x86-coverage
-    <<: *test-job-x86
-    event:
-      <<: *test-job-x86-event
-      name: kbuild-gcc-12-x86-coverage
-
   test-job-x86-intel: &test-job-x86-intel
     <<: *test-job-x86
     platforms: *intel-platforms
@@ -456,22 +450,8 @@ scheduler:
       - hp-11A-G6-EE-grunt
       - hp-x360-12b-ca0010nr-n4020-octopus
 
-  - job: ltp-crypto
-    <<: *test-job-x86-coverage
-    platforms:
-      - asus-C523NA-A20057-coral
-      - hp-11A-G6-EE-grunt
-      - hp-x360-12b-ca0010nr-n4020-octopus
-
   - job: ltp-fcntl-locktests
     <<: *test-job-x86
-    platforms:
-      - asus-C433TA-AJ0005-rammus
-      - asus-C523NA-A20057-coral
-      - hp-11A-G6-EE-grunt
-
-  - job: ltp-fcntl-locktests
-    <<: *test-job-x86-coverage
     platforms:
       - asus-C433TA-AJ0005-rammus
       - asus-C523NA-A20057-coral
@@ -482,21 +462,8 @@ scheduler:
     platforms:
       - asus-C523NA-A20057-coral
 
-  - job: ltp-ima
-    <<: *test-job-x86-coverage
-    platforms:
-      - asus-C523NA-A20057-coral
-
   - job: ltp-ipc
     <<: *test-job-x86
-    platforms:
-      - acer-cp514-2h-1130g7-volteer
-      - asus-C436FA-Flip-hatch
-      - hp-11A-G6-EE-grunt
-      - hp-x360-12b-ca0010nr-n4020-octopus
-
-  - job: ltp-ipc
-    <<: *test-job-x86-coverage
     platforms:
       - acer-cp514-2h-1130g7-volteer
       - asus-C436FA-Flip-hatch
@@ -510,13 +477,6 @@ scheduler:
       - hp-11A-G6-EE-grunt
       - hp-x360-12b-ca0010nr-n4020-octopus
 
-  - job: ltp-mm
-    <<: *test-job-x86-coverage
-    platforms:
-      - asus-C436FA-Flip-hatch
-      - hp-11A-G6-EE-grunt
-      - hp-x360-12b-ca0010nr-n4020-octopus
-
   - job: ltp-pty
     <<: *test-job-x86
     platforms:
@@ -524,23 +484,8 @@ scheduler:
       - asus-C523NA-A20057-coral
       - hp-11A-G6-EE-grunt
 
-  - job: ltp-pty
-    <<: *test-job-x86-coverage
-    platforms:
-      - asus-C433TA-AJ0005-rammus
-      - asus-C523NA-A20057-coral
-      - hp-11A-G6-EE-grunt
-
   - job: ltp-timers
     <<: *test-job-x86
-    platforms:
-      - asus-C433TA-AJ0005-rammus
-      - asus-C436FA-Flip-hatch
-      - asus-C523NA-A20057-coral
-      - hp-11A-G6-EE-grunt
-
-  - job: ltp-timers
-    <<: *test-job-x86-coverage
     platforms:
       - asus-C433TA-AJ0005-rammus
       - asus-C436FA-Flip-hatch

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -713,9 +713,6 @@ scheduler:
   - job: kbuild-gcc-12-x86-build-only
     <<: *build-k8s-all
 
-  - job: kbuild-gcc-12-x86-coverage
-    <<: *build-k8s-all
-
   - job: kbuild-gcc-12-x86-kcidebug
     <<: *build-k8s-all
 


### PR DESCRIPTION
Our only planned user for code coverage analysis is the ChromeOS kernel team, so this PR fully reworks the coverage-enabled builds and test jobs.

To sum things up, the current, generic x86 kernel build is replaced by 4 distinct builds:
* 2 for Intel & AMD ChromeBooks (x86)
* 2 for Qualcomm & Mediatek ChromeBooks (arm64)

Those builds use the following config fragments on top of the usual ones:
* `coverage` for enabling GCOV support in the kernel
* `kselftest` so we can run the corresponding tests on those kernels (will be enabled as a follow-up PR)
* `crypto` so those kernels can also execute the `ltp-crypto` job

All LTP jobs currently executed on the ChromeOS kernel are now also scheduled for those new builds, replacing the previous LTP scheduler entries (those were using the generic x86 build which is phased out in this PR).