### PR TITLE
config: Introduce rootfs_ref

### DIFF
--- a/config/jobs-chromeos.yaml
+++ b/config/jobs-chromeos.yaml
@@ -36,8 +36,7 @@ _anchors:
     kind: job
     params:
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
-    kcidb_test_suite: boot.nfs
+      rootfs_ref: bookworm
     rules:
       tree:
         - mainline
@@ -50,7 +49,7 @@ _anchors:
     params: &kselftest-params
       test_method: kselftest
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+      rootfs_ref: bookworm-kselftest
       job_timeout: 10
     kcidb_test_suite: kselftest
     rules:
@@ -63,7 +62,7 @@ _anchors:
     params: &fluster-debian-params
       test_method: fluster-debian
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240926.0/{debarch}/'
+      rootfs_ref: bookworm-gst-fluster
       job_timeout: 30
       videodec_parallel_jobs: 1
       videodec_timeout: 90
@@ -92,7 +91,7 @@ _anchors:
     params: &wifi-basic-job-params
       test_method: wifi-basic
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20250925.0/{debarch}/'
+      rootfs_ref: bookworm-wifi
     rules:
       tree:
         - mainline

--- a/config/jobs-cip.yaml
+++ b/config/jobs-cip.yaml
@@ -4,7 +4,7 @@ _anchors:
     kind: job
     kcidb_test_suite: boot
     params:
-      ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{brarch}/rootfs.cpio.gz'
+      rootfs_ref: buildroot-baseline
 
   baseline-nfs-job-cip: &baseline-nfs-job-cip
     template: baseline-nfs.jinja2
@@ -12,7 +12,7 @@ _anchors:
     kcidb_test_suite: boot.nfs
     params:
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
+      rootfs_ref: bookworm
 
   kbuild-job-cip: &kbuild-job-cip
     template: kbuild.jinja2

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -14,7 +14,7 @@ _anchors:
     priority: medium
     kcidb_test_suite: boot
     params:
-      ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{brarch}/rootfs.cpio.gz'
+      rootfs_ref: buildroot-baseline
 
   baseline-nfs-job: &baseline-nfs-job
     template: baseline-nfs.jinja2
@@ -23,7 +23,7 @@ _anchors:
     kcidb_test_suite: boot.nfs
     params:
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}
+      rootfs_ref: bookworm
 
   kbuild-job: &kbuild-job
     template: kbuild.jinja2
@@ -93,7 +93,7 @@ _anchors:
     priority: low
     params: &kvm-unit-tests-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kvm-unit-tests/20250624.0/{debarch}'
+      rootfs_ref: bookworm-kvm-unit-tests
     kcidb_test_suite: kvm-unit-tests
     rules:
       fragments:
@@ -105,7 +105,7 @@ _anchors:
     priority: low
     params: &ltp-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20260219.0/{debarch}'
+      rootfs_ref: trixie-ltp
       skip_install: "true"
       skipfile: skipfile-lkft.yaml
       workers: max
@@ -1560,7 +1560,7 @@ jobs:
     params:
       test_method: blktests-ddp
       job_timeout: 30
-      rootfs: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-blktest/20250212.0/amd64'
+      rootfs_ref: bookworm-blktest
     rules:
       tree:
         - aaptel
@@ -1576,7 +1576,7 @@ jobs:
     params: &kselftest-params
       test_method: kselftest
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+      rootfs_ref: bookworm-kselftest
       job_timeout: 10
     rules: &kselftest-rules
       tree:
@@ -1593,7 +1593,7 @@ jobs:
     params: &kselftest-params-ramdisk
       test_method: kselftest
       boot_commands: ramdisk
-      ramdiskroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+      rootfs_ref: bookworm-kselftest
       job_timeout: 10
     rules: &kselftest-rules-ramdisk
       tree:
@@ -2373,7 +2373,7 @@ jobs:
     priority: low
     params: &rt-tests-params
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-rt/20240806.0/{debarch}'
+      rootfs_ref: bookworm-rt
     kcidb_test_suite: rt-tests
     rules:
       fragments:
@@ -2465,7 +2465,7 @@ jobs:
     params:
       test_method: sleep
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/bullseye/20240129.0/{debarch}
+      rootfs_ref: bullseye
       sleep_params: mem freeze
     kcidb_test_suite: kernelci_sleep
 
@@ -2475,7 +2475,7 @@ jobs:
     params:
       test_method: h26forge-debian
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-h26forge/20250117.0/{debarch}/'
+      rootfs_ref: bookworm-gst-h26forge
     rules:
       tree:
         - media
@@ -2487,7 +2487,7 @@ jobs:
     params:
       test_method: wifi-basic
       boot_commands: nfs
-      nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20250925.0/{debarch}/'
+      rootfs_ref: bookworm-wifi
     rules:
       tree:
         - mainline

