### PR TITLE
config: scheduler-chromeos: drop Tast tests on coverage-enabled builds

### DIFF
--- a/config/scheduler-chromeos.yaml
+++ b/config/scheduler-chromeos.yaml
@@ -1177,26 +1177,14 @@ scheduler:
   - job: tast-platform-arm64-mediatek
     <<: *test-job-chromeos-mediatek
 
-  - job: tast-platform-arm64-mediatek
-    <<: *test-job-arm64-mediatek-coverage
-
   - job: tast-platform-arm64-qualcomm
     <<: *test-job-chromeos-qualcomm
-
-  - job: tast-platform-arm64-qualcomm
-    <<: *test-job-arm64-qualcomm-coverage
 
   - job: tast-platform-x86-amd
     <<: *test-job-chromeos-amd
 
-  - job: tast-platform-x86-amd
-    <<: *test-job-x86-amd-coverage
-
   - job: tast-platform-x86-intel
     <<: *test-job-chromeos-intel-tast
-
-  - job: tast-platform-x86-intel
-    <<: *test-job-x86-intel-coverage
 
   - job: tast-power-arm64-mediatek
     <<: *test-job-chromeos-mediatek


### PR DESCRIPTION
Those were only enabled in order to have them scheduled and properly tested. As we don't have any user for those, and not enough time to monitor and process the results, they should be dropped in order to avoid unneeded noise.