### PR TITLE
config: chromeos: enable kselftest for coverage-enabled builds

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -115,6 +115,28 @@ _anchors:
       tree:
         - chromiumos
 
+  kselftest: &kselftest-job
+    template: generic.jinja2
+    kind: job
+    params: &kselftest-params
+      test_method: kselftest
+      boot_commands: nfs
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+      job_timeout: 10
+    kcidb_test_suite: kselftest
+    rules:
+      tree:
+        - collabora-next:for-kernelci
+
+  kselftest-cros-kernel: &kselftest-cros-kernel-job
+    <<: *kselftest-job
+    params: &kselftest-cros-kernel-params
+      <<: *kselftest-params
+      extra_kernel_args: "lsm=capability,landlock,yama,safesetid,selinux,bpf"
+    rules: &kselftest-cros-kernel-rules
+      tree:
+        - chromiumos
+
   ltp-cros-kernel: &ltp-cros-kernel-job
     template: ltp.jinja2
     kind: job
@@ -805,31 +827,240 @@ jobs:
         - 'chromiumos:chromeos-6.6'
 
   kselftest-acpi:
-    template: generic.jinja2
-    kind: job
+    <<: *kselftest-job
     params:
-      test_method: kselftest
-      boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+      <<: *kselftest-params
       collections: acpi
-      job_timeout: 10
-    rules:
-      tree:
-        - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.acpi
 
-  kselftest-device-error-logs:
-    template: generic.jinja2
-    kind: job
+  kselftest-cros-kernel-alsa:
+    <<: *kselftest-cros-kernel-job
     params:
-      test_method: kselftest
-      boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
-      collections: devices/error_logs
-      job_timeout: 10
+      <<: *kselftest-cros-kernel-params
+      collections: alsa
+    kcidb_test_suite: kselftest.alsa
+
+  kselftest-cros-kernel-arm64:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: arm64
+    kcidb_test_suite: kselftest.arm64
+
+  kselftest-cros-kernel-capabilities:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: capabilities
+    kcidb_test_suite: kselftest.capabilities
+
+  kselftest-cros-kernel-clone3:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: clone3
+    kcidb_test_suite: kselftest.clone3
+
+  kselftest-cros-kernel-cpufreq:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: cpufreq
+    kcidb_test_suite: kselftest.cpufreq
+
+  kselftest-cros-kernel-cpufreq-suspend:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: cpufreq
+      env: 'KSELFTEST_MAIN_SH_ARGS="-t suspend_rtc"'
     rules:
-      tree:
-        - collabora-next:for-kernelci
+      <<: *kselftest-cros-kernel-rules
+      min_version:
+        version: 6
+        patchlevel: 12
+    kcidb_test_suite: kselftest.cpufreq.suspend
+
+  kselftest-cros-kernel-dmabuf-heaps:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: dmabuf-heaps
+    kcidb_test_suite: kselftest.dmabuf-heaps
+
+  kselftest-cros-kernel-dt:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: dt
+    rules:
+      <<: *kselftest-cros-kernel-rules
+      min_version:
+        version: 6
+        patchlevel: 7
+    kcidb_test_suite: kselftest.dt
+
+  kselftest-cros-kernel-exec:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: exec
+    kcidb_test_suite: kselftest.exec
+
+  kselftest-cros-kernel-ftrace:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: ftrace
+    kcidb_test_suite: kselftest.ftrace
+
+  kselftest-cros-kernel-futex:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: futex
+    kcidb_test_suite: kselftest.futex
+
+  kselftest-cros-kernel-kcmp:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: kcmp
+    kcidb_test_suite: kselftest.kcmp
+
+  kselftest-cros-kernel-kvm:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: kvm
+    kcidb_test_suite: kselftest.kvm
+
+  kselftest-cros-kernel-landlock:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: landlock
+    kcidb_test_suite: kselftest.landlock
+
+  kselftest-cros-kernel-lsm:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: lsm
+    kcidb_test_suite: kselftest.lsm
+
+  kselftest-cros-kernel-memfd:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: memfd
+    kcidb_test_suite: kselftest.memfd
+
+  kselftest-cros-kernel-net:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: net
+      job_timeout: 300
+      skipfile: https://storage.kernelci.org/skipfile-net.yaml
+    kcidb_test_suite: kselftest.net
+
+  kselftest-cros-kernel-perf-events:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: perf_events
+    kcidb_test_suite: kselftest.perf_events
+
+  kselftest-cros-kernel-proc:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: proc
+    kcidb_test_suite: kselftest.proc
+
+  kselftest-cros-kernel-ptrace:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: ptrace
+    kcidb_test_suite: kselftest.ptrace
+
+  kselftest-cros-kernel-rlimits:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: rlimits
+    kcidb_test_suite: kselftest.rlimits
+
+  kselftest-cros-kernel-seccomp:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: seccomp
+    kcidb_test_suite: kselftest.seccomp
+
+  kselftest-cros-kernel-splice:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: splice
+    kcidb_test_suite: kselftest.splce
+
+  kselftest-cros-kernel-sync:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: sync
+    kcidb_test_suite: kselftest.sync
+
+  kselftest-cros-kernel-timens:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: timens
+    kcidb_test_suite: kselftest.timens
+
+  kselftest-cros-kernel-timers:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: timers
+    kcidb_test_suite: kselftest.timers
+
+  kselftest-cros-kernel-tpm2:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: tpm2
+    kcidb_test_suite: kselftest.tpm2
+
+  kselftest-cros-kernel-user-events:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: user_events
+    kcidb_test_suite: kselftest.user_events
+
+  kselftest-cros-kernel-vdso:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: vDSO
+    kcidb_test_suite: kselftest.vdso
+
+  kselftest-cros-kernel-zram:
+    <<: *kselftest-cros-kernel-job
+    params:
+      <<: *kselftest-cros-kernel-params
+      collections: zram
+    kcidb_test_suite: kselftest.zram
+
+  kselftest-device-error-logs:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: devices/error_logs
     kcidb_test_suite: kselftest.device_error_logs
 
   ltp-capability-cros-kernel:

