### PR TITLE
Add support for CIP -st branches

### DIFF
--- a/config/jobs-cip.yaml
+++ b/config/jobs-cip.yaml
@@ -59,6 +59,7 @@ jobs:
   job-gcc-14-arm64-510-cip-rt: *baseline-job-cip
   job-gcc-14-arm64-419-cip: *baseline-job-cip
   job-gcc-14-arm64-419-cip-rt: *baseline-job-cip
+  job-gcc-14-arm64-419-cip-st: *baseline-job-cip
 
   kbuild-gcc-14-arm64-612-cip: &kbuild-gcc-14-arm64-612-cip
     <<: *kbuild-gcc-14-arm64-job
@@ -184,6 +185,20 @@ jobs:
       branch:
         - 'cip:linux-4.19.y-cip-rt'
 
+  kbuild-gcc-14-arm64-419-cip-st:
+    <<: *kbuild-gcc-14-arm64-job
+    params:
+      <<: *kbuild-gcc-14-arm64-params
+      defconfig:
+        - defconfig
+      fragments:
+        - 'kselftest'
+        - 'lab-setup'
+    rules:
+      branch:
+        - 'cip:linux-4.19.y-st'
+        - 'cip:linux-4.19.y-st-rc'
+
 # start of CIP arm configuration for boot tests
   job-gcc-14-arm-612-cip: *baseline-nfs-job-cip
   job-gcc-14-arm-612-cip-rt: *baseline-nfs-job-cip
@@ -193,8 +208,10 @@ jobs:
   job-gcc-14-arm-510-cip-rt: *baseline-nfs-job-cip
   job-gcc-14-arm-419-cip: *baseline-nfs-job-cip
   job-gcc-14-arm-419-cip-rt: *baseline-nfs-job-cip
+  job-gcc-14-arm-419-cip-st: *baseline-nfs-job-cip
   job-gcc-14-arm-44-cip: *baseline-nfs-job-cip
   job-gcc-14-arm-44-cip-rt: *baseline-nfs-job-cip
+  job-gcc-14-arm-44-cip-st: *baseline-nfs-job-cip
 
   kbuild-gcc-14-arm-612-cip: &kbuild-gcc-14-arm-612-cip
     <<: *kbuild-gcc-14-arm-job
@@ -328,6 +345,20 @@ jobs:
       branch:
         - 'cip:linux-4.19.y-cip-rt'
 
+  kbuild-gcc-14-arm-419-cip-st:
+    <<: *kbuild-gcc-14-arm-job
+    params:
+      <<: *kbuild-gcc-14-arm-params
+      defconfig:
+        - multi_v7_defconfig
+      fragments:
+        - 'kselftest'
+        - 'lab-setup'
+    rules:
+      branch:
+        - 'cip:linux-4.19.y-st'
+        - 'cip:linux-4.19.y-st-rc'
+
   kbuild-gcc-14-arm-44-cip: &kbuild-gcc-14-arm-44-cip
     <<: *kbuild-gcc-14-arm-job
     params: &kbuild-gcc-14-arm-44-cip-params
@@ -360,6 +391,20 @@ jobs:
       branch:
         - 'cip:linux-4.4.y-cip-rt'
 
+  kbuild-gcc-14-arm-44-cip-st:
+    <<: *kbuild-gcc-14-arm-job
+    params:
+      <<: *kbuild-gcc-14-arm-params
+      defconfig:
+        - multi_v7_defconfig
+      fragments:
+        - 'kselftest'
+        - 'lab-setup'
+    rules:
+      branch:
+        - 'cip:linux-4.4.y-st'
+        - 'cip:linux-4.4.y-st-rc'
+
 # start of CIP x86_64 configuration for boot tests
   job-gcc-14-x86-612-cip: *baseline-nfs-job-cip
   job-gcc-14-x86-612-cip-rt: *baseline-nfs-job-cip
@@ -369,8 +414,10 @@ jobs:
   job-gcc-14-x86-510-cip-rt: *baseline-nfs-job-cip
   job-gcc-14-x86-419-cip: *baseline-nfs-job-cip
   job-gcc-14-x86-419-cip-rt: *baseline-nfs-job-cip
+  job-gcc-14-x86-419-cip-st: *baseline-nfs-job-cip
   job-gcc-14-x86-44-cip: *baseline-nfs-job-cip
   job-gcc-14-x86-44-cip-rt: *baseline-nfs-job-cip
+  job-gcc-14-x86-44-cip-st: *baseline-nfs-job-cip
 
   kbuild-gcc-14-x86-612-cip: &kbuild-gcc-14-x86-612-cip
     <<: *kbuild-gcc-14-x86-job-cip
@@ -472,6 +519,18 @@ jobs:
       branch:
         - 'cip:linux-4.19.y-cip-rt'
 
+  kbuild-gcc-14-x86-419-cip-st:
+    <<: *kbuild-gcc-14-x86-job-cip
+    params:
+      <<: *kbuild-gcc-14-x86-params
+      fragments:
+        - 'kselftest'
+        - 'lab-setup'
+    rules:
+      branch:
+        - 'cip:linux-4.19.y-st'
+        - 'cip:linux-4.19.y-st-rc'
+
   kbuild-gcc-14-x86-44-cip: &kbuild-gcc-14-x86-44-cip
     <<: *kbuild-gcc-14-x86-job-cip
     params: &kbuild-gcc-14-x86-44-cip-params
@@ -497,3 +556,15 @@ jobs:
     rules:
       branch:
         - 'cip:linux-4.4.y-cip-rt'
