### PR TITLE
Enable build job retry

### DIFF
--- a/src/job_retry.py
+++ b/src/job_retry.py
@@ -20,7 +20,7 @@ class JobRetry(Service):
     def _setup(self, args):
         return self._api_helper.subscribe_filters({
             "state": "done",
-            "result": ("fail", "incomplete"),
+            "result": "incomplete",
             "kind": ("kbuild", "job"),
         })
 


### PR DESCRIPTION
Enable job retry service to trigger retry for failed/incomplete build jobs.