### PR TITLE
config: Enable sync selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1827,6 +1827,13 @@ jobs:
       collections: signal
     kcidb_test_suite: kselftest.signal
 
+  kselftest-splice:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: splice
+    kcidb_test_suite: kselftest.splce
+
   kselftest-sync:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1112,6 +1112,22 @@ scheduler:
     platforms:
       - bcm2837-rpi-3-b-plus
 
+  - job: kselftest-splice
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-splice
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-sync
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The sync selftest is a software only test, enable it on a few boards in
my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
