### PR TITLE
hardware_registry: add initial hardware registry with TI boards

### DIFF
--- a/config/hardware_registry/index.yaml
+++ b/config/hardware_registry/index.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Hardware Registry Index
+#
+# Lists all vendor registry files that are part of the official hardware
+# registry. Add a new entry here when contributing a new vendor file.
+#
+# Schema path is relative to this file's directory.
+
+version: "1.0.0"
+schema: "schema.yaml"
+
+registries:
+  - ti.yaml

--- a/config/hardware_registry/schema.yaml
+++ b/config/hardware_registry/schema.yaml
@@ -1,0 +1,242 @@
+
+$schema: "http://json-schema.org/draft-07/schema#"
+title: "Hardware Catalog Schema"
+description: "Schema for describing silicon vendors, processors/SoCs, system-on-modules (SoMs), platform vendors, and platforms with cross-references"
+type: "object"
+
+$defs:
+  schema_version:
+    type: "object"
+    required: ["version", "revision_date"]
+    properties:
+      version:
+        type: "string"
+        pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        description: "Semantic version (MAJOR.MINOR.PATCH)"
+      revision_date:
+        type: "string"
+        format: "date"
+        description: "Date of this schema revision"
+      compatible_versions:
+        type: "array"
+        description: "List of schema versions this data is compatible with"
+        items:
+          type: "string"
+          pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+
+  base_entity:
+    type: "object"
+    required: ["id", "type", "url"]
+    properties:
+      id:
+        type: "string"
+        pattern: '^[a-z0-9_-]+$'
+        description: "Unique identifier (lowercase, underscores and dashes allowed)"
+      type:
+        type: "string"
+        description: "Entity type identifier"
+      url:
+        type: "string"
+        format: "uri"
+        description: "Primary URL"
+      details:
+        type: "string"
+        description: "Brief description"
+      version:
+        type: "string"
+        description: "Version identifier for the entity"
+      release_date:
+        type: "string"
+        format: "date"
+        description: "Release or founding date (ISO 8601: YYYY-MM-DD)"
+      spec_url:
+        type: "string"
+        format: "uri"
+        description: "URL to technical documentation"
+      deprecated:
+        type: "boolean"
+        description: "Whether this entity is deprecated"
+        default: false
+      deprecation_date:
+        type: "string"
+        format: "date"
+        description: "Date when this entity was deprecated"
+
+  vendor_entity:
+    allOf:
+      - $ref: "#/$defs/base_entity"
+      - required: ["id", "type", "url"]
+      - properties:
+          type:
+            type: "string"
+            enum: ["silicon_vendor", "platform_vendor"]
+
+  silicon_vendor:
+    allOf:
+      - $ref: "#/$defs/vendor_entity"
+      - properties:
+          type:
+            const: "silicon_vendor"
+
+  platform_vendor:
+    allOf:
+      - $ref: "#/$defs/vendor_entity"
+      - properties:
+          type:
+            const: "platform_vendor"
+
+  processor:
+    allOf:
+      - $ref: "#/$defs/base_entity"
+      - required: ["vendor_id", "id", "architecture", "url"]
+        properties:
+          type:
+            type: "string"
+            enum: ["cpu", "soc", "mcu", "dsp", "fpga", "gpu", "asic"]
+            description: "Type of silicon component"
+          vendor_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Reference to silicon vendor ID"
+          architecture:
+            type: "string"
+            description: "Instruction set architecture"
+            examples: ["arm", "arm64", "x86_64", "risc-v", "mips", "powerpc"]
+          cores:
+            type: "integer"
+            minimum: 1
+            description: "Number of processing cores"
+          max_clock_speed_mhz:
+            type: "number"
+            minimum: 0
+            description: "Maximum rated clock speed in MHz"
+          process_node_nm:
+            type: "number"
+            minimum: 0
+            description: "Manufacturing process node in nanometers"
+
+  # System Modules (System on Module or or System in Package) entity between processor and platform
+  system_module:
+    allOf:
+      - $ref: "#/$defs/base_entity"
+      - required: ["vendor_id", "processor_id", "type", "url"]
+        properties:
+          type:
+            type: "string"
+            enum: ["system_on_module", "system_in_package"]
+            description: "Represents a SoM (System on Module) or SiP (System in Package)"
+          vendor_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Reference to SoM/SiP vendor ID (typically a platform vendor like Toradex/PHYTEC)"
+          processor_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Reference to the processor/SoC ID used inside the SoM/SiP"
+          form_factor:
+            type: "string"
+            description: "SoM/SiP connector/mechanical standard"
+            examples: ["sodimm", "edimm", "mxm", "custom", "package"]
+          memory_mb:
+            type: "integer"
+            minimum: 0
+          storage_gb:
+            type: "number"
+            minimum: 0
+
+  platform:
+    allOf:
+      - $ref: "#/$defs/base_entity"
+      - required: ["vendor_id", "processor_id", "type", "url"]
+        properties:
+          type:
+            type: "string"
+            enum:
+              - "evaluation_board"
+              - "reference_board"
+              - "single_board_computer"
+              - "development_board"
+              - "product_board"
+              - "industrial_gateway"
+              - "laptop"
+              - "desktop"
+            description: "Platform type/category"
+          vendor_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Reference to platform vendor ID"
+          processor_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Reference to processor ID (often same as SoM's processor)"
+          system_module_id:
+            type: "string"
+            pattern: '^[a-zA-Z0-9_-]+$'
+            description: "Optional reference to a System on Module used on this platform"
+          form_factor:
+            type: "string"
+            description: "Physical form factor"
+            examples: ["credit_card", "din_rail", "laptop", "mini_pc", "pcie_card", "m.2", "atx", "matx"]
+          memory_mb:
+            type: "integer"
+            minimum: 0
+            description: "Onboard memory in megabytes"
+          storage_gb:
+            type: "number"
+            minimum: 0
+            description: "Onboard storage in gigabytes"
+
+  entity_collection:
+    type: "object"
+    patternProperties:
+      '^[a-zA-Z0-9_-]+$':
+        type: "object"
+    additionalProperties: false
+
+properties:
+  schema_info:
+    $ref: "#/$defs/schema_version"
+    description: "Schema version and compatibility information"
+
+  silicon_vendors:
+    allOf:
+      - $ref: "#/$defs/entity_collection"
+      - description: "Collection of silicon/chip manufacturers"
+        patternProperties:
+          '^[a-zA-Z0-9_-]+$':
+            $ref: "#/$defs/silicon_vendor"
+
+  platform_vendors:
+    allOf:
+      - $ref: "#/$defs/entity_collection"
+      - description: "Collection of platform manufacturers"
+        patternProperties:
+          '^[a-zA-Z0-9_-]+$':
+            $ref: "#/$defs/platform_vendor"
+
+  processors:
+    allOf:
+      - $ref: "#/$defs/entity_collection"
+      - description: "Collection of processors, SoCs, CPUs, and microcontrollers"
+        patternProperties:
+          '^[a-zA-Z0-9_-]+$':
+            $ref: "#/$defs/processor"
+
+  system_modules:
+    allOf:
+      - $ref: "#/$defs/entity_collection"
+      - description: "Collection of reusable System-on-Modules (SoMs) or System-in-Package (SiPs)"
+        patternProperties:
+          '^[a-zA-Z0-9_-]+$':
+            $ref: "#/$defs/system_module"
+
+  platforms:
+    allOf:
+      - $ref: "#/$defs/entity_collection"
+      - description: "Collection of hardware platforms"
+        patternProperties:
+          '^[a-zA-Z0-9_-]+$':
+            $ref: "#/$defs/platform"
+
+required: ["schema_info", "silicon_vendors", "platform_vendors", "processors", "platforms"]
+additionalProperties: false

--- a/config/hardware_registry/ti.yaml
+++ b/config/hardware_registry/ti.yaml
@@ -1,0 +1,584 @@
+schema_info:
+  version: "1.0.0"
+  revision_date: "2025-12-11"
+  compatible_versions: ["1.0.0"]
+
+silicon_vendors:
+  ti:
+    id: "ti"
+    type: "silicon_vendor"
+    url: "https://www.ti.com"
+    details: "Texas Instruments embedded processors, microcontrollers, and analog ICs"
+
+platform_vendors:
+  ti:
+    id: "ti"
+    type: "platform_vendor"
+    url: "https://ti.com"
+    details: "Evaluation boards for Texas Instruments products"
+
+  beagleboard:
+    id: "beagleboard"
+    type: "platform_vendor"
+    url: "https://beagleboard.org"
+    details: "Open-source single-board computers"
+
+processors:
+  am3358:
+    id: "am3358"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM3358"
+    details: "Arm Cortex-A8, 3D graphics, PRU-ICSS, CAN"
+    architecture: "arm"
+    cores: 1
+    max_clock_speed_mhz: 800
+
+  am3359:
+    id: "am3359"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM3359"
+    details: "Arm Cortex-A8, EtherCAT, 3D, PRU-ICSS, CAN"
+    architecture: "arm"
+    cores: 1
+    max_clock_speed_mhz: 800
+
+  am4378:
+    id: "am4378"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM4378"
+    details: "Arm Cortex-A9, PRU-ICSS, 3D graphics"
+    architecture: "arm"
+    cores: 1
+    max_clock_speed_mhz: 1000
+
+  am5718:
+    id: "am5718"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM5718"
+    details: "Arm Cortex-A15 & DSP, multimedia"
+    architecture: "arm"
+    cores: 2
+    max_clock_speed_mhz: 1500
+
+  am5728:
+    id: "am5728"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM5728"
+    details: "Dual Arm Cortex-A15 & dual DSP, multimedia"
+    architecture: "arm"
+    cores: 2
+    max_clock_speed_mhz: 1500
+
+  am5748:
+    id: "am5748"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM5748"
+    details: "Dual arm Cortex-A15 & dual DSP, multimedia, ECC on DDR and secure boot"
+    architecture: "arm"
+    cores: 2
+    max_clock_speed_mhz: 1500
+
+  am625:
+    id: "am625"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM625"
+    details: "Human-machine-interaction SoC with Arm Cortex-A53-based edge AI and full-HD dual display"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 1400
+
+  am62a7:
+    id: "am62a7"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM62A7"
+    details: "2 TOPS vision SoC with RGB-IR ISP for 1-2 cameras, low-power systems, machine vision, robotics"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 1400
+
+  am62d2:
+    id: "am62d2"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM62D-Q1"
+    details: "Automotive 40GFLOPS DSP audio processor with Arm Cortex-A53, Cortex-R5F and LPDDR4"
+    architecture: "arm64"
+    cores: 2
+    max_clock_speed_mhz: 1400
+
+  am62p5:
+    id: "am62p5"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM62P"
+    details: "Arm Cortex-A53 SoC with triple display, 3D graphics, 4K video codec for HMI"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 1400
+
+  am6442:
+    id: "am6442"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM6442"
+    details: "Dual-core 64-bit Arm Cortex-A53, quad-core Cortex-R5F, PCIe, USB 3.0 and security"
+    architecture: "arm64"
+    cores: 2
+    max_clock_speed_mhz: 1000
+
+  am6548:
+    id: "am6548"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM6548"
+    details: "Quad Arm Cortex-A53 and dual Arm Cortex-R5F Sitara processor with gigabit PRU-ICSS, 3D graphics"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 1100
+
+  am68:
+    id: "am68"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM68A"
+    details: "8 TOPS vision SoC for 1-8 cameras, machine vision, smart traffic, retail automation"
+    architecture: "arm64"
+    cores: 8
+    max_clock_speed_mhz: 2000
+
+  am69a:
+    id: "am69a"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/AM69A"
+    details: "32 TOPS vision SoC for 1-12 cameras, autonomous mobile robots, machine vision, mobile DVR, AI-BOX"
+    architecture: "arm64"
+    cores: 8
+    max_clock_speed_mhz: 2000
+
+  dra718:
+    id: "dra718"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/DRA718"
+    details: "1 GHz Arm Cortex-A15 SoC processor with graphics & DSP for infotainment & cluster"
+    architecture: "arm"
+    cores: 1
+    max_clock_speed_mhz: 1000
+
+  dra821u:
+    id: "dra821u"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/DRA821U-Q1"
+    details: "SoC with Dual Arm Cortex-A72, 4 port Ethernet, and 4 lane PCIe for networking and compute"
+    architecture: "arm64"
+    cores: 2
+    max_clock_speed_mhz: 2000
+
+  tda4vm:
+    id: "tda4vm"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/TDA4VM"
+    details: "SoC with Dual Arm Cortex-A72, 8 TOPS of AI, C7xDSP, and GPU for vision perception and analytics"
+    architecture: "arm64"
+    cores: 2
+    max_clock_speed_mhz: 2000
+
+  tda4vl:
+    id: "tda4vl"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/TDA4VL-Q1"
+    details: "SoC with Dual Arm Cortex-A72, 4 TOPS of AI, C7xDSP, and GPU for vision perception and analytics"
+    architecture: "arm64"
+    cores: 2
+    max_clock_speed_mhz: 1200
+
+  tda4ven:
+    id: "tda4ven"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/TDA4VEN-Q1"
+    details: "SoC with Quad Arm Cortex-A53, 4 TOPS of AI, C7xDSP, and GPU for vision perception and analytics"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 1400
+
+  tda4vpe:
+    id: "tda4vpe"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/TDA4VPE-Q1"
+    details: "SoC with Quad Arm Cortex-A72, 16 TOPS of AI, C7xDSP and GPU for vision perception and analytics"
+    architecture: "arm64"
+    cores: 4
+    max_clock_speed_mhz: 2000
+
+  tda4ap:
+    id: "tda4ap"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/TDA4AP-Q1"
+    details: "Octa Cortex-A72 processor for high-performance automotive"
+    architecture: "arm64"
+    cores: 8
+    max_clock_speed_mhz: 2000
+
+  66ak2g12:
+    id: "66ak2g12"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/66AK2G12"
+    details: "High performance multicore DSP+Arm - 1x Arm A15 cores, 1x C66x DSP core"
+    architecture: "arm"
+    cores: 1
+    max_clock_speed_mhz: 1000
+
+  66ak2h14:
+    id: "66ak2h14"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/66AK2H14"
+    details: "High performance multicore DSP+Arm - 4x Arm A15 cores, 8x C66x DSP cores, 10GbE"
+    architecture: "arm"
+    cores: 4
+    max_clock_speed_mhz: 1400
+
+  66al2l06:
+    id: "66al2l06"
+    type: "soc"
+    vendor_id: "ti"
+    url: "https://www.ti.com/product/66AK2L06"
+    details: "Multicore DSP+ARM KeyStone II System-on-Chip"
+    max_clock_speed_mhz: 1200
+    architecture: "arm"
+    cores: 4
+
+system_modules:
+  j721exsomxevm:
+    id: "j721exsomxevm"
+    type: "system_on_module"
+    vendor_id: "ti"
+    processor_id: "tda4vm"
+    url: "https://www.ti.com/tool/J721EXSOMXEVM"
+    details: "TDA4VM and DRA829V socketed system on module"
+    form_factor: "board"
+
+  j721s2xsomxevm:
+    id: "j721s2xsomxevm"
+    type: "system_on_module"
+    vendor_id: "ti"
+    processor_id: "tda4vl"
+    url: "https://www.ti.com/tool/J721S2XSOMXEVM"
+    details: "TDA4VE-Q1, TDA4VL-Q1 and TDA4AL-Q1 system on module (SoM)"
+    form_factor: "board"
+
+platforms:
+  am335x-ice:
+    id: "am335x-ice"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am3359"
+    url: "https://www.ti.com/tool/TMDSICE3359"
+    details: "AM3359 Industrial Communications Engine"
+    form_factor: "board"
+
+  am335x-bone-black:
+    id: "am335x-bone-black"
+    type: "single_board_computer"
+    vendor_id: "beagleboard"
+    processor_id: "am3358"
+    url: "https://beagleboard.org/black"
+    details: "BeagleBone Black open-source development board"
+    form_factor: "board"
+
+  am335x-evm:
+    id: "am335x-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am3358"
+    url: "https://www.ti.com/tool/TMDXEVM3358"
+    details: "AM335x evaluation module"
+    form_factor: "board"
+
+  am335x-sk:
+    id: "am335x-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am3358"
+    url: "https://www.ti.com/tool/TMDSSK3358"
+    details: "AM335x Starter Kit evaluation board"
+    form_factor: "board"
+
+  am437x-gpevm:
+    id: "am437x-gpevm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am4378"
+    url: "https://www.ti.com/tool/TMDSEVM437X"
+    details: "AM437x General Purpose evaluation module"
+    form_factor: "board"
+
+  am437x-idk-evm:
+    id: "am437x-idk-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am4378"
+    url: "https://www.ti.com/tool/TMDSIDK437X"
+    details: "AM437x Industrial Development Kit"
+    form_factor: "board"
+
+  am437x-sk-evm:
+    id: "am437x-sk-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am4378"
+    url: "https://www.ti.com/tool/TMDXSK437X"
+    details: "AM437x Starter Kit"
+    form_factor: "board"
+
+  am571x-idk:
+    id: "am571x-idk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am5718"
+    url: "https://www.ti.com/tool/TMDXIDK5718"
+    details: "AM571x Industrial Development Kit"
+    form_factor: "board"
+
+  am57xx-evm:
+    id: "am57xx-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am5728"
+    url: "https://www.ti.com/tool/TMDSEVM572X"
+    details: "AM572x evaluation module"
+    form_factor: "board"
+
+  am572x-idk:
+    id: "am572x-idk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am5728"
+    url: "https://www.ti.com/tool/TMDSIDK572"
+    details: "AM572x Industrial Development Kit"
+    form_factor: "board"
+
+  am57xx-beagle-x15:
+    id: "am57xx-beagle-x15"
+    type: "single_board_computer"
+    vendor_id: "beagleboard"
+    processor_id: "am5728"
+    url: "https://www.beagleboard.org/boards/beagleboard-x15"
+    details: "BeagleBoard X15 high-performance single board computer"
+    form_factor: "board"
+
+  am574x-idk:
+    id: "am574x-idk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am5748"
+    url: "https://www.ti.com/tool/TMDSIDK574"
+    details: "AM5748 Industrial Development Kit"
+    form_factor: "board"
+
+  am62-sk:
+    id: "am62-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am625"
+    url: "https://www.ti.com/tool/SK-AM62"
+    details: "AM62x Starter Kit for Sitara processors"
+    form_factor: "board"
+
+  am62a-sk:
+    id: "am62a-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am62a7"
+    url: "https://www.ti.com/tool/SK-AM62A-LP"
+    details: "AM62A Starter Kit for vision AI applications"
+    form_factor: "board"
+
+  am62d-evm:
+    id: "am62d-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am62d2"
+    url: "https://www.ti.com/tool/AUDIO-AM62D-EVM"
+    details: "AM62D expandable hardware for premium audio"
+    form_factor: "board"
+
+  am62-lp-sk:
+    id: "am62-lp-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am625"
+    url: "https://www.ti.com/tool/SK-AM62-LP"
+    details: "AM62 Low Power Starter Kit"
+    form_factor: "board"
+
+  am62p-sk:
+    id: "am62p-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am62p5"
+    url: "https://www.ti.com/tool/SK-AM62P-LP"
+    details: "AM62P5 Starter Kit"
+    form_factor: "board"
+
+  am64-evm:
+    id: "am64-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am6442"
+    url: "https://www.ti.com/tool/TMDS64EVM"
+    details: "AM64x evaluation module"
+    form_factor: "board"
+
+  am64-sk:
+    id: "am64-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am6442"
+    url: "https://www.ti.com/tool/SK-AM64B"
+    details: "AM64x Starter Kit"
+    form_factor: "board"
+
+  am654-idk:
+    id: "am654-idk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am6548"
+    url: "https://www.ti.com/tool/TMDX654IDKEVM"
+    details: "AM65x industrial development kit"
+    form_factor: "board"
+
+  am68-sk:
+    id: "am68-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am68"
+    url: "https://www.ti.com/tool/SK-AM68"
+    details: "AM68 and AM68A starter kit for vision AI and general purpose processors"
+    form_factor: "board"
+
+  am69-sk:
+    id: "am69-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "am69a"
+    url: "https://www.ti.com/tool/SK-AM69"
+    details: "AM69 and AM69A starter kit for vision AI and general purpose processors"
+    form_factor: "board"
+
+  dra71-evm:
+    id: "dra71-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "dra718"
+    url: "https://www.ti.com/tool/DRA71XEVM"
+    details: "DRA71x evaluation module"
+    form_factor: "board"
+
+  j7200-evm:
+    id: "j7200-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "dra821u"
+    url: "https://www.ti.com/tool/J7200XSOMXEVM"
+    details: "J7200 evaluation module for automotive applications"
+    form_factor: "board"
+
+  j721e-evm:
+    id: "j721e-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4vm"
+    system_module_id: "j721exsomxevm"
+    url: "https://www.ti.com/tool/J721EXSOMXEVM"
+    details: "J721E evaluation module for automotive and industrial"
+    form_factor: "board"
+
+  j721e-sk:
+    id: "j721e-sk"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4vm"
+    url: "https://www.ti.com/tool/SK-TDA4VM"
+    details: "TDA4VM processor starter kit for edge AI vision systems"
+    form_factor: "board"
+
+  j721s2-evm:
+    id: "j721s2-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4vl"
+    system_module_id: "j721s2xsomxevm"
+    url: "https://www.ti.com/tool/J721S2XSOMXEVM"
+    details: "J721S2 evaluation module"
+    form_factor: "board"
+
+  j722s-evm:
+    id: "j722s-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4ven"
+    url: "https://www.ti.com/tool/J722SXH01EVM"
+    details: "J722S evaluation module"
+    form_factor: "board"
+
+  j742s2-evm:
+    id: "j742s2-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4vpe"
+    url: "https://www.ti.com/tool/J742S2XH01EVM"
+    details: "J742S2 evaluation module for industrial and automotive applications"
+    form_factor: "board"
+
+  j784s4-evm:
+    id: "j784s4-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "tda4ap"
+    url: "https://www.ti.com/tool/J784S4XEVM"
+    details: "J784S4 evaluation module for module for SoC far-field analytic systems"
+    form_factor: "board"
+
+  k2g-evm:
+    id: "k2g-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "66ak2g12"
+    url: "https://www.ti.com/tool/EVMK2GX"
+    details: "66AK2Gx 1GHz evaluation module"
+    form_factor: "board"
+
+  k2hk-evm:
+    id: "k2hk-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "66ak2h14"
+    url: ""
+    details: "K2HK evaluation module for high-performance processing"
+    form_factor: "board"
+
+  k2l-evm:
+    id: "k2l-evm"
+    type: "evaluation_board"
+    vendor_id: "ti"
+    processor_id: "66al2l06"
+    url: ""
+    details: "K2L evaluation module for networking applications"
+    form_factor: "board"

--- a/tests/hw_reg_checker.py
+++ b/tests/hw_reg_checker.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+#
+# Validate all hardware registry files listed in the registry index against
+# the hardware registry schema.
+#
+# Usage:
+#   python3 tests/hw_reg_checker.py
+#   python3 tests/hw_reg_checker.py /path/to/hardware_registry/index.yaml
+
+import argparse
+import os
+import sys
+
+import yaml
+from jsonschema import validate, ValidationError
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Validate hardware registry files against the schema"
+    )
+    parser.add_argument(
+        "index",
+        nargs="?",
+        help="Path to hardware registry index.yaml (default: config/hardware_registry/index.yaml)",
+    )
+    return parser.parse_args()
+
+
+def default_index_path():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(script_dir)
+    return os.path.join(repo_root, "config", "hardware_registry", "index.yaml")
+
+
+def validate_references(data, registry_file):
+    """Validate cross-references between sections in a registry file.
+
+    Returns a list of error strings (empty if all references are valid).
+    """
+    errors = []
+
+    silicon_vendors = set(data.get("silicon_vendors", {}).keys())
+    platform_vendors = set(data.get("platform_vendors", {}).keys())
+    processors = set(data.get("processors", {}).keys())
+    system_modules = set(data.get("system_modules", {}).keys())
+
+    def check_ref(section, entry_key, field, valid_set, valid_set_name):
+        value = data.get(section, {}).get(entry_key, {}).get(field)
+        if value is not None and value not in valid_set:
+            errors.append(
+                f"{section}[{entry_key}].{field} = '{value}' "
+                f"not found in {valid_set_name}"
+            )
+
+    for section in ("silicon_vendors", "platform_vendors", "processors",
+                    "system_modules", "platforms"):
+        for key, entity in data.get(section, {}).items():
+            entity_id = entity.get("id")
+            if entity_id is not None and entity_id != key:
+                errors.append(
+                    f"{section}[{key}].id = '{entity_id}' "
+                    f"does not match its key '{key}'"
+                )
+
+    for key in data.get("processors", {}):
+        check_ref("processors", key, "vendor_id", silicon_vendors, "silicon_vendors")
+
+    for key in data.get("system_modules", {}):
+        check_ref("system_modules", key, "vendor_id", platform_vendors, "platform_vendors")
+        check_ref("system_modules", key, "processor_id", processors, "processors")
+
+    for key in data.get("platforms", {}):
+        check_ref("platforms", key, "vendor_id", platform_vendors, "platform_vendors")
+        check_ref("platforms", key, "processor_id", processors, "processors")
+        check_ref("platforms", key, "system_module_id", system_modules, "system_modules")
+
+    return errors
+
+
+def main():
+    args = parse_args()
+    index_path = os.path.abspath(args.index or default_index_path())
+    index_dir = os.path.dirname(index_path)
+
+    if not os.path.exists(index_path):
+        print(f"ERROR: Index file not found: {index_path}")
+        sys.exit(1)
+
+    with open(index_path) as f:
+        index = yaml.safe_load(f)
+
+    schema_path = os.path.normpath(os.path.join(index_dir, index["schema"]))
+    if not os.path.exists(schema_path):
+        print(f"ERROR: Schema file not found: {schema_path}")
+        sys.exit(1)
+
+    with open(schema_path) as f:
+        schema = yaml.safe_load(f)
+
+    registries = index.get("registries", [])
+    if not registries:
+        print("WARNING: No registry files listed in index.")
+        sys.exit(0)
+
+    print(f"Schema:  {os.path.relpath(schema_path)}")
+    print(f"Index:   {os.path.relpath(index_path)}")
+    print(f"Entries: {len(registries)}\n")
+
+    all_passed = True
+
+    for registry_file in registries:
+        registry_path = os.path.normpath(os.path.join(index_dir, registry_file))
+        print(f"Checking {registry_file} ...")
+
+        if not os.path.exists(registry_path):
+            print(f"  ERROR: File not found: {registry_path}")
+            all_passed = False
+            continue
+
+        try:
+            with open(registry_path) as f:
+                data = yaml.safe_load(f)
+
+            validate(instance=data, schema=schema)
+
+            ref_errors = validate_references(data, registry_file)
+            if ref_errors:
+                print(f"  FAIL: Reference errors")
+                for err in ref_errors:
+                    print(f"    {err}")
+                all_passed = False
+            else:
+                print(f"  OK")
+                print(f"  Silicon vendors:  {len(data.get('silicon_vendors', {}))}")
+                print(f"  Platform vendors: {len(data.get('platform_vendors', {}))}")
+                print(f"  Processors:       {len(data.get('processors', {}))}")
+                if "system_modules" in data:
+                    print(f"  System modules:   {len(data['system_modules'])}")
+                print(f"  Platforms:        {len(data.get('platforms', {}))}")
+
+        except ValidationError as e:
+            print(f"  FAIL: Validation error")
+            print(f"    Message:     {e.message}")
+            print(f"    Path:        {' -> '.join(map(str, e.path))}")
+            print(f"    Schema path: {' -> '.join(map(str, e.schema_path))}")
+            all_passed = False
+
+        print()
+
+    if all_passed:
+        print("All registry files passed validation.")
+    else:
+        print("One or more registry files failed validation.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces a vendor-extensible hardware registry under config/:

- config/hardware_registry/schema.yaml: Schema defining the structure for silicon vendors, platform vendors, processors, system modules, and platforms.

- config/hardware_registry/index.yaml: manifest listing the active vendor registry files and pointing to the schema. New vendors add their file here.

- config/hardware_registry/ti.yaml: initial registry covering Texas Instruments silicon vendors, processors (AM3x, AM4x, AM5x, AM6x, J7-series, K2-series), system modules, and evaluation/starter boards.

- tests/hw_reg_checker.py: validation tool that reads the index, resolves the schema, and validates every listed registry file, reporting per-file statistics and exiting non-zero on failure.