+
+  kbuild-gcc-14-x86-44-cip-st:
+    <<: *kbuild-gcc-14-x86-job-cip
+    params:
+      <<: *kbuild-gcc-14-x86-params
+      fragments:
+        - 'kselftest'
+        - 'lab-setup'
+    rules:
+      branch:
+        - 'cip:linux-4.4.y-st'
+        - 'cip:linux-4.4.y-st-rc'

--- a/config/scheduler-cip.yaml
+++ b/config/scheduler-cip.yaml
@@ -116,6 +116,15 @@ scheduler:
   - <<: *job-gcc-14-arm64-419-cip-rt
     job: rt-tests-cyclictest
 
+  - job: job-gcc-14-arm64-419-cip-st
+    event:
+      <<: *kbuild-gcc-14-arm64-node-event
+      name: kbuild-gcc-14-arm64-419-cip-st
+    runtime: *lava-cip-runtime
+    platforms:
+      - qemu-arm64
+      - zynqmp-zcu102
+
   - job: kbuild-gcc-14-arm64-612-cip
     <<: *build-k8s-all
 
@@ -138,6 +147,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-arm64-419-cip-rt
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-14-arm64-419-cip-st
     <<: *build-k8s-all
 
 # start of CIP arm scheduler
@@ -236,6 +248,17 @@ scheduler:
   - <<: *job-gcc-14-arm-419-cip-rt
     job: rt-tests-cyclictest
 
+  - job: job-gcc-14-arm-419-cip-st
+    event:
+      <<: *kbuild-gcc-14-arm-node-event
+      name: kbuild-gcc-14-arm-419-cip-st
+    runtime: *lava-cip-runtime
+    platforms:
+      - beaglebone-black
+      - de0-nano-soc
+      - qemu-arm
+      - r8a7743-iwg20d-q7
+
   - job: job-gcc-14-arm-44-cip
     event:
       <<: *kbuild-gcc-14-arm-node-event
@@ -259,6 +282,15 @@ scheduler:
 
   - <<: *job-gcc-14-arm-44-cip-rt
     job: rt-tests-cyclictest
+
+  - job: job-gcc-14-arm-44-cip-st
+    event:
+      <<: *kbuild-gcc-14-arm-node-event
+      name: kbuild-gcc-14-arm-44-cip-st
+    runtime: *lava-cip-runtime
+    platforms:
+      - beaglebone-black
+      - qemu-arm
 
   - job: kbuild-gcc-14-arm-612-cip
     <<: *build-k8s-all
@@ -284,10 +316,16 @@ scheduler:
   - job: kbuild-gcc-14-arm-419-cip-rt
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-14-arm-419-cip-st
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-arm-44-cip
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-arm-44-cip-rt
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-14-arm-44-cip-st
     <<: *build-k8s-all
 
 # start of CIP x86-64 scheduler
@@ -386,6 +424,16 @@ scheduler:
   - <<: *job-gcc-14-x86-419-cip-rt
     job: rt-tests-cyclictest
 
+  - job: job-gcc-14-x86-419-cip-st
+    event:
+      <<: *kbuild-gcc-14-x86-node-event
+      name: kbuild-gcc-14-x86-419-cip-st
+    runtime: *lava-cip-runtime
+    platforms:
+      - qemu
+      - x86-openblocks-iot-vx2
+      - x86-simatic-ipc227e
+
   - job: job-gcc-14-x86-44-cip
     event:
       <<: *kbuild-gcc-14-x86-node-event
@@ -407,6 +455,14 @@ scheduler:
 
   - <<: *job-gcc-14-x86-44-cip-rt
     job: rt-tests-cyclictest
+
+  - job: job-gcc-14-x86-44-cip-st
+    event:
+      <<: *kbuild-gcc-14-x86-node-event
+      name: kbuild-gcc-14-x86-44-cip-st
+    runtime: *lava-cip-runtime
+    platforms:
+      - qemu
 
   - job: kbuild-gcc-14-x86-612-cip
     <<: *build-k8s-all
@@ -432,8 +488,14 @@ scheduler:
   - job: kbuild-gcc-14-x86-419-cip-rt
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-14-x86-419-cip-st
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-x86-44-cip
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-x86-44-cip-rt
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-14-x86-44-cip-st
     <<: *build-k8s-all

--- a/config/trees/cip.yaml
+++ b/config/trees/cip.yaml
@@ -23,6 +23,10 @@ build_configs:
     <<: *cip-4-4
     branch: 'linux-4.4.y-st'
 
+  cip-4.4-st-rc:
+    <<: *cip-4-4
+    branch: 'linux-4.4.y-st-rc'
+
   cip-4.19: &cip-4-19
     <<: *cip
     branch: 'linux-4.19.y-cip'
@@ -38,6 +42,10 @@ build_configs:
   cip-4.19-st:
     <<: *cip-4-19
     branch: 'linux-4.19.y-st'
+
+  cip-4.19-st-rc:
+    <<: *cip-4-19
+    branch: 'linux-4.19.y-st-rc'
 
   cip-5.10:
     <<: *cip


### PR DESCRIPTION
CIP maintains some "-st" branches. These are essentially the same as LTS, but for the kernels that CIP supports once LTS is EOL.

The list of platforms tested is slightly different compared to normal CIP SLTS kernels because these branches don't have backports adding new hardware support.

Builds are done using defconfig rather than CIP's configs because CIP's configs may use drivers etc. that aren't present on -st.