### PR TITLE
tools: add requirements and update docs for example_pull_lab.py

### DIFF
--- a/doc/connecting-pull-lab.md
+++ b/doc/connecting-pull-lab.md
@@ -101,11 +101,11 @@ payloads using tuxrun for QEMU-based virtual targets.
 
 ### Prerequisites
 
-Tuxrun is required to run the jobs, Tuxrun requires podman also to be setup to
-execute the jobs.
+Tuxrun is required to run the jobs. By default tuxrun uses podman, but Docker
+can be used instead by passing `--runtime docker`.
 
-- Install tuxrun: `pip install tuxrun`
-- Install podman: `sudo apt install podman`
+- Python packages: `pip install -r tools/requirements.txt`
+- Install podman: `sudo apt install podman` (or Docker: `sudo apt install docker.io`)
 - Tuxrun handles downloads and QEMU VM execution automatically
 
 ### Running the Script

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -6,3 +6,6 @@ labgrid
 pytest
 pyyaml
 requests
+
+# example_pull_lab.py (also requires podman or docker)
+tuxrun


### PR DESCRIPTION
Add a requirements file listing the pip-installable dependencies (requests, tuxrun) and update the documentation to note that tuxrun supports both podman (default) and Docker via --runtime docker.