--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -367,6 +367,333 @@ scheduler:
   - job: kselftest-acpi
     <<: *test-job-x86-intel
 
+  - job: kselftest-cros-kernel-alsa
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-alsa
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-alsa
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-alsa
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-arm64
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-arm64
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-capabilities
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-capabilities
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-capabilities
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-capabilities
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-clone3
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-clone3
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-clone3
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-clone3
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-cpufreq
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-cpufreq
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-cpufreq
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-cpufreq
+    <<: *test-job-x86-intel-coverage
+
+  # This job only passes on MTK devices, so only enable it for those
+  - job: kselftest-cros-kernel-cpufreq-suspend
+    <<: *test-job-arm64-mediatek-coverage
+
+  # This job only passes on MTK devices, so only enable it for those
+  - job: kselftest-cros-kernel-dmabuf-heaps
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-dt
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-dt
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-exec
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-exec
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-exec
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-exec
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-ftrace
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-ftrace
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-ftrace
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-ftrace
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-futex
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-futex
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-futex
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-futex
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-kcmp
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-kcmp
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-kcmp
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-kcmp
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-kvm
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-kvm
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-kvm
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-kvm
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-landlock
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-landlock
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-landlock
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-landlock
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-lsm
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-lsm
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-memfd
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-memfd
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-memfd
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-memfd
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-net
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-net
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-net
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-net
+    <<: *test-job-x86-intel-coverage
+
+  # This job currently makes MTK devices panic or hang forever
+  # - job: kselftest-cros-kernel-perf-events
+  #   <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-perf-events
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-perf-events
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-perf-events
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-proc
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-proc
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-proc
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-proc
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-ptrace
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-ptrace
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-ptrace
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-ptrace
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-rlimits
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-rlimits
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-rlimits
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-rlimits
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-seccomp
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-seccomp
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-seccomp
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-seccomp
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-splice
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-splice
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-splice
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-splice
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-sync
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-sync
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-sync
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-sync
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-timens
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-timens
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-timens
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-timens
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-timers
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-timers
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-timers
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-timers
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-tpm2
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-tpm2
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-tpm2
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-tpm2
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-user-events
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-user-events
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-user-events
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-user-events
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-vdso
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-vdso
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-vdso
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-vdso
+    <<: *test-job-x86-intel-coverage
+
+  - job: kselftest-cros-kernel-zram
+    <<: *test-job-arm64-mediatek-coverage
+
+  - job: kselftest-cros-kernel-zram
+    <<: *test-job-arm64-qualcomm-coverage
+
+  - job: kselftest-cros-kernel-zram
+    <<: *test-job-x86-amd-coverage
+
+  - job: kselftest-cros-kernel-zram
+    <<: *test-job-x86-intel-coverage
+
   - job: kselftest-dt
     <<: *lava-job-collabora
     event:


### PR DESCRIPTION
For now, we only run a (very) limited set of kselftests. However, enabling more of those would allow for greater code coverage. This patch creates kselftest jobs suited to running on the ChromiumOS kernel (in particular, ensuring we don't enable the ChromiumOS downstream LSM, which doesn't work with a Debian userspace).

Those tests are triggered by coverage-enabled kbuilds only, so we can eventually lower the frequency they run.