### PR TITLE
config: use qemu-x86_64 platform name instead of bare qemu

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -435,7 +435,7 @@ platforms:
     dtb: dtbs/qcom/monaco-evk.dtb
     compatible: ['qcom,monaco-evk', 'qcom,qcs8300']
 
-  qemu: &qemu-device
+  qemu-x86_64: &qemu-device
     base_name: qemu
     arch: x86_64
     boot_method: qemu
@@ -444,8 +444,6 @@ platforms:
       arch: x86_64
       cpu: qemu64
       guestfs_interface: ide
-
-  qemu-x86: *qemu-device
 
   qemu-arm:
     <<: *qemu-device

--- a/config/scheduler-cip.yaml
+++ b/config/scheduler-cip.yaml
@@ -336,7 +336,7 @@ scheduler:
       name: kbuild-gcc-14-x86
     runtime: *lava-cip-runtime
     platforms: &cip-x86-platforms
-      - qemu
+      - qemu-x86_64
       - x86-openblocks-iot-vx2
       - x86-siemens-mcom
       - x86-simatic-ipc227e
@@ -410,7 +410,7 @@ scheduler:
       name: kbuild-gcc-14-x86-419-cip
     runtime: *lava-cip-runtime
     platforms: &cip-x86-platforms-419
-      - qemu
+      - qemu-x86_64
       - x86-openblocks-iot-vx2
       - x86-simatic-ipc227e
 
@@ -434,7 +434,7 @@ scheduler:
       name: kbuild-gcc-14-x86-419-cip-st
     runtime: *lava-cip-runtime
     platforms:
-      - qemu
+      - qemu-x86_64
       - x86-openblocks-iot-vx2
       - x86-simatic-ipc227e
 
@@ -444,7 +444,7 @@ scheduler:
       name: kbuild-gcc-14-x86-44-cip
     runtime: *lava-cip-runtime
     platforms: &cip-x86-platforms-44
-      - qemu
+      - qemu-x86_64
 
   - &job-gcc-14-x86-44-cip-rt
     job: job-gcc-14-x86-44-cip-rt
@@ -466,7 +466,7 @@ scheduler:
       name: kbuild-gcc-14-x86-44-cip-st
     runtime: *lava-cip-runtime
     platforms:
-      - qemu
+      - qemu-x86_64
 
   - job: kbuild-gcc-14-x86-612-cip
     <<: *build-k8s-all

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -61,4 +61,4 @@ scheduler:
       type: pull_labs
       name: pull-labs-demo
     platforms:
-      - qemu
+      - qemu-x86_64

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -324,14 +324,14 @@ scheduler:
       name: kbuild-gcc-14-x86
     runtime: *lava-collabora-runtime
     platforms: &collabora-x86-platforms
-      - qemu
+      - qemu-x86_64
       - aaeon-UPN-EHLX4RE-A10-0864
 
   - job: baseline-x86-baylibre
     event: *kbuild-gcc-14-x86-node-event
     runtime: *lava-baylibre-runtime
     platforms:
-      - qemu
+      - qemu-x86_64
 
   - job: baseline-x86-kcidebug-amd
     event: &kbuild-gcc-14-x86-kcidebug-node-event
@@ -374,7 +374,7 @@ scheduler:
       name: kbuild-gcc-14-x86-mfd
     runtime: *lava-collabora-runtime
     platforms:
-      - qemu
+      - qemu-x86_64
       - aaeon-UPN-EHLX4RE-A10-0864
 
   - job: blktests-ddp-x86
@@ -1993,7 +1993,7 @@ scheduler:
     event: *kbuild-gcc-14-x86-node-event
     runtime: *lava-collabora-runtime
     platforms:
-      - qemu
+      - qemu-x86_64
 
   - job: ltp-watchqueue
     event: *kbuild-gcc-14-arm-node-event

--- a/tools/example_api_lab.py
+++ b/tools/example_api_lab.py
@@ -142,13 +142,13 @@ def main():
         {
             "name": "test1",
             "result": "pass",
-            "platform": "qemu",
+            "platform": "qemu-x86_64",
             "runtime": "lab-abcde",
         },
         {
             "name": "test2",
             "result": "fail",
-            "platform": "qemu-x86",
+            "platform": "qemu-x86_64",
             "runtime": "lab-abcde",
         },
     ]

--- a/tools/example_pull_lab.py
+++ b/tools/example_pull_lab.py
@@ -161,8 +161,8 @@ def main():
     )
     parser.add_argument(
         "--platform",
-        default="qemu",
-        help="Filter jobs by platform (default: qemu). Use empty string to accept all platforms.",
+        default="qemu-x86_64",
+        help="Filter jobs by platform (default: qemu-x86_64). Use empty string to accept all platforms.",
     )
     parser.add_argument(
         "--runtime",
@@ -246,14 +246,7 @@ def main():
                             print(f"Skipping job - no platform specified in environment")
                             continue
 
-                        # Use platform as device, or construct it if platform is generic
-                        if platform.startswith("qemu-"):
-                            device = platform
-                        elif platform == "qemu":
-                            # Fallback: construct device from platform + arch
-                            device = f"qemu-{arch}"
-                        else:
-                            device = platform
+                        device = platform
 
                         print(f"Job environment: platform={platform}, arch={arch} -> device={device}")
 


### PR DESCRIPTION
Replace bare 'qemu' platform references with 'qemu-x86_64' for consistency with the arch-prefixed naming convention used by other qemu platforms (qemu-arm, qemu-arm64, qemu-riscv64). Rename the platform alias in platforms.yaml from qemu-x86 to qemu-x86_64 to match the actual architecture.