### PR TITLE
src/timeout: fix `datetime` related error

### DIFF
--- a/src/timeout.py
+++ b/src/timeout.py
@@ -116,7 +116,7 @@ class Holdoff(TimeoutService):
     def _get_available_nodes(self):
         nodes = self._api.node.find({
             'state': 'available',
-            'holdoff__lt': datetime.isoformat(datetime.utcnow()),
+            'holdoff__lt': datetime.datetime.isoformat(datetime.datetime.now(datetime.UTC)),
         })
         return {node['id']: node for node in nodes}
 


### PR DESCRIPTION
Fix the below error:
```
File "/home/kernelci/pipeline/src/timeout.py", line 119, in _get_available_nodes
    'holdoff__lt': datetime.isoformat(datetime.utcnow()),
                   ^^^^^^^^^^^^^^^^^^
AttributeError: module 'datetime' has no attribute 'isoformat'
```
Related to: https://github.com/kernelci/kernelci-pipeline/pull/1277