### PR TITLE
src: scheduler: fix crash in _verify_architecture_filter()

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -377,7 +377,7 @@ class Scheduler(Service):
         """Verify if the job can be run, if node has architecture filter
         """
         if job.kind == 'kbuild' and 'architecture_filter' in node['data'] and \
-           node['data']['architecture_filter'] and \
+           node['data']['architecture_filter'] and 'arch' in job.params and \
            job.params['arch'] not in node['data']['architecture_filter']:
             msg = f"Node {node['id']} has architecture filter "
             msg += f"{node['data']['architecture_filter']} "


### PR DESCRIPTION
For some reason, kbuild jobs might not have an `arch` param, so let's ensure we don't crash in this case.

This error can be seen in the `scheduler-k8s` service:

```
Exception in thread Thread-2 (_run_scheduler):
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/home/kernelci/pipeline/./src/scheduler.py", line 442, in _run_scheduler
    if not self._verify_architecture_filter(job, input_node):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/scheduler.py", line 381, in _verify_architecture_filter
    job.params['arch'] not in node['data']['architecture_filter']:
    ~~~~~~~~~~^^^^^^^^
KeyError: 'arch'
```