### PR TITLE
src: lava_callback, job_retry: fix retry logic

### DIFF
--- a/src/job_retry.py
+++ b/src/job_retry.py
@@ -73,6 +73,11 @@ Not submitting a retry.")
                 if not event_data:
                     self.log.error(f"Not able to find parent node for {node['id']}")
                     continue
+                # Test jobs are triggered on `available` state only
+                # Note: post-processing jobs such as coverage report generation are triggered
+                # when kbuild node changes state to `done`, but we don't care about retrying
+                # those (at least for now)
+                event_data["state"] = "available"
                 event_data["jobfilter"] = [node["name"]]
                 event_data["platform_filter"] = [node["data"].get("platform")]
                 event_data["retry_counter"] = retry_counter + 1

--- a/src/lava_callback.py
+++ b/src/lava_callback.py
@@ -482,13 +482,15 @@ async def jobretry(data: JobRetry, request: Request,
         knode['jobfilter'].extend(data.jobfilter)
     knode['op'] = 'updated'
     knode['data'].pop('artifacts', None)
-    # state - done, result - pass
-    if knode.get('state') != 'done':
-        item['message'] = 'Kernel build is not done'
+    # state - closing, available or done / result - pass
+    if knode.get('state') == 'running':
+        item['message'] = 'Kernel build is not complete yet'
         return JSONResponse(content=item, status_code=400)
     if knode.get('result') != 'pass':
         item['message'] = 'Kernel build result is not pass'
         return JSONResponse(content=item, status_code=400)
+    # set state to available so retried test job is scheduled as expected
+    knode['state'] = 'available'
     # remove created, updated, timeout, owner, submitter, usergroups
     knode.pop('created', None)
     knode.pop('updated', None)


### PR DESCRIPTION
Due to state machine improvements over the past few months, test jobs are scheduled when `kbuild` nodes transition to the `available` state. The retry logic is currently triggered only when `kbuild` is `done`, preserving this state in the generated event. This causes log entries such as the following to show up:
```
  Job coverage-report not found in jobfilter for node (['ltp-syscalls'])
```
This is due to the event being submitted with state `done`, causing only the post-processing jobs (in this case `coverage-report`) to be tentatively scheduled, rather than actual test jobs.

Fix this by allowing the `kbuild` node state to be anything but `running` (meaning the build has completed anyway) and setting the state *in the event* to `available`: this will cause the scheduler to trigger all test jobs for this `kbuild`, but discarding almost all of those because of the `jobfilter` entry.