### PR TITLE
send_kcidb: fix file logging

### DIFF
--- a/docker-compose-kcidb.yaml
+++ b/docker-compose-kcidb.yaml
@@ -23,7 +23,7 @@ services:
     volumes:
       - './config:/home/kernelci/config'
       - './data/kcidb:/home/kernelci/data/kcidb'
-      - './logs:/home/kernelci/logs'
+      - './logs:/home/kernelci/pipeline/logs'
     restart: on-failure
   postgres:
     container_name: 'kernelci-pipeline-postgres-proxy'


### PR DESCRIPTION
File logging has stopped working when services started using `kernelci/staging-kernelci:pipeline` image.
Enable it again.

Related to: https://github.com/kernelci/kernelci-pipeline/pull/1265/