### PR TITLE
Qemu arm64 console

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -438,6 +438,7 @@ platforms:
       machine: virt,virtualization=on,gic-version=3,mte=on
       guestfs_interface: virtio
       memory: 4G
+      serial: ttyAMA0
 
   fvp: &fvp-device
     base_name: fvp


### PR DESCRIPTION
Set the machine options so we also get MTE, but by default the job is booting with 512M, this isn't enough and likely to cause kernels to fail to boot. 4G tends to be standard practice for booting these jobs.

Set the console so the arm64 job boots