### PR TITLE
Rename ltp-* to a normalised pattern

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -23,7 +23,7 @@ jobs:
   baseline-arm64-pull-labs-demo: *baseline-job-pull-labs
   baseline-x86-pull-labs-demo: *baseline-job-pull-labs
 
-  ltp-smoketest-pull-labs:
+  ltp-smoke-pull-labs:
     template: ltp-pull-labs.jinja2
     kind: job
     params:

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -2322,7 +2322,7 @@ jobs:
       <<: *ltp-params
       tst_cmdfiles: "sched"
 
-  ltp-smoketest:
+  ltp-smoke:
     <<: *ltp-job
     params:
       <<: *ltp-params

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -34,7 +34,7 @@ scheduler:
       - fvp-aemva
       - qemu-arm64
 
-  - job: ltp-smoketest-pull-labs
+  - job: ltp-smoke-pull-labs
     event: *kbuild-gcc-14-arm64-node-event
     runtime:
       type: pull_labs
@@ -42,7 +42,7 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
 
-  - job: ltp-smoketest-pull-labs
+  - job: ltp-smoke-pull-labs
     event:
       <<: *node-event-kbuild
       name: kbuild-gcc-14-arm64-nfsboot

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1933,19 +1933,19 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
 
-  - job: ltp-smoketest
+  - job: ltp-smoke
     event: *kbuild-gcc-14-arm-node-event
     runtime: *lava-broonie-runtime
     platforms:
       - beaglebone-black
 
-  - job: ltp-smoketest
+  - job: ltp-smoke
     event: *kbuild-gcc-14-armv5-node-event
     runtime: *lava-broonie-runtime
     platforms:
       - at91sam9g20ek
 
-  - job: ltp-smoketest
+  - job: ltp-smoke
     event: *kbuild-gcc-14-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:

--- a/doc/connecting-pull-lab.md
+++ b/doc/connecting-pull-lab.md
@@ -139,7 +139,7 @@ Add a job definition in [`config/jobs.yaml`](../config/jobs.yaml):
 
 ```yaml
 jobs:
-  ltp-smoketest-pull-labs:
+  ltp-smoke-pull-labs:
     template: ltp-pull-labs.jinja2
     kind: job
     params:
@@ -166,7 +166,7 @@ Key parameters:
 Add a scheduler entry in [`config/scheduler.yaml`](../config/scheduler.yaml):
 
 ```yaml
-  - job: ltp-smoketest-pull-labs
+  - job: ltp-smoke-pull-labs
     event: *kbuild-gcc-14-arm64-node-event
     runtime:
       type: pull_labs


### PR DESCRIPTION
4 patches to rename ltp-* tests to a normalised pattern