### PR TITLE
Add devices currently in lab at pengutronix

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -104,6 +104,13 @@ platforms:
     dtb: dtbs/eswin/eic7700-hifive-premier-p550.dtb
     compatible: ['sifive,hifive-premier-p550', 'eswin,eic7700']
 
+  imx23-olinuxino:
+    <<: *arm-device
+    boot_method: barebox
+    mach: imx
+    dtb: dtbs/imx23-olinuxino.dtb
+    compatible: ['olimex,imx23-olinuxino', '"fsl,imx23']
+
   imx27-phytec-phycard-s-rdk:
     <<: *arm-device
     boot_method: barebox

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -113,6 +113,7 @@ scheduler:
       type: lava
       name: lava-pengutronix
     platforms:
+      - imx23-olinuxino
       - imx27-phytec-phycard-s-rdk
       - imx28-duckbill
       - imx53-qsrb


### PR DESCRIPTION
See https://lava.pengutronix.de/scheduler/alldevices/online for an overview

Close to #987, but updated to the new structure with splitted yaml files and without the one non-working board. Will add that later.

Closes #987