### PR TITLE
trigger: Fix crash on unreachable tree

### DIFF
--- a/src/trigger.py
+++ b/src/trigger.py
@@ -60,7 +60,7 @@ class Trigger(Service):
                 return
         except Exception as ex:
             self.log.error(f"Failed to get branch head for {current_config.name:32s}, ignoring")
-            self.traceback(ex)
+            self.log.traceback()
             return
         search_terms = {
             "kind": "checkout",
@@ -133,7 +133,7 @@ class Trigger(Service):
             if detail:
                 self.log.error(detail)
         except Exception as ex:
-            self.traceback(ex)
+            self.log.traceback()
 
     def _iterate_trees(self, force, timeout, trees):
         for tree in self._trees.keys():


### PR DESCRIPTION
Fix crash:
fatal: unable to access 'https://gitlab.collabora.com/google/chromeos-kernel.git/': Failed to connect to gitlab.collabora.com port 443 after 15693 ms: Couldn't connect to server 08/14/2025 04:36:07 AM UTC [ERROR] Failed to get branch head for collabora-chromeos-kernel_for-kernelci, ignoring 08/14/2025 04:36:07 AM UTC [ERROR] Traceback (most recent call last):
  File "/home/kernelci/pipeline/./src/trigger.py", line 57, in _run_trigger
    head_commit = kernelci.build.get_branch_head(current_config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kernelci/build.py", line 81, in get_branch_head
    head = shell_cmd(cmd)
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kernelci/__init__.py", line 29, in shell_cmd
    return subprocess.check_output(cmd, shell=True).decode()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'git ls-remote https://gitlab.collabora.com/google/chromeos-kernel.git refs/heads/for-kernelci' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kernelci/pipeline/src/base.py", line 70, in run
    status = self._run(context)
             ^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/trigger.py", line 165, in _run
    self._iterate_trees(force, timeout, trees)
  File "/home/kernelci/pipeline/./src/trigger.py", line 142, in _iterate_trees
    self._run_trigger(config, force, timeout, trees)
  File "/home/kernelci/pipeline/./src/trigger.py", line 63, in _run_trigger
    self.traceback(ex)
    ^^^^^^^^^^^^^^
AttributeError: 'Trigger' object has no attribute 'traceback'