### PR TITLE
scheduler: Reduce load on Avenger96

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -791,7 +791,6 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - beaglebone-black
-      - stm32mp157a-dhcor-avenger96
 
   - job: kselftest-breakpoints
     event: *kbuild-gcc-12-arm64-node-event
@@ -1019,7 +1018,7 @@ scheduler:
       name: kbuild-gcc-12-arm-kselftest
     runtime: *lava-broonie-runtime
     platforms:
-      - stm32mp157a-dhcor-avenger96
+      - beaglebone-black
 
   - job: kselftest-memfd
     event:
@@ -1193,7 +1192,7 @@ scheduler:
       name: kbuild-gcc-12-arm-kselftest
     runtime: *lava-broonie-runtime
     platforms:
-      - stm32mp157a-dhcor-avenger96
+      - beaglebone-black
 
   - job: kselftest-sync
     event:
@@ -1224,7 +1223,6 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - beaglebone-black
-      - stm32mp157a-dhcor-avenger96
 
   - job: kselftest-timers
     event: *kbuild-gcc-12-arm64-node-event
@@ -1277,7 +1275,7 @@ scheduler:
       name: kbuild-gcc-12-arm-kselftest
     runtime: *lava-broonie-runtime
     platforms:
-      - stm32mp157a-dhcor-avenger96
+      - beaglebone-black
 
   - job: kselftest-ublk
     event:


### PR DESCRIPTION
Theere's only one Avenger96 in my lab, and it's running the LTP syscalls
suite which is fairly lengthy.  Remove all the other generic tests from
the board, leaving only things that test the specific hardware.

Signed-off-by: Mark Brown <broonie@kernel.org>
