### PR TITLE
config: chromeos: pass probability value

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -464,6 +464,7 @@ _anchors:
       test_method: fault-injection
       test_name: suspend-resume
       test_command: 'rtcwake -m mem -s 15'
+      probability: "{{ range(1, 101)|random }}"
       boot_commands: nfs
       nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-fault-injection/20250520.0/{debarch}/'
       extra_kernel_args: "lsm=capability,landlock,yama,loadpin,safesetid,selinux,bpf"


### PR DESCRIPTION
Pass a random probability value between 1 and 100 for the fault-injection-cros-kernel job. This ensures each job run uses a different probability value.