### PR TITLE
trees: Add stable-rt v6.12 tree

### DIFF
--- a/config/trees/stable-rt.yaml
+++ b/config/trees/stable-rt.yaml
@@ -39,3 +39,7 @@ build_configs:
   stable-rt_v6.6-rt:
     <<: *stable-rt
     branch: 'v6.6-rt'
+
+  stable-rt_v6.12-rt:
+    <<: *stable-rt
+    branch: 'v6.12-rt'


### PR DESCRIPTION
There's a v6.12 stable-rt release, include it in our coverage.  There
will also be a v6.18 release at some point but that's not there yet.

Signed-off-by: Mark Brown <broonie@kernel.org>
