### PR TITLE
config: Enable ring-buffer selftest

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1806,6 +1806,13 @@ jobs:
       collections: ptrace
     kcidb_test_suite: kselftest.ptrace
 
+  kselftest-ring-buffer:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: ring-buffer
+    kcidb_test_suite: kselftest.ring-buffer
+
   kselftest-rlimits:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1096,6 +1096,22 @@ scheduler:
     platforms:
       - bcm2837-rpi-3-b-plus
 
+  - job: kselftest-ring-buffer
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-ring-buffer
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
   - job: kselftest-rlimits
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
The ring buffer selftest is another software only test, enable it on a
couple of boards in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
