### PR TITLE
.gitignore: ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 data
 *.pyc
 *.venv
-
+*.log


### PR DESCRIPTION
This helps keeping local clone status clean of generated files, which helps reasoning about changes.