### PR TITLE
platforms: Fix typo

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -174,7 +174,7 @@ platforms:
   jh7110-starfive-visionfive-2-v1-3b:
     <<: *riscv-device
     mach: starfive
-    dtb: starfive/jh7110-starfive-visionfive-2-v1.3.dtb
+    dtb: starfive/jh7110-starfive-visionfive-2-v1.3b.dtb
     compatible: ["starfive,visionfive-2-v1.3b", "starfive,jh7110"]
 
   juno-uboot:


### PR DESCRIPTION
The Vision5 was missing a b in the DTB name.

Signed-off-by: Mark Brown <broonie@kernel.org>
