### PR TITLE
Address deprecation warnings for `datetime.datetime.utcnow()`

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -8,7 +8,7 @@
 # Author: Nikolay Yurin <yurinnick@meta.com>
 
 import copy
-from datetime import datetime, timedelta
+import datetime
 import os
 import re
 import sys
@@ -174,7 +174,7 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
             'artifacts': {
                 'tarball': tarball_url,
             },
-            'holdoff': str(datetime.utcnow() + timedelta(minutes=10))
+            'holdoff': str(datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=10))
         })
         try:
             self._api.node.update(node)

--- a/src/timeout.py
+++ b/src/timeout.py
@@ -6,7 +6,7 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 import sys
-from datetime import datetime
+import datetime
 from time import sleep
 import json
 import requests
@@ -100,7 +100,7 @@ class Timeout(TimeoutService):
 
         while True:
             timeout_nodes = self._get_pending_nodes({
-                'timeout__lt': datetime.isoformat(datetime.utcnow())
+                'timeout__lt': datetime.datetime.isoformat(datetime.datetime.now(datetime.UTC))
             })
             self._submit_lapsed_nodes(timeout_nodes, 'done', 'TIMEOUT')
             sleep(ctx['poll_period'])

--- a/src/trigger.py
+++ b/src/trigger.py
@@ -7,7 +7,7 @@
 # Author: Jeny Sadadia <jeny.sadadia@collabora.com>
 
 import copy
-from datetime import datetime, timedelta
+import datetime
 import sys
 import time
 
@@ -102,9 +102,9 @@ class Trigger(Service):
             'branch': current_config.branch,
             'commit': head_commit,
         }
-        checkout_timeout = datetime.utcnow() + timedelta(minutes=timeout)
+        checkout_timeout = datetime.datetime.now(datetime.UTC) + datetime.timedelta(minutes=timeout)
         # treeid is sha256(url+branch+timestamp)
-        hashstr = revision['url'] + revision['branch'] + str(datetime.now())
+        hashstr = revision['url'] + revision['branch'] + str(datetime.datetime.now())
         treeid = hashlib.sha256(hashstr.encode()).hexdigest()
         node = {
             'name': 'checkout',


### PR DESCRIPTION
Closes https://github.com/kernelci/kernelci-pipeline/issues/1276

Update pipeline services to use `datetime.datetime.now(datetime.UTC)` in place of deprecated method i.e., `datetime.datetime.utcnow()`.