### PR TITLE
config: add platform rules for Orion O6

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -82,6 +82,15 @@ platforms:
     <<: *arm64-device
     mach: cix
     boot_method: grub
+    rules:
+      min_version:
+        version: 6
+        patchlevel: 12
+      tree:
+        - mainline
+        - next
+        - stable
+        - stable-rc
 
   da850-lcdk:
     <<: *arm-device


### PR DESCRIPTION
The Orion O6 (CIX Sky1 SoC) requires kernel >= 6.12 for PCIe enumeration via ACPI/ECAM (validated on stable v6.12.78, native PCIe host driver lands in v6.19-rc1). Older stable branches (6.1.y, 6.6.y) fail to enumerate PCIe devices.

Add platform-level rules to limit cd8180-orion-o6 to mainline, next, stable, and stable-rc trees with min_version 6.12.