### PR TITLE
lava_callback: take into account jobfilter suffix if needed

### DIFF
--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -637,7 +637,10 @@ async def checkout(data: ManualCheckout, request: Request,
             if len(data.jobfilter) > 8:
                 item['message'] = 'Too many jobs in jobfilter'
                 return JSONResponse(content=item, status_code=400)
-            for jobname in data.jobfilter:
+            # jobfilter entries can be suffixed with '+', meaning this
+            # job and all of its child jobs are allowed; we should
+            # therefore drop the suffix when checking if job exists
+            for jobname in (f.rstrip('+') for f in data.jobfilter):
                 if not is_job_exist(jobname):
                     item['message'] = f'Job {jobname} not found'
                     return JSONResponse(content=item, status_code=404)


### PR DESCRIPTION
`jobfilter` entries can now be suffixed with a `+` (see https://github.com/kernelci/kernelci-core/pull/2930), meaning "this job and all of its child nodes are allowed". We need to take this into account by dropping this suffix if it's present when checking whether the listed job actually exists.