### PR TITLE
config: add support for ramdisk based kselftest pipeline

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1561,6 +1561,17 @@ jobs:
       collections: arm64
     kcidb_test_suite: kselftest.arm64
 
+  kselftest-arm64-ramdisk:
+    <<: *kselftest-job
+    template: generic.jinja2
+    kind: job
+    params:
+      <<: *kselftest-params
+      collections: arm64
+      boot_commands: ramdisk
+      ramdiskroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+    kcidb_test_suite: kselftest.arm64
+
   kselftest-breakpoints:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -814,6 +814,16 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms: *lava-broonie-arm64
 
+  - job: kselftest-arm64-ramdisk
+    event: *kbuild-gcc-12-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+
   - job: kselftest-breakpoints
     event: *kbuild-gcc-12-arm-node-event
     runtime: *lava-broonie-runtime


### PR DESCRIPTION
Some platform does not support nfs boot which prevents these platforms to enable kselftest pipeline.
This change adding support for ramdisk-based kselftest pipeline by adding a new job definition.