--- a/config/rootfs.yaml
+++ b/config/rootfs.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Centralized rootfs definitions.
+# Jobs reference these by name via 'rootfs_ref' in their params.
+# The scheduler resolves rootfs_ref to actual URL params before
+# template rendering.
+#
+# NOTE: Entries must be sorted alphabetically.
+
+rootfs:
+
+  bookworm:
+    nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm/20240313.0/{debarch}'
+
+  bookworm-blktest:
+    rootfs: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-blktest/20250212.0/amd64'
+
+  bookworm-blktest-nfs:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-blktest/20251016.0/amd64/'
+
+  bookworm-fault-injection:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-fault-injection/20250520.0/{debarch}/'
+
+  bookworm-gst-fluster:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-fluster/20240926.0/{debarch}/'
+
+  bookworm-gst-h26forge:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-gst-h26forge/20250117.0/{debarch}/'
+
+  bookworm-kselftest:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+    ramdiskroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250724.0/{debarch}'
+
+  bookworm-kselftest-boot:
+    nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20250117.0/{debarch}'
+
+  bookworm-kvm-unit-tests:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-kvm-unit-tests/20250624.0/{debarch}'
+
+  bookworm-ltp:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-ltp/20250818.0/{debarch}'
+
+  bookworm-rt:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-rt/20240806.0/{debarch}'
+
+  bookworm-wifi:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/bookworm-wifi/20250925.0/{debarch}/'
+
+  buildroot-baseline:
+    ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230703.0/{brarch}/rootfs.cpio.gz'
+
+  buildroot-baseline-depthcharge:
+    ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230623.0/{brarch}/rootfs.cpio.gz'
+
+  buildroot-baseline-qemu:
+    ramdisk: 'http://storage.kernelci.org/images/rootfs/buildroot/buildroot-baseline/20230421.0/{brarch}/rootfs.cpio.gz'
+
+  bullseye:
+    nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/bullseye/20240129.0/{debarch}'
+
+  trixie-ltp:
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-ltp/20251201.0/{debarch}'

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -593,6 +593,11 @@ class Scheduler(Service):
                 err_msg = json.loads(err.response.content).get("detail", [])
                 self.log.error(err_msg)
             return
+        # Resolve rootfs config references (before format_params
+        # resolves {brarch}/{debarch} etc.)
+        kernelci.config.resolve_rootfs_params(
+            params, self._raw_yaml.get('rootfs', {})
+        )
         # Process potential f-strings in `params` with configured job params
         # and platform attributes
         kernel_revision = job_node['data']['kernel_revision']['version']

--- a/tests/validate_yaml.py
+++ b/tests/validate_yaml.py
@@ -184,6 +184,42 @@ def validate_platforms(data):
                 )
 
 
+def validate_rootfs_refs(data):
+    """
+    Validate rootfs references:
+    1. Every rootfs_ref in job params resolves to an entry in rootfs section
+    2. Rootfs entries are sorted alphabetically
+    """
+    rootfs_defs = data.get("rootfs", {})
+    if not rootfs_defs:
+        print("Warning: No rootfs definitions found")
+        return
+
+    # Check alphabetical sorting
+    rootfs_names = list(rootfs_defs.keys())
+    sorted_names = sorted(rootfs_names)
+    if rootfs_names != sorted_names:
+        raise yaml.YAMLError(
+            f"Rootfs entries are not sorted alphabetically. "
+            f"Expected order: {sorted_names}"
+        )
+
+    # Check all rootfs_ref values in jobs resolve
+    jobs = data.get("jobs", {})
+    for job_name, job_def in jobs.items():
+        if not job_def or not isinstance(job_def, dict):
+            continue
+        params = job_def.get("params")
+        if not params or not isinstance(params, dict):
+            continue
+        rootfs_ref = params.get("rootfs_ref")
+        if rootfs_ref and rootfs_ref not in rootfs_defs:
+            raise yaml.YAMLError(
+                f"rootfs_ref '{rootfs_ref}' in job '{job_name}' "
+                f"not found in rootfs definitions"
+            )
+
+
 def validate_unused_trees(data):
     """
     Check if all trees are used in build_configs
@@ -273,6 +309,8 @@ def validate_yaml(merged_data):
     validate_build_configs(merged_data)
     validate_unused_trees(merged_data)
     validate_platforms(merged_data)
+    print("Validating rootfs references")
+    validate_rootfs_refs(merged_data)
     print("All yaml files are valid")
 
 


### PR DESCRIPTION
At current moment we have rootfs scattered across configs, and even hardcoded inside kernelci-core.
We need to arrange that properly, similar to legacy system (even better), where we have single section with all rootfs kinds (templated), which can be referenced in other sections such as rootfs_ref parameter.

Requires: https://github.com/kernelci/kernelci-core/pull/3062