### PR TITLE
Remove use of `env` file in cron service

### DIFF
--- a/docker-compose-cron.yaml
+++ b/docker-compose-cron.yaml
@@ -16,4 +16,3 @@ services:
       - './tools/cron/:/home/kernelci/'
       - './logs/:/home/kernelci/logs/'
       - './config:/home/kernelci/config'
-      - '.env:/home/kernelci/.env'

--- a/tools/cron/.env
+++ b/tools/cron/.env
@@ -1,9 +1,0 @@
-UPLOAD_PATH="kci-dev/report"
-FILE_PATH="/home/kernelci/logs/"
-STORAGE_URL="https://files-staging.kernelci.org/"
-STORAGE_TOKEN=<storage-token>
-SMTP_HOST=<smtp-host>
-SMTP_PORT=<smtp-port>
-EMAIL_SENDER=<email-sender>
-EMAIL_PASSWORD=<email-password>
-EMAIL_RECIPIENT=<email-recipient>

--- a/tools/cron/run_maestro_validate.sh
+++ b/tools/cron/run_maestro_validate.sh
@@ -6,8 +6,5 @@ log_file_name="cron-$timestamp.log"
 cd /home/kernelci
 kci-dev --settings kci-dev.toml maestro validate builds --all-checkouts >> "$log_file_path/$log_file_name"
 kci-dev --settings kci-dev.toml maestro validate boots --all-checkouts >> "$log_file_path/$log_file_name"
-set -a
-source /home/kernelci/.env
-set +a
 python upload_log.py $log_file_name
 python email_sender.py $log_file_name


### PR DESCRIPTION
Use `kernelci.toml` file to define all the config variables and remove use of `.env` file for cron service.