### PR TITLE
Fix re-subscription logic from pipeline services

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -59,13 +59,15 @@ class Monitor(Service):
             try:
                 event = self._api.receive_event(sub_id)
             except Exception as e:
-                self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
-                time.sleep(10)
-                sub_id = self._api.subscribe('node')
-                subscribe_retries += 1
-                if subscribe_retries > 3:
-                    self.log.error("Failed to re-subscribe to node events")
-                    return False
+                self.log.error(f"Error receiving event: {e}")
+                if "404 Client Error" in str(e):
+                    self.log.error(f"Error receiving event: {e}. Re-subscribing...")
+                    sub_id = self._setup(None)
+                    subscribe_retries += 1
+                    if subscribe_retries > 3:
+                        self.log.error("Failed to re-subscribe to node events")
+                        return False
+                    continue
                 continue
             subscribe_retries = 0
             obj = event.data

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -382,13 +382,15 @@ class Scheduler(Service):
             try:
                 event = self._api_helper.receive_event_data(sub_id, block=False)
             except Exception as e:
-                self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
-                time.sleep(10)
-                sub_id = self._api.subscribe('node')
-                subscribe_retries += 1
-                if subscribe_retries > 3:
-                    self.log.error("Failed to re-subscribe to node events")
-                    return False
+                self.log.error(f"Error receiving event: {e}")
+                if "404 Client Error" in str(e):
+                    self.log.error(f"Error receiving event: {e}. Re-subscribing...")
+                    sub_id = self._setup(None)
+                    subscribe_retries += 1
+                    if subscribe_retries > 3:
+                        self.log.error("Failed to re-subscribe to node events")
+                        return False
+                    continue
                 continue
             if not event:
                 # If we received a keep-alive event, just continue

--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -702,13 +702,15 @@ in {runtime}",
                 try:
                     node, is_hierarchy = self._api_helper.receive_event_node(context['sub_id'])
                 except Exception as e:
-                    self.log.error(f"Error receiving event: {e}, re-subscribing in 10 seconds")
-                    time.sleep(10)
-                    context['sub_id'] = self._api_helper.subscribe_filters(self._filters, promiscuous=True)
-                    subscribe_retries += 1
-                    if subscribe_retries > 3:
-                        self.log.error("Failed to re-subscribe to node events")
-                        return False
+                    self.log.error(f"Error receiving event: {e}")
+                    if "404 Client Error" in str(e):
+                        self.log.error(f"Error receiving event: {e}. Re-subscribing...")
+                        context['sub_id'] = self._api_helper.subscribe_filters(self._filters, promiscuous=True)
+                        subscribe_retries += 1
+                        if subscribe_retries > 3:
+                            self.log.error("Failed to re-subscribe to node events")
+                            return False
+                        continue
                     continue
                 subscribe_retries = 0
                 self.log.info(f"Processing event node: {node['id']}")


### PR DESCRIPTION
When API helper functions `receive_event_node` or `receive_event_data` fail, there may be some issue with extracting node data from the event rather than an issue with the subscription.
Check exception message before resubscribing.

Fixes: f04f6d0 ("(events): Add re-subscribe mechanism")