### PR TITLE
jobs: Run KUnit --alltests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -2165,6 +2165,7 @@ jobs:
     <<: *kunit-job
     params:
       arch: x86_64
+      args: --alltests
     rules:
       tree:
         - '!chromiumos'

--- a/config/runtime/kunit.jinja2
+++ b/config/runtime/kunit.jinja2
@@ -23,6 +23,7 @@ RESULT_MAP = {
     'SKIP': 'skip',
 }
 ARCH = '{{ arch }}'
+ARGS = '{{ args }}'
 {% endblock %}
 
 {% block python_job -%}
@@ -104,11 +105,12 @@ cd {src_path}
         if os.path.exists(job_log_path):
             os.remove(job_log_path)
 
+        args = f'{ARGS}' if ARGS else ''
         arch_arg = f'--arch={ARCH}' if ARCH else ''
         steps = {
-            'config': f'config {arch_arg}',
-            'build': f'build --jobs=$(nproc) {arch_arg}',
-            'exec': f'exec --json={kunit_json} {arch_arg}',
+            'config': f'config {args} {arch_arg}',
+            'build': f'build --jobs=$(nproc) {args} {arch_arg}',
+            'exec': f'exec --json={kunit_json} {args} {arch_arg}',
         }
         step_results = {name: (None, []) for name in steps.keys()}
 


### PR DESCRIPTION
KUnit has an option --alltests that enables greater coverage.  For the
purposes of KernelCI it really doesn't make that much sense to use the
cut down default set of tests only, enable the full set as standard.

Signed-off-by: Mark Brown <broonie@kernel.org>
