### PR TITLE
config: fix coverage-report jobs

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -158,7 +158,7 @@ jobs:
 
   coverage-report-arm: &coverage-report-job
     template: coverage-report.jinja2
-    kind: job
+    kind: process
     image: ghcr.io/kernelci/{image_prefix}gcc-12:arm-kselftest-kernelci
     rules: &coverage-report-rules
       arch:

--- a/config/runtime/coverage-report.jinja2
+++ b/config/runtime/coverage-report.jinja2
@@ -97,7 +97,7 @@ class Job(BaseJob):
 
         return {
             'node': {
-                'result': 'pass' if node['id'] == self._node['id'] else node['result'],
+                'result': 'pass',
                 'artifacts': {},
             },
             'child_nodes': child_nodes,
@@ -124,7 +124,10 @@ class Job(BaseJob):
         tracefile = coverage_dir + '.json'
         json_summary = coverage_dir + '.summary.json'
         self._logfile.write(f"--- Processing coverage data for {node['id']} ---\n")
-        cmd = subprocess.run(self._gcovr_cmd + [
+        cmd = subprocess.run([
+            'gcovr',
+            '--gcov-ignore-parse-errors',
+            '--root', self._src_path,
             '--object-directory', coverage_dir,
             '--json', tracefile,
             '--json-summary', json_summary,
@@ -185,12 +188,6 @@ class Job(BaseJob):
         self._src_path = os.path.join(self._workspace, 'linux')
         self._logfile.write(f"Coverage source downloaded from {tarball_url}\n")
 
-        self._gcovr_cmd = [
-            'gcovr',
-            '--gcov-ignore-parse-errors',
-            '--root', self._src_path,
-        ]
-
         output_base = os.path.join(self._workspace, f"coverage-{self._node['parent']}")
 
         if parent_node['kind'] == 'job':
@@ -227,13 +224,14 @@ class Job(BaseJob):
             # Coverage data has been processed for all job nodes, we can now merge the tracefiles
             tracefile = output_base + '.json'
             json_summary = output_base + '.summary.json'
-            args = self._gcovr_cmd
-            for trace in tracefiles:
-                args += ['--add-tracefile', trace]
-            args += [
+            args = [
+                'gcovr',
+                '--root', self._src_path,
                 '--json', tracefile,
                 '--json-summary', json_summary,
             ]
+            for trace in tracefiles:
+                args += ['--add-tracefile', trace]
 
             self._logfile.write("--- Merging tracefiles ---\n")
             cmd = subprocess.run(args,
@@ -246,7 +244,9 @@ class Job(BaseJob):
 
         self._logfile.write("--- Generating HTML report ---\n")
         html_report = output_base + '.html'
-        args = self._gcovr_cmd + [
+        args = [
+            'gcovr',
+            '--root', self._src_path,
             '--add-tracefile', tracefile,
             '--html', html_report,
         ]

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -341,13 +341,25 @@ scheduler:
     <<: *build-k8s-all
     event: *node-event-kbuild-done
 
+  - job: coverage-report-arm
+    <<: *build-k8s-all
+    event: *job-event
+
   - job: coverage-report-arm64
+    <<: *build-k8s-all
+    event: *node-event-kbuild-done
+
+  - job: coverage-report-arm64
+    <<: *build-k8s-all
+    event: *job-event
+
+  - job: coverage-report-x86
     <<: *build-k8s-all
     event: *node-event-kbuild-done
 
   - job: coverage-report-x86
     <<: *build-k8s-all
-    event: *node-event-kbuild-done
+    event: *job-event
 
   - job: kbuild-clang-17-arm
     <<: *build-k8s-all


### PR DESCRIPTION
The current only `coverage-report` entry is using the x86 toolchain, making it unable to process arm* results. Fix this by splitting this job definition into 3 variants, one for each architecture for which we could want coverage support.

Moreover, when a lot of test jobs are being triggered for a single `kbuild`, the processing time becomes a real issue, making the coverage-report job time out after 6 hours! This problem is fixed by processing the results for each job once they complete, and only use the kbuild-triggered job for merging all those data and generating the global HTML report.