### PR TITLE
jobs.yaml: Update LTP rootfs to pick up LTP 20260130

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -105,7 +105,7 @@ _anchors:
     priority: low
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251201.0/{debarch}'
+      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20260219.0/{debarch}'
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       workers: max


### PR DESCRIPTION
LTP have done a new release, update to use a rootfs image which includes
it.  This gets us new tests and fixes for existing tests.

Signed-off-by: Mark Brown <broonie@kernel.org>
