### PR TITLE
config: chromeos: ltp: add missing ima fragments

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -1092,6 +1092,10 @@ jobs:
     params:
       <<: *ltp-cros-kernel-params
       tst_cmdfiles: "ima"
+    rules:
+      fragments:
+        - 'ima'
+        - '!kselftest'
 
   ltp-input-cros-kernel:
     <<: *ltp-cros-kernel-job
@@ -1156,6 +1160,10 @@ jobs:
     params:
       <<: *ltp-fault-injection-cros-kernel-params
       tst_cmdfiles: "ima"
+    rules:
+      fragments:
+        - 'ima'
+        - '!kselftest'
 
   ltp-fault-injection-input-cros-kernel:
     <<: *ltp-fault-injection-cros-kernel-job


### PR DESCRIPTION
Add the missing ima fragments for both regular and fault-injection LTP jobs.