### PR TITLE
config: chromeos: enable LTP fault injection tests

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -474,6 +474,16 @@ _anchors:
         - 'chromiumos:chromeos-6.6'
     kcidb_test_suite: kernelci_fault_injection
 
+  ltp-fault-injection-cros-kernel: &ltp-fault-injection-cros-kernel-job
+    <<: *ltp-cros-kernel-job
+    params: &ltp-fault-injection-cros-kernel-params
+      <<: *ltp-cros-kernel-params
+      extra_kirk_args: "-F 50"
+    rules: &ltp-fault-injection-cros-kernel-rules
+      <<: *ltp-cros-kernel-rules
+      branch:
+        - chromeos-6.6
+
   watchdog-reset: &watchdog-reset-job
     template: generic.jinja2
     kind: job
@@ -547,6 +557,7 @@ jobs:
   baseline-nfs-x86-intel-cros-kernel: *baseline-nfs-cros-kernel-job
 
   fault-injection-x86-intel-cros-kernel: *fault-injection-cros-kernel-job
+  ltp-fault-injection-x86-intel-cros-kernel: *ltp-fault-injection-cros-kernel-job
 
   kbuild-clang-17-arm64-chromeos-daily-mediatek:
     <<: *kbuild-clang-17-arm64-chromeos-job

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -181,6 +181,16 @@ _anchors:
       <<: *test-job-x86-event
       name: kbuild-gcc-12-x86-chromeos-daily-intel
 
+  test-job-x86-intel-fault-injection: &test-job-x86-intel-fault-injection
+    <<: *test-job-x86-intel-cros-kernel
+    platforms:
+      - acer-cbv514-1h-34uz-brya
+      - acer-chromebox-cxi5-brask
+      - acer-n20q11-r856ltn-p1s2-nissa
+    event:
+      <<: *test-job-x86-event
+      name: kbuild-gcc-12-x86-chromeos-daily-intel-fault-injection
+
 scheduler:
 
   - job: baseline-arm64-mediatek-chromebook
@@ -327,14 +337,10 @@ scheduler:
     <<: *build-k8s-all
 
   - job: fault-injection-x86-intel-cros-kernel
-    <<: *test-job-x86-intel-cros-kernel
-    platforms:
-      - acer-cbv514-1h-34uz-brya
-      - acer-chromebox-cxi5-brask
-      - acer-n20q11-r856ltn-p1s2-nissa
-    event:
-      <<: *test-job-x86-event
-      name: kbuild-gcc-12-x86-chromeos-daily-intel-fault-injection
+    <<: *test-job-x86-intel-fault-injection
+
+  - job: ltp-fault-injection-x86-intel-cros-kernel
+    <<: *test-job-x86-intel-fault-injection
 
   - job: kbuild-clang-17-arm64-chromeos-daily-mediatek
     <<: *build-k8s-all


### PR DESCRIPTION
Add a new job to run LTP fault injection tests with the fault-injection kernel for the chromiumos tree.