### PR TITLE
Add orion-o6 to pull-labs

### DIFF
--- a/config/fragments.yaml
+++ b/config/fragments.yaml
@@ -537,6 +537,25 @@ fragments:
       - 'CONFIG_NET_VENDOR_MEDIATEK=y'
       - 'CONFIG_NET_MEDIATEK_STAR_EMAC=m'
 
+  netdev:
+    path: "kernel/configs/netdev.config"
+    configs:
+      - 'CONFIG_NET_VENDOR_REALTEK=y'
+      - 'CONFIG_R8169=y'
+
+  nfs-root-boot:
+    path: "kernel/configs/nfs-root-boot.config"
+    configs:
+      - 'CONFIG_NFS_FS=y'
+      - 'CONFIG_NFS_V2=y'
+      - 'CONFIG_NFS_V3=y'
+      - 'CONFIG_NFS_V3_ACL=y'
+      - 'CONFIG_NFS_V4=y'
+      - 'CONFIG_ROOT_NFS=y'
+      - 'CONFIG_IP_PNP=y'
+      - 'CONFIG_IP_PNP_DHCP=y'
+      - 'CONFIG_IP_PNP_BOOTP=y'
+
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"
     configs:

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -61,6 +61,19 @@ _anchors:
         - 'lab-setup'
         - 'kselftest'
 
+  kbuild-gcc-14-arm64-nfsboot-job: &kbuild-gcc-14-arm64-nfsboot-job
+    <<: *kbuild-job
+    image: ghcr.io/kernelci/{image_prefix}gcc-14:arm64-kselftest-kernelci
+    params: &kbuild-gcc-14-arm64-nfsboot-params
+      arch: arm64
+      compiler: gcc-14
+      cross_compile: 'aarch64-linux-gnu-'
+      defconfig: defconfig
+      fragments:
+        - 'netdev'
+        - 'nfs-root-boot'
+        - 'kselftest'
+
   kbuild-gcc-14-x86-job: &kbuild-gcc-14-x86-job
     <<: *kbuild-job
     image: ghcr.io/kernelci/{image_prefix}gcc-14:x86-kselftest-kernelci
@@ -871,6 +884,8 @@ jobs:
       - 'sashal-next'
 
   kbuild-gcc-14-arm64: *kbuild-gcc-14-arm64-job
+
+  kbuild-gcc-14-arm64-nfsboot: *kbuild-gcc-14-arm64-nfsboot-job
 
   kbuild-gcc-14-arm64-chromebook-main:
     <<: *kbuild-gcc-14-arm64-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -172,6 +172,7 @@ scheduler:
       name: pull-labs-demo
     platforms:
       - bcm2711-rpi-4-b
+      - cd8180-orion-o6
       - fvp-aemva
       - qemu-arm64
 
@@ -182,6 +183,16 @@ scheduler:
       name: pull-labs-demo
     platforms:
       - bcm2711-rpi-4-b
+
+  - job: ltp-smoketest-pull-labs
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64-nfsboot
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - cd8180-orion-o6
 
   - job: baseline-nfs-arm64
     event: *kbuild-gcc-14-arm64-node-event
@@ -633,6 +644,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-arm64
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-14-arm64-nfsboot
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-arm64-allnoconfig


### PR DESCRIPTION
The orion-o6 uses an r8169 NIC which isn't included in the generic KernelCI initrd. For NFS rootfs boots, the kernel needs to handle DHCP directly via IP_PNP rather than relying on the initrd.

Add netdev fragment with built-in r8169 driver and nfs-root-boot fragment enabling IP_PNP. The kbuild-gcc-14-arm64-nfsboot job combines these for LTP/smoketest jobs that mount rootfs over NFS.

Boot jobs use the standard kernel since they only need the ramdisk.