### PR TITLE
config: Enable coredump selftest

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1571,6 +1571,13 @@ jobs:
       collections: clone3
     kcidb_test_suite: kselftest.clone3
 
+  kselftest-coredump:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: coredump
+    kcidb_test_suite: kselftest.coredump
+
   kselftest-cpufreq:
     <<: *kselftest-job
     template: generic.jinja2

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -822,6 +822,18 @@ scheduler:
     platforms:
       - meson-gxl-s905x-libretech-cc
 
+  - job: kselftest-coredump
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-coredump
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime: *lava-broonie-runtime
+    platforms:
+      - meson-gxl-s905x-libretech-cc
+
   - job: kselftest-dt
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime


### PR DESCRIPTION
A very simple, quick software only test.  Enable it for one board per
arch in my lab.

Signed-off-by: Mark Brown <broonie@kernel.org>
