### PR TITLE
jobs.yaml: Fix suite for LTP syscalls-ipc suite

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -2143,7 +2143,7 @@ jobs:
     <<: *ltp-job
     params:
       <<: *ltp-params
-      tst_cmdfiles: "syscalls"
+      tst_cmdfiles: "syscalls-ipc"
 
   ltp-timers:
     <<: *ltp-job


### PR DESCRIPTION
The LTP syscalls-ipc job actually specifies the syscalls suite which is
a *much* larger suite that doesn't finish in the allocated time, causing
constant timeouts for every job that is scheduled.  Use the expected
suite name to schedule the much smaller syscalls-ipc suite.

Signed-off-by: Mark Brown <broonie@kernel.org>
