### PR TITLE
config: chromeos: update fault-injection rules

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -781,6 +781,8 @@ jobs:
       tree:
         - 'chromiumos'
       branch:
+        - 'chromiumos:chromeos-5.15'
+        - 'chromiumos:chromeos-6.1'
         - 'chromiumos:chromeos-6.6'
 
   kselftest-acpi:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -186,9 +186,11 @@ _anchors:
   test-job-x86-intel-fault-injection: &test-job-x86-intel-fault-injection
     <<: *test-job-x86-intel-cros-kernel
     platforms:
+      - acer-cb317-1h-c3z6-dedede
       - acer-cbv514-1h-34uz-brya
       - acer-chromebox-cxi5-brask
       - acer-n20q11-r856ltn-p1s2-nissa
+      - hp-x360-12b-ca0010nr-n4020-octopus
     event:
       <<: *test-job-x86-event
       name: kbuild-gcc-12-x86-chromeos-daily-intel-fault-injection


### PR DESCRIPTION
Add chromeos-5.15 and chromeos-6.1 to branch rules for fault injection jobs. Add acer-cb317-1h-c3z6-dedede and hp-x360-12b-ca0010nr-n4020-octopus to test-job-x86-intel-fault-injection platforms.