### PR TITLE
config: chromeos: randomize fault injection value

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -478,7 +478,7 @@ _anchors:
     <<: *ltp-cros-kernel-job
     params: &ltp-fault-injection-cros-kernel-params
       <<: *ltp-cros-kernel-params
-      extra_kirk_args: "-F 50"
+      extra_kirk_args: "-F {{ range(1, 101)|random }}"
     rules: &ltp-fault-injection-cros-kernel-rules
       <<: *ltp-cros-kernel-rules
       branch:


### PR DESCRIPTION
Replace the fixed "-F 50" with a random value between 1 and 100 for the ltp-fault-injection-cros-kernel job. This ensures each job run uses a different fault injection value.