### PR TITLE
tools: add example pytest + QEMU script for pull-lab jobs

### DIFF
--- a/doc/connecting-pull-lab.md
+++ b/doc/connecting-pull-lab.md
@@ -123,6 +123,43 @@ The script will:
 **TODO:** Support for FVP (Fixed Virtual Platform) and DUT (Device Under Test)
 jobs will be added in future versions, along with publishing to KCIDB.
 
+## Running with pytest + QEMU
+
+The `tools/example_pull_lab_pytest.py` script is an alternative that uses
+pytest and labgrid (with QEMU) instead of tuxrun. It boots the kernel from
+a job definition in QEMU and runs simple boot-verification tests.
+
+### Prerequisites
+
+- Python packages: `pip install -r tools/requirements.txt`
+- QEMU: `qemu-system-aarch64`, `qemu-system-x86_64`, or `qemu-system-arm`
+  depending on the job architecture
+
+### Poll mode
+
+Polls the KernelCI events API and runs each matching job automatically:
+
+```bash
+python tools/example_pull_lab_pytest.py poll --runtime pull-labs-demo
+```
+
+Results are saved to `./test_output/<node-id>/` with `results.xml` (JUnit)
+and `log.txt` (full boot and test output).
+
+### Direct mode
+
+Runs pytest against a local job definition JSON file, useful for debugging:
+
+```bash
+python tools/example_pull_lab_pytest.py direct --kci-job-json job.json
+```
+
+### Limitations
+
+The QEMU boot uses `-initrd` so it only works with jobs that provide a
+`ramdisk` artifact (cpio format). Jobs with full rootfs tarballs (e.g.
+LTP NFS root) require tuxrun or a lab with proper provisioning.
+
 ## Running LTP Tests on Pull Labs
 
 In addition to baseline boot tests, pull-labs supports running LTP (Linux Test

--- a/tools/example_pull_lab_pytest.py
+++ b/tools/example_pull_lab_pytest.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Poll KernelCI API for pull-lab jobs and execute them with pytest + QEMU.
+
+Two modes:
+  poll (default) — polls KernelCI events API for new jobs
+  direct         — runs pytest against a local job JSON file
+"""
+
+import argparse
+import json
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+
+import requests
+
+
+BASE_URI = "https://staging.kernelci.org:9000/latest"
+EVENTS_PATH = "/events"
+REQUEST_TIMEOUT = 30
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_TESTS_DIR = os.path.join(SCRIPT_DIR, "example_pytest_tests")
+
+log = logging.getLogger(__name__)
+
+
+def pollevents(timestamp, kind):
+    url = (
+        BASE_URI
+        + EVENTS_PATH
+        + f"?state=done&kind={kind}&limit=1000&recursive=true&from={timestamp}"
+    )
+    log.debug("Polling %s", url)
+    response = requests.get(url, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def retrieve_job_definition(url):
+    log.debug("Retrieving job definition from %s", url)
+    response = requests.get(url, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def run_pytest(job, tests_dir, output_dir=None):
+    tmp_file = None
+    try:
+        if isinstance(job, dict):
+            tmp_file = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", prefix="kci-job-", delete=False
+            )
+            json.dump(job, tmp_file)
+            tmp_file.close()
+            job_json_path = tmp_file.name
+        else:
+            job_json_path = str(job)
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            f"--rootdir={tests_dir}",
+            f"--kci-job-json={job_json_path}",
+            "-v",
+            "-s",
+        ]
+
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            cmd.append(f"--junitxml={os.path.join(output_dir, 'results.xml')}")
+
+        cmd.append(tests_dir)
+
+        log.debug("Executing: %s", " ".join(shlex.quote(arg) for arg in cmd))
+
+        if output_dir:
+            log_path = os.path.join(output_dir, "log.txt")
+            with open(log_path, "w") as logfile:
+                result = subprocess.run(cmd, stdout=logfile, stderr=subprocess.STDOUT)
+            log.info("Log saved to %s", log_path)
+        else:
+            result = subprocess.run(cmd)
+
+        log.info("pytest exited with code %d", result.returncode)
+        return result.returncode
+
+    finally:
+        if tmp_file is not None:
+            try:
+                os.unlink(tmp_file.name)
+            except OSError:
+                pass
+
+
+def poll_loop(args):
+    timestamp = "1970-01-01T00:00:00.000000"
+    retry_count = 0
+    while True:
+        try:
+            events = pollevents(timestamp, "job")
+            retry_count = 0
+
+            if not events:
+                log.debug("No new events, sleeping for 30 seconds")
+                time.sleep(30)
+                continue
+
+            log.debug("Got %d events", len(events))
+            for event in events:
+                try:
+                    node = event.get("node", {})
+                    artifacts = node.get("artifacts", {})
+                    job_definition_url = artifacts.get("job_definition", "")
+
+                    if not job_definition_url or not job_definition_url.startswith(
+                        "http"
+                    ):
+                        continue
+
+                    group = node.get("group", "")
+                    if args.group_filter and args.group_filter not in group:
+                        continue
+
+                    data = event.get("data", {}).get("data", {})
+                    platform = data.get("platform")
+                    runtime = data.get("runtime")
+
+                    if args.platform and platform != args.platform:
+                        continue
+                    if args.runtime and runtime != args.runtime:
+                        continue
+
+                    log.info("Matched job: %s", job_definition_url)
+                    jobdata = retrieve_job_definition(job_definition_url)
+
+                    if "kernel" not in jobdata.get("artifacts", {}):
+                        log.debug("Skipping - missing kernel artifact")
+                        continue
+
+                    if "ramdisk" not in jobdata.get("artifacts", {}):
+                        log.debug(
+                            "Skipping - no ramdisk artifact (nfsboot kernel requires NFS)"
+                        )
+                        continue
+
+                    output_dir = None
+                    if not args.no_save_outputs and args.output_dir:
+                        output_dir = os.path.join(
+                            args.output_dir, node.get("id", "unknown")
+                        )
+
+                    run_pytest(jobdata, tests_dir=args.tests_dir, output_dir=output_dir)
+
+                except Exception as e:
+                    log.error("Error processing event: %s", e)
+                    traceback.print_exc()
+
+            if events:
+                timestamp = events[-1]["timestamp"]
+        except requests.exceptions.RequestException as e:
+            retry_count += 1
+            log.error(
+                "Error fetching events (attempt %d/%d): %s",
+                retry_count,
+                args.max_retries,
+                e,
+            )
+            if retry_count >= args.max_retries:
+                log.error("Max retries (%d) reached. Exiting.", args.max_retries)
+                sys.exit(1)
+            log.info("Retrying in 30 seconds...")
+            time.sleep(30)
+
+
+def direct_run(args):
+    rc = run_pytest(
+        args.kci_job_json,
+        tests_dir=args.tests_dir,
+        output_dir=args.output_dir if not args.no_save_outputs else None,
+    )
+    sys.exit(rc)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Poll KernelCI API for pull-lab jobs and run them with pytest + QEMU."
+    )
+    parser.add_argument(
+        "--tests-dir",
+        default=DEFAULT_TESTS_DIR,
+        help="Directory containing pytest tests (default: example_pytest_tests/).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./test_output",
+        help="Directory for JUnit XML results (default: ./test_output).",
+    )
+    parser.add_argument(
+        "--no-save-outputs", action="store_true", help="Disable saving outputs."
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    poll_parser = subparsers.add_parser(
+        "poll", help="Poll KernelCI events API (default)."
+    )
+    poll_parser.add_argument("--platform", default="", help="Filter by platform.")
+    poll_parser.add_argument("--runtime", help="Filter by runtime/lab name.")
+    poll_parser.add_argument(
+        "--group-filter",
+        default="pull-labs",
+        help="Filter by group (default: pull-labs).",
+    )
+    poll_parser.add_argument(
+        "--max-retries", type=int, default=5, help="Max API retries (default: 5)."
+    )
+
+    direct_parser = subparsers.add_parser(
+        "direct", help="Run pytest against a local job JSON."
+    )
+    direct_parser.add_argument(
+        "--kci-job-json", required=True, help="Path to job definition JSON."
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    if args.command == "direct":
+        direct_run(args)
+    else:
+        poll_loop(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/example_pytest_tests/conftest.py
+++ b/tools/example_pytest_tests/conftest.py
@@ -1,0 +1,118 @@
+import json
+import logging
+import shutil
+
+import pytest
+import requests
+import yaml
+from labgrid import Environment
+
+QEMU_CONFIGS = {
+    "x86_64": ("qemu-system-x86_64", "pc", "max", "ttyS0"),
+    "arm64": ("qemu-system-aarch64", "virt", "cortex-a57", "ttyAMA0"),
+    "arm": ("qemu-system-arm", "virt", "cortex-a15", "ttyAMA0"),
+}
+
+REQUEST_TIMEOUT = 120
+
+log = logging.getLogger(__name__)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--kci-job-json",
+        required=True,
+        help="Path to KernelCI job definition JSON.",
+    )
+
+
+def _download(url, path):
+    log.debug("Downloading %s", url)
+    resp = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    with open(path, "wb") as f:
+        for chunk in resp.iter_content(8192):
+            f.write(chunk)
+
+
+def _write_env_yaml(path, qemu_bin, machine, cpu, console, kernel, ramdisk=None):
+    extra_args = "-no-reboot"
+    if ramdisk:
+        extra_args += f" -initrd {ramdisk}"
+
+    config = {
+        "targets": {
+            "main": {
+                "drivers": {
+                    "QEMUDriver": {
+                        "qemu_bin": "qemu",
+                        "machine": machine,
+                        "cpu": cpu,
+                        "memory": "512M",
+                        "boot_args": f"console={console}",
+                        "kernel": "kernel",
+                        "extra_args": extra_args,
+                    },
+                    "ShellDriver": {
+                        "prompt": ".*[#$] ",
+                        "login_prompt": "login:",
+                        "username": "root",
+                    },
+                },
+            },
+        },
+        "tools": {"qemu": qemu_bin},
+        "images": {"kernel": kernel},
+    }
+
+    with open(path, "w") as f:
+        yaml.dump(config, f)
+
+
+@pytest.fixture(scope="session")
+def kci_job(request):
+    with open(request.config.getoption("--kci-job-json")) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def kci_environment(kci_job):
+    return kci_job.get("environment", {})
+
+
+@pytest.fixture(scope="session")
+def shell(kci_job, kci_environment, tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("qemu")
+    arch = kci_environment.get("arch", "x86_64")
+    qemu_name, machine, cpu, console = QEMU_CONFIGS.get(arch, QEMU_CONFIGS["x86_64"])
+
+    qemu_bin = shutil.which(qemu_name)
+    if not qemu_bin:
+        pytest.skip(f"QEMU binary not found: {qemu_name}")
+
+    artifacts = kci_job["artifacts"]
+    kernel = str(tmpdir / "kernel")
+    _download(artifacts["kernel"], kernel)
+
+    ramdisk_url = artifacts.get("ramdisk")
+    if not ramdisk_url:
+        pytest.skip(
+            "No ramdisk artifact - nfsboot kernels require NFS and cannot run in QEMU with -initrd"
+        )
+
+    ramdisk = str(tmpdir / "ramdisk")
+    _download(ramdisk_url, ramdisk)
+
+    env_yaml = str(tmpdir / "env.yaml")
+    _write_env_yaml(env_yaml, qemu_bin, machine, cpu, console, kernel, ramdisk)
+    log.debug("Labgrid env: %s", env_yaml)
+
+    env = Environment(env_yaml)
+    target = env.get_target("main")
+    qemu = target.get_driver("QEMUDriver")
+    qemu.on()
+    shell_driver = target.get_driver("ShellDriver")
+
+    yield shell_driver
+
+    target.cleanup()

--- a/tools/example_pytest_tests/test_boot.py
+++ b/tools/example_pytest_tests/test_boot.py
@@ -1,0 +1,23 @@
+def test_shell_available(shell):
+    _, _, rc = shell.run("echo hello")
+    assert rc == 0
+
+
+def test_kernel_version(shell):
+    stdout, _, rc = shell.run("cat /proc/version")
+    assert rc == 0
+    print("".join(stdout).strip())
+
+
+def test_kernel_cmdline(shell):
+    stdout, _, rc = shell.run("cat /proc/cmdline")
+    assert rc == 0
+    assert "".join(stdout).strip()
+
+
+def test_device_is_up(shell, kci_environment):
+    stdout, _, rc = shell.run("uptime")
+    assert rc == 0
+    platform = kci_environment.get("platform", "unknown")
+    arch = kci_environment.get("arch", "unknown")
+    print(f"{platform}/{arch}: {''.join(stdout).strip()}")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,8 @@
 PyJWT==2.9.0
 toml==0.10.2
+
+# example_pull_lab_pytest.py (also requires qemu-system-*)
+labgrid
+pytest
+pyyaml
+requests


### PR DESCRIPTION
Add an example script that polls the KernelCI API for pull-lab jobs and executes boot tests using pytest + QEMU, as an alternative to the existing tuxrun-based example.
