### PR TITLE
Add qcom-next tree to run CI/CD on the next branch

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -106,6 +106,7 @@ _anchors:
     - 'next'
     - 'pm'
     - 'qcom'
+    - 'qcom-next'
     - 'renesas'
     - 'robh'
     - 'rppt'

--- a/config/trees.yaml
+++ b/config/trees.yaml
@@ -116,6 +116,9 @@ trees:
   qcom:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
 
+  qcom-next:
+    url: "https://github.com/qualcomm-linux/kernel.git"
+
   renesas:
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"
 

--- a/config/trees/qcom-next.yaml
+++ b/config/trees/qcom-next.yaml
@@ -1,0 +1,6 @@
+build_configs:
+  qcom-next:
+    tree: qcom-next
+    branch: 'qcom-next'
+    architectures:
+      - arm64


### PR DESCRIPTION
Integrates the qcom-next tree to enable CI/CD workflows on the 'next' branch to 
ensures validation of changes and improves stability across development iterations.