### PR TITLE
staging: Remove netdev-testing from staging

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,7 +147,7 @@ services:
       - './src/trigger.py'
       - '--settings=${KCI_SETTINGS:-/home/kernelci/config/kernelci.toml}'
       - 'run'
-      - '--trees=kernelci,netdev-testing'
+      - '--trees=kernelci'
       - '--name=trigger'
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
We dont have feedback from netdev-testing at moment, and presence on staging is just adding unnecessary load.