### PR TITLE
config/platforms|scheduler: fvp

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -448,7 +448,7 @@ platforms:
       model: Base_RevC-2xAEMvA
       cpu: cortex-a57
 
-  fvp-arm64: *fvp-device
+  fvp-aemva: *fvp-device
 
   rk3288-rock2-square:
     <<: *arm-device

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -172,7 +172,8 @@ scheduler:
       name: pull-labs-demo
     platforms:
       - bcm2711-rpi-4-b
-      - fvp-arm64
+      - fvp-aemva
+      - qemu-arm64
 
   - job: baseline-nfs-arm64
     event: *kbuild-gcc-14-arm64-node-event
@@ -389,7 +390,7 @@ scheduler:
     platforms:
       - qemu
       - aaeon-UPN-EHLX4RE-A10-0864
-  
+
   - job: baseline-x86-pull-labs-demo
     event: *kbuild-gcc-14-x86-node-event
     runtime:


### PR DESCRIPTION
Rename fvp-arm64 to fvp-aemva.

This was my mistake, but this naming should be based on the model (from FVP) rather than the arch. 