### PR TITLE
config: Update to wifi 20250925 release

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -505,7 +505,7 @@ _anchors:
     params: &wifi-basic-job-params
       test_method: wifi-basic
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20240313.0/{debarch}/'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20250925.0/{debarch}/'
     rules:
       tree:
         - mainline

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -2276,7 +2276,7 @@ jobs:
     params:
       test_method: wifi-basic
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20240313.0/{debarch}/'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20250925.0/{debarch}/'
     rules:
       tree:
         - mainline


### PR DESCRIPTION
Update to the 20250925.0 rootfs build, which includes fixes to load iwlmvm before iwlwifi. This ensures the wlan interface is created for intel boards.