### PR TITLE
src: send_kcidb: process coverage-report nodes

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -567,6 +567,7 @@ in {runtime}",
         return parsed_test_node, dummy_build
 
     def _parse_coverage_node(self, origin, node):
+        self.log.debug(f"Parsing coverage node: {node['id']}")
         # Coverage report nodes are not sent to the DB themselves, but rather
         # parsed to submit an updated build node including the functions/lines
         # coverage percentages as misc fields.
@@ -597,6 +598,7 @@ in {runtime}",
             parsed_coverage_node['misc']['coverage_report_url'] = artifacts.get('coverage_report')
             parsed_coverage_node['misc']['coverage_log_url'] = artifacts.get('log')
 
+        self.log.debug(f"Parsed coverage node: {parsed_coverage_node}")
         return [parsed_coverage_node]
 
     def _get_test_data(self, node, origin,


### PR DESCRIPTION
Coverage report nodes are meant to provide global coverage percentages for a while `kbuild`, aggregating the results from individual test jobs. As such, they shouldn't be sent to KCIDB as nodes, but rather parsed in order to submit an updated build node which includes the functions/lines coverage percentages as misc fields.

Add a new processing function for such nodes, which are of kind `process` and are named `coverage-report-<arch>`.