### PR TITLE
tarball: fix error when commit not found

### DIFF
--- a/src/tarball.py
+++ b/src/tarball.py
@@ -11,6 +11,7 @@ import copy
 from datetime import datetime, timedelta
 import os
 import re
+import subprocess
 import sys
 import json
 import requests
@@ -270,10 +271,14 @@ git archive --format=tar --prefix={prefix}/ HEAD | gzip > {tarball_path}
                 tarball_name
             )
             tarball_url = self._push_tarball(tarball_path)
-            commit_tags, commit_message, branch_tip = self._get_commit_info(
-                self._service_config.kdir, commitid, config_tree, config_branch)
-            self._update_node(checkout_node, describe, version, tarball_url,
-                              commit_tags, commit_message, branch_tip)
+            try:
+                commit_tags, commit_message, branch_tip = self._get_commit_info(
+                    self._service_config.kdir, commitid, config_tree, config_branch)
+                self._update_node(checkout_node, describe, version, tarball_url,
+                                  commit_tags, commit_message, branch_tip)
+            except subprocess.CalledProcessError as err:
+                self._logger.error(f"Git commit info retrieval failed: {err}")
+                self._update_failed_checkout_node(checkout_node, "git_commit_error", str(err))
 
 
 class cmd_run(Command):


### PR DESCRIPTION
Fixes crash: 08/12/2025 05:15:40 PM UTC [INFO] Tarball created 08/12/2025 05:15:40 PM UTC [INFO] Uploading /home/kernelci/data/output/linux-stable-rc-linux-6.1.y-v6.1.147-254-g851142f00f891.tar.gz 08/12/2025 05:16:10 PM UTC [INFO] Upload complete: https://files.kernelci.org/linux-stable-rc-linux-6.1.y-v6.1.147-254-g851142f00f891.tar.gz fatal: bad object 6bfb1f61a3e0af6e41d6e5469ec1ab348787f73d 08/12/2025 05:16:10 PM UTC [ERROR] Traceback (most recent call last):
  File "/home/kernelci/pipeline/src/base.py", line 70, in run
    status = self._run(context)
             ^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/tarball.py", line 273, in _run
    commit_tags, commit_message, branch_tip = self._get_commit_info(
                                              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kernelci/pipeline/./src/tarball.py", line 149, in _get_commit_info
    commit_message = kernelci.build.git_commit_message(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kernelci/build.py", line 257, in git_commit_message
    message = shell_cmd(cmd)
              ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kernelci/__init__.py", line 29, in shell_cmd
    return subprocess.check_output(cmd, shell=True).decode()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '
set -e
cd /home/kernelci/data/src/linux
git show -s --format=%B 6bfb1f61a3e0af6e41d6e5469ec1ab348787f73d ' returned non-zero exit status 128.