### PR TITLE
config: move pull-labs entries to dedicated split files

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2026 Linaro Limited
+
+_anchors:
+  baseline-job-pull-labs: &baseline-job-pull-labs
+    template: baseline.jinja2
+    kind: job
+    priority: medium
+    kcidb_test_suite: boot
+    params:
+      ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{brarch}/rootfs.cpio.gz'
+
+  ltp-params-pull-labs: &ltp-params-pull-labs
+    boot_commands: nfs
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251201.0/{debarch}'
+    skip_install: "true"
+    skipfile: skipfile-lkft.yaml
+    workers: max
+
+jobs:
+  baseline-arm-pull-labs-demo: *baseline-job-pull-labs
+  baseline-arm64-pull-labs-demo: *baseline-job-pull-labs
+  baseline-x86-pull-labs-demo: *baseline-job-pull-labs
+
+  ltp-smoketest-pull-labs:
+    template: ltp-pull-labs.jinja2
+    kind: job
+    params:
+      <<: *ltp-params-pull-labs
+      tst_cmdfiles: "smoketest"
+    kcidb_test_suite: ltp

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -160,7 +160,6 @@ jobs:
   baseline-arm: *baseline-job
   baseline-arm-broonie: *baseline-job
   baseline-arm-testpull: *baseline-job
-  baseline-arm-pull-labs-demo: *baseline-job
   baseline-arm-baylibre: *baseline-job
   baseline-arm-clabbe: *baseline-job
   baseline-arm-kontron: *baseline-job
@@ -178,7 +177,6 @@ jobs:
   baseline-arm64-pengutronix: *baseline-job
   baseline-arm64-foundriesio: *baseline-job
   baseline-arm64-qualcomm: *baseline-job
-  baseline-arm64-pull-labs-demo: *baseline-job
   baseline-riscv-broonie: *baseline-job
   baseline-riscv-clabbe: *baseline-job
   baseline-riscv-collabora: *baseline-job
@@ -188,7 +186,6 @@ jobs:
   baseline-x86-kcidebug-intel: *baseline-job
   baseline-x86-mfd: *baseline-job
   baseline-x86-qualcomm: *baseline-job
-  baseline-x86-pull-labs-demo: *baseline-job
 
   baseline-nfs-arm64: *baseline-nfs-job
   coverage-report-arm: &coverage-report-job
@@ -2330,14 +2327,6 @@ jobs:
     params:
       <<: *ltp-params
       tst_cmdfiles: "smoketest"
-
-  ltp-smoketest-pull-labs:
-    template: ltp-pull-labs.jinja2
-    kind: job
-    params:
-      <<: *ltp-params
-      tst_cmdfiles: "smoketest"
-    kcidb_test_suite: ltp
 
   ltp-syscalls:
     <<: *ltp-job

--- a/config/pipeline-pull-labs.yaml
+++ b/config/pipeline-pull-labs.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2026 Linaro Limited
+
+runtimes:
+
+  pull-labs-demo:
+    lab_type: pull_labs
+    poll_interval: 45
+    timeout: 7200
+    storage_name: kci-storage
+    notify:
+      callback:
+        token: kernelci-pull-labs-demo

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -162,14 +162,5 @@ runtimes:
       callback:
         token: kernelci-lab-testpull
 
-  pull-labs-demo:
-    lab_type: pull_labs
-    poll_interval: 45
-    timeout: 7200
-    storage_name: kci-storage
-    notify:
-      callback:
-        token: kernelci-pull-labs-demo
-
   shell:
     lab_type: shell

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2026 Linaro Limited
+
+_anchors:
+  node-event: &node-event-kbuild
+    channel: node
+    kind: kbuild
+    state: available
+
+scheduler:
+
+  - job: baseline-arm-pull-labs-demo
+    event: &kbuild-gcc-14-arm-node-event
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm
+    runtime: &pull-labs-demo-runtime
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - beaglebone-black
+      - imx6dl-udoo
+
+  - job: baseline-arm64-pull-labs-demo
+    event: &kbuild-gcc-14-arm64-node-event
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - bcm2711-rpi-4-b
+      - cd8180-orion-o6
+      - fvp-aemva
+      - qemu-arm64
+
+  - job: ltp-smoketest-pull-labs
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - bcm2711-rpi-4-b
+
+  - job: ltp-smoketest-pull-labs
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64-nfsboot
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - cd8180-orion-o6
+      - qemu-arm64
+
+  - job: baseline-x86-pull-labs-demo
+    event: &kbuild-gcc-14-x86-node-event
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-x86
+    runtime:
+      type: pull_labs
+      name: pull-labs-demo
+    platforms:
+      - qemu

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -82,15 +82,6 @@ scheduler:
       - beaglebone-black
       - imx6dl-udoo
 
-  - job: baseline-arm-pull-labs-demo
-    event: *kbuild-gcc-14-arm-node-event
-    runtime: &pull-labs-demo-runtime
-      type: pull_labs
-      name: pull-labs-demo
-    platforms: &pull-labs-demo-arm
-      - beaglebone-black
-      - imx6dl-udoo
-
   - job: baseline-arm-clabbe
     event: *kbuild-gcc-14-arm-node-event
     runtime: &lava-clabbe-runtime
@@ -164,36 +155,6 @@ scheduler:
       - rk3399-rock-pi-4b
       - rk3588-rock-5b
       - sun50i-h6-pine-h64
-
-  - job: baseline-arm64-pull-labs-demo
-    event: *kbuild-gcc-14-arm64-node-event
-    runtime:
-      type: pull_labs
-      name: pull-labs-demo
-    platforms:
-      - bcm2711-rpi-4-b
-      - cd8180-orion-o6
-      - fvp-aemva
-      - qemu-arm64
-
-  - job: ltp-smoketest-pull-labs
-    event: *kbuild-gcc-14-arm64-node-event
-    runtime:
-      type: pull_labs
-      name: pull-labs-demo
-    platforms:
-      - bcm2711-rpi-4-b
-
-  - job: ltp-smoketest-pull-labs
-    event:
-      <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm64-nfsboot
-    runtime:
-      type: pull_labs
-      name: pull-labs-demo
-    platforms:
-      - cd8180-orion-o6
-      - qemu-arm64
 
   - job: baseline-nfs-arm64
     event: *kbuild-gcc-14-arm64-node-event
@@ -410,14 +371,6 @@ scheduler:
     platforms:
       - qemu
       - aaeon-UPN-EHLX4RE-A10-0864
-
-  - job: baseline-x86-pull-labs-demo
-    event: *kbuild-gcc-14-x86-node-event
-    runtime:
-      type: pull_labs
-      name: pull-labs-demo
-    platforms:
-      - qemu
 
   - job: blktests-ddp-x86
     event: *kbuild-gcc-14-x86-node-event


### PR DESCRIPTION
Move pull-labs scheduler entries, runtime definition, and job definitions from the main config files into dedicated split files