### PR TITLE
Platforms: Add FVP into pull-labs platform

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -438,6 +438,18 @@ platforms:
       machine: virt,gic-version=3
       guestfs_interface: virtio
 
+  fvp: &fvp-device
+    base_name: fvp
+    arch: arm64
+    boot_method: fvp
+    mach: arm
+    context:
+      arch: arm64
+      model: Base_RevC-2xAEMvA
+      cpu: cortex-a57
+
+  fvp-arm64: *fvp-device
+
   rk3288-rock2-square:
     <<: *arm-device
     mach: rockchip

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -172,6 +172,7 @@ scheduler:
       name: pull-labs-demo
     platforms:
       - bcm2711-rpi-4-b
+      - fvp-arm64
 
   - job: baseline-nfs-arm64
     event: *kbuild-gcc-14-arm64-node-event


### PR DESCRIPTION
Bring in changes to allow pull labs to start consuming FVP jobs by adding FVP targets into the platforms and scheduler.