### PR TITLE
lava/scheduler: Scale limit up with number of online devices

### DIFF
--- a/doc/config-reference.md
+++ b/doc/config-reference.md
@@ -328,7 +328,8 @@ LAVA runtimes are used to submit test jobs to LAVA labs.
   - **hours**: integer
 - **max_queue_depth**: integer - Maximum number of queued jobs per device type before skipping new submissions
   - **Default**: 50
-  - When the queue depth for a device type reaches this limit, new jobs will be skipped
+  - Used as per-device budget when online device count is available
+  - Effective limit is `max_queue_depth * online_devices` by default
   - Jobs are also skipped if no online devices are available for the device type
 - **rules**: dictionary - Tree/branch filtering rules
 
@@ -342,7 +343,7 @@ runtimes:
     url: https://lava.collabora.dev/
     priority_min: 40
     priority_max: 60
-    max_queue_depth: 100  # Higher limit for larger lab
+    max_queue_depth: 20  # Effective limit scales with online boards
     notify:
       callback:
         token: kernelci-api-token
@@ -369,7 +370,8 @@ The `max_queue_depth` parameter controls job submission throttling per LAVA lab:
 
 2. The job is **skipped** (not submitted) if:
    - No online devices are available for the device type
-   - The queue depth is >= `max_queue_depth`
+   - The queue depth is >= effective queue limit, where:
+     - `max_queue_depth * online_devices`
 
 3. When a job is skipped, a log message is generated:
    ```

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
+import types
 from unittest.mock import MagicMock
 from src.scheduler import Scheduler
 
@@ -58,6 +59,89 @@ class TestSchedulerTreePriority(unittest.TestCase):
 
         result = Scheduler._get_tree_priority(scheduler, 'stable', 'linux-6.6.y')
         self.assertIsNone(result)
+
+
+class TestSchedulerQueueDepth(unittest.TestCase):
+    """Test queue-depth throttling logic in scheduler."""
+
+    def _make_common_mocks(self):
+        scheduler = MagicMock(spec=Scheduler)
+        scheduler.log = MagicMock()
+
+        runtime = MagicMock()
+        runtime.config.lab_type = 'lava'
+        runtime.config.name = 'lab-test'
+
+        job_config = MagicMock()
+        job_config.name = 'baseline'
+        job_config.params = {'device_type': 'beaglebone-black'}
+
+        platform = MagicMock()
+        platform.name = 'beaglebone-black'
+
+        return scheduler, runtime, job_config, platform
+
+    def test_queue_depth_uses_scaled_limit_per_device(self):
+        """Scaled limit should be per-device depth * online device count."""
+        scheduler, runtime, job_config, platform = self._make_common_mocks()
+        runtime.config.max_queue_depth = 10
+        runtime.get_device_names_by_type.return_value = [
+            'bbb-1', 'bbb-2', 'bbb-3'
+        ]
+
+        runtime.get_devicetype_job_count.return_value = 29
+        result = Scheduler._should_skip_due_to_queue_depth(
+            scheduler, runtime, job_config, platform
+        )
+        self.assertFalse(result)
+
+        runtime.get_devicetype_job_count.return_value = 30
+        result = Scheduler._should_skip_due_to_queue_depth(
+            scheduler, runtime, job_config, platform
+        )
+        self.assertTrue(result)
+
+    def test_queue_depth_scales_with_max_queue_depth(self):
+        """max_queue_depth is treated as per-device queue budget."""
+        scheduler, runtime, job_config, platform = self._make_common_mocks()
+        runtime.config.max_queue_depth = 50
+        runtime.get_device_names_by_type.return_value = ['bbb-1', 'bbb-2', 'bbb-3']
+
+        runtime.get_devicetype_job_count.return_value = 149
+        result = Scheduler._should_skip_due_to_queue_depth(
+            scheduler, runtime, job_config, platform
+        )
+        self.assertFalse(result)
+
+        runtime.get_devicetype_job_count.return_value = 150
+        result = Scheduler._should_skip_due_to_queue_depth(
+            scheduler, runtime, job_config, platform
+        )
+        self.assertTrue(result)
+
+    def test_queue_depth_check_skips_when_device_query_not_available(self):
+        """If device query helper is missing, queue-depth check is skipped."""
+        scheduler = MagicMock(spec=Scheduler)
+        scheduler.log = MagicMock()
+
+        runtime = types.SimpleNamespace(
+            config=types.SimpleNamespace(
+                lab_type='lava',
+                name='lab-test',
+                max_queue_depth=50,
+            ),
+            get_devicetype_job_count=lambda _device_type: 100,
+        )
+        job_config = types.SimpleNamespace(
+            name='baseline',
+            params={'device_type': 'beaglebone-black'},
+        )
+        platform = types.SimpleNamespace(name='beaglebone-black')
+
+        result = Scheduler._should_skip_due_to_queue_depth(
+            scheduler, runtime, job_config, platform
+        )
+        self.assertFalse(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As @broonie suggested in https://github.com/kernelci/kernelci-core/issues/3039 it will be reasonable to increase limit proportionally to number of devices. Even 50 jobs will clear up fast if we have 5-10 devices.