### PR TITLE
labs: Add pull-only labs support and demo

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -12,6 +12,8 @@ _anchors:
     template: baseline.jinja2
     kind: job
     kcidb_test_suite: boot
+    params:
+      ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{brarch}/rootfs.cpio.gz'
 
   kbuild-job: &kbuild-job
     template: kbuild.jinja2
@@ -132,6 +134,7 @@ jobs:
   baseline-arm: *baseline-job
   baseline-arm-broonie: *baseline-job
   baseline-arm-testpull: *baseline-job
+  baseline-arm-pull-labs-demo: *baseline-job
   baseline-arm-baylibre: *baseline-job
   baseline-arm-clabbe: *baseline-job
   baseline-arm-kontron: *baseline-job

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -162,6 +162,14 @@ runtimes:
       callback:
         token: kernelci-lab-testpull
 
+  pull-labs-demo:
+    lab_type: pull_labs
+    poll_interval: 45
+    timeout: 7200
+    storage_name: kci-storage
+    notify:
+      callback:
+        token: kernelci-pull-labs-demo
+
   shell:
     lab_type: shell
-

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -82,6 +82,15 @@ scheduler:
       - beaglebone-black
       - imx6dl-udoo
 
+  - job: baseline-arm-pull-labs-demo
+    event: *kbuild-gcc-12-arm-node-event
+    runtime: &pull-labs-demo-runtime
+      type: pull_labs
+      name: pull-labs-demo
+    platforms: &pull-labs-demo-arm
+      - beaglebone-black
+      - imx6dl-udoo
+
   - job: baseline-arm-clabbe
     event: *kbuild-gcc-12-arm-node-event
     runtime: &lava-clabbe-runtime

--- a/doc/connecting-pull-lab.md
+++ b/doc/connecting-pull-lab.md
@@ -1,0 +1,92 @@
+---
+title: "Connecting Pull Labs runtime"
+date: 2025-02-14
+description: "Connecting a PULL_LABS compatible lab to the KernelCI pipeline"
+weight: 4
+---
+
+KernelCI supports labs that follow the [PULL_LABS protocol](https://github.com/kernelci/kernelci-core/pull/3008) in addition to
+LAVA- and Kubernetes-based integrations. This guide shows the minimum
+configuration needed to make a lab instance visible to the pipeline.
+
+The examples below mirror the demo entries committed in this repository.
+Replace the names and tokens with the values that match your deployment.
+
+## Pipeline configuration
+
+Add a new runtime entry to [`config/pipeline.yaml`](../config/pipeline.yaml)
+under the `runtimes` section:
+
+```yaml
+  pull-labs-demo:
+    lab_type: pull_labs
+    poll_interval: 45
+    timeout: 7200
+    storage_name: docker-host
+    notify:
+      callback:
+        token: kernelci-pull-labs-demo
+```
+
+- `poll_interval` controls how often the lab polls the API for new jobs.
+- `timeout` sets the default job timeout in seconds that will be written
+  into the generated pull-labs job definition.
+- `storage_name` must point to a storage backend defined in the same file.
+- `notify.callback.token` is the name advertised to the lab so it knows
+  which callback token value to present when sending back results.
+
+## Scheduler configuration
+
+Declare at least one scheduler entry in
+[`config/scheduler.yaml`](../config/scheduler.yaml) that targets the runtime:
+
+```yaml
+  - job: baseline-arm-pull-labs-demo
+    event:
+      channel: node
+      kind: kbuild
+      name: kbuild-gcc-12-arm
+      state: available
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - beaglebone-black
+      - imx6dl-udoo
+```
+
+The scheduler entry must reference a job defined in `config/jobs.yaml` and
+point to a set of existing platforms.
+
+## Jobs
+
+Add or reuse a job definition inside [`config/jobs.yaml`](../config/jobs.yaml):
+
+```yaml
+jobs:
+  baseline-arm-pull-labs-demo: *baseline-job
+```
+
+Any template that depends on the runtime name (for example `baseline.jinja2`)
+will automatically extend `config/runtime/base/pull_labs.jinja2` from
+`kernelci-core` once the scheduler selects a `pull_labs` runtime.
+
+## Runtime secrets
+
+When the lab requires a secret token for callbacks, store the
+token value in [`config/kernelci.toml`](../config/kernelci.toml) by adding:
+
+```toml
+[runtime.pull-labs-demo]
+runtime_token="REPLACE_WITH_CALLBACK_TOKEN_VALUE"
+```
+
+The name inside the square brackets must match the runtime name from
+`config/pipeline.yaml`.
+
+## Deployment
+
+Ensure the `scheduler` service is started with the `--runtimes pull-labs-demo`
+argument in the relevant `docker-compose` file so the new runtime becomes active.
+The lab will see the generated events once it authenticates with the callback
+token value paired with the token name defined in the pipeline configuration.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
       - 'lava-kontron'
       - 'lava-foundriesio'
       - 'lava-testpull'
+      - 'pull-labs-demo'
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:


### PR DESCRIPTION
Depends-on: https://github.com/kernelci/kernelci-core/pull/3008

This PR implement new runtime, pull-only lab