### PR TITLE
jobs: Update LTP to 20250930 release

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -76,7 +76,7 @@ _anchors:
     kind: job
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250818.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251008.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       workers: max


### PR DESCRIPTION
LTP has done a new release, as have Kirk and Debian. Update to use new
rootfs images including these, probably the most exciting change here from
a KernelCI point of view is that Kirk has improvements which make the
console output much more suitable for batch use especially on multiprocessor
systems. Initial testing suggests some performance improvements as well.

Signed-off-by: Mark Brown <broonie@kernel.org>
