### PR TITLE
config: jobs: remove redundant fragments rule 

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -373,8 +373,6 @@ jobs:
         - 'stable'
         - 'stable-rc'
         - 'sashal-next'
-      fragments:
-        - kselftest
 
   kbuild-clang-21-arm64-mainline: &kbuild-clang-21-arm64-mainline-job
     <<: *kbuild-clang-21-arm64-job


### PR DESCRIPTION
config: jobs: remove redundant fragments rule from kbuild-kselftest-rules

Remove the fragments allow-list from kbuild-kselftest-rules.

Since kernelci-core commit fdc7c8754 allow-list rules require the
attribute to exist in the node hierarchy. Checkout nodes don't have
a fragments attribute, causing this rule to fail with:

rules[fragments]: attribute 'fragments' not found in node hierarchy

This may be blocking kselftest builds from being scheduled.

The rule is redundant anyway - the job params already define which
fragments to use for the build.