### PR TITLE
jobs.yaml: Update LTP rootfs to latest build

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -86,7 +86,7 @@ _anchors:
     kind: job
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251008.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251201.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       workers: max


### PR DESCRIPTION
Update our LTP rootfs images to pick up more tools that the tests try to
use, improving our coverage (mainly around filesystem things).

Signed-off-by: Mark Brown <broonie@kernel.org>
