### PR TITLE
Enable CIP config builds with stable-rc branches

### DIFF
--- a/config/jobs-cip.yaml
+++ b/config/jobs-cip.yaml
@@ -76,6 +76,7 @@ jobs:
     rules:
       branch:
         - 'cip:linux-6.12.y-cip'
+        - 'stable-rc:linux-6.12.y'
 
   kbuild-gcc-14-arm64-612-cip-rt:
     <<: *kbuild-gcc-14-arm64-612-cip
@@ -105,6 +106,7 @@ jobs:
       branch:
         - 'cip:linux-6.1.y-cip'
         - 'cip:linux-6.1.y-cip-rt'
+        - 'stable-rc:linux-6.1.y'
 
   kbuild-gcc-14-arm64-61-cip-rt:
     <<: *kbuild-gcc-14-arm64-61-cip
@@ -137,6 +139,7 @@ jobs:
       branch:
         - 'cip:linux-5.10.y-cip'
         - 'cip:linux-5.10.y-cip-rt'
+        - 'stable-rc:linux-5.10.y'
 
   kbuild-gcc-14-arm64-510-cip-rt:
     <<: *kbuild-gcc-14-arm64-510-cip
@@ -228,6 +231,7 @@ jobs:
     rules:
       branch:
         - 'cip:linux-6.12.y-cip'
+        - 'stable-rc:linux-6.12.y'
 
   kbuild-gcc-14-arm-61-cip: &kbuild-gcc-14-arm-61-cip
     <<: *kbuild-gcc-14-arm-job
@@ -246,6 +250,7 @@ jobs:
       branch:
         - 'cip:linux-6.1.y-cip'
         - 'cip:linux-6.1.y-cip-rt'
+        - 'stable-rc:linux-6.1.y'
 
   kbuild-gcc-14-arm-61-cip-rt:
     <<: *kbuild-gcc-14-arm-61-cip
@@ -280,6 +285,7 @@ jobs:
       branch:
         - 'cip:linux-5.10.y-cip'
         - 'cip:linux-5.10.y-cip-rt'
+        - 'stable-rc:linux-5.10.y'
 
   kbuild-gcc-14-arm-510-cip-rt:
     <<: *kbuild-gcc-14-arm-510-cip
@@ -416,6 +422,7 @@ jobs:
     rules:
       branch:
         - 'cip:linux-6.12.y-cip'
+        - 'stable-rc:linux-6.12.y'
 
   kbuild-gcc-14-x86-612-cip-rt:
     <<: *kbuild-gcc-14-x86-612-cip
@@ -439,6 +446,7 @@ jobs:
       branch:
         - 'cip:linux-6.1.y-cip'
         - 'cip:linux-6.1.y-cip-rt'
+        - 'stable-rc:linux-6.1.y'
 
   kbuild-gcc-14-x86-61-cip-rt:
     <<: *kbuild-gcc-14-x86-61-cip
@@ -465,6 +473,7 @@ jobs:
       branch:
         - 'cip:linux-5.10.y-cip'
         - 'cip:linux-5.10.y-cip-rt'
+        - 'stable-rc:linux-5.10.y'
 
   kbuild-gcc-14-x86-510-cip-rt:
     <<: *kbuild-gcc-14-x86-510-cip


### PR DESCRIPTION
Let's start with the stable-rc versions that match CIP STLS versions.

There's a chance that some of the configs won't work on non-STLS kernels, so I'll check those results before we consider merging this PR.