### PR TITLE
config: Enable memfd selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1742,6 +1742,13 @@ jobs:
       collections: lsm
     kcidb_test_suite: kselftest.lsm
 
+  kselftest-memfd:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: memfd
+    kcidb_test_suite: kselftest.memfd
+
   # No hugepages allocation (for architectures without it)
   kselftest-mm:
     <<: *kselftest-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -995,6 +995,22 @@ scheduler:
     platforms:
       - stm32mp157a-dhcor-avenger96
 
+  - job: kselftest-memfd
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2837-rpi-3-b-plus
+
+  - job: kselftest-memfd
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-12-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
   - job: kselftest-mm
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
Another software only test enabled on one board per architecture in my
lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
