### PR TITLE
config/platforms: qemu-arm64

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -435,8 +435,9 @@ platforms:
     context:
       arch: arm64
       cpu: cortex-a57
-      machine: virt,gic-version=3
+      machine: virt,virtualization=on,gic-version=3,mte=on
       guestfs_interface: virtio
+      memory: 4G
 
   fvp: &fvp-device
     base_name: fvp


### PR DESCRIPTION
Set the machine options so we also get MTE, but by default the job is booting with 512M, this isn't enough and likely to cause kernels to fail to boot. 4G tends to be standard practice for booting these jobs.