### PR TITLE
platforms: Fix StarFive DTB path prefix

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -168,13 +168,13 @@ platforms:
   jh7100-starfive-visionfive-v1:
     <<: *riscv-device
     mach: starfive
-    dtb: starfive/jh7100-starfive-visionfive-v1.dtb
+    dtb: dtbs/starfive/jh7100-starfive-visionfive-v1.dtb
     compatible: ["starfive,visionfive-v1", "starfive,jh7100"]
 
   jh7110-starfive-visionfive-2-v1-3b:
     <<: *riscv-device
     mach: starfive
-    dtb: starfive/jh7110-starfive-visionfive-2-v1.3b.dtb
+    dtb: dtbs/starfive/jh7110-starfive-visionfive-2-v1.3b.dtb
     compatible: ["starfive,visionfive-2-v1.3b", "starfive,jh7110"]
 
   juno-uboot:


### PR DESCRIPTION
Platform field "dtb" requires full path to the artifact to confirm a match in the metadata [0]. It could be more convenient to configure a common prefix for such fields ("dtbs/") to reduce repetition in Maestro Pipeline configs.

[0] https://github.com/kernelci/kernelci-core/blob/4dc4f1cbd507f14307a12ef55b68f33a1db1b43a/kernelci/runtime/__init__.py#L156