### PR TITLE
config: rpm aws builds

### DIFF
--- a/config/fragments.yaml
+++ b/config/fragments.yaml
@@ -903,3 +903,17 @@ fragments:
 
   x86_kvm_guest:
     path: "kernel/configs/kvm_guest.config"
+
+  aws-ec2:
+    path: "kernel/configs/aws-ec2.config"
+    configs:
+      - 'CONFIG_NET_VENDOR_AMAZON=y'
+      - 'CONFIG_ENA_ETHERNET=y'
+      - 'CONFIG_NVME_CORE=y'
+      - 'CONFIG_BLK_DEV_NVME=y'
+      - 'CONFIG_XFS_FS=y'
+      - 'CONFIG_VIRTIO=y'
+      - 'CONFIG_VIRTIO_PCI=y'
+      - 'CONFIG_VIRTIO_BLK=y'
+      - 'CONFIG_VIRTIO_NET=y'
+      - 'CONFIG_DEBUG_INFO=n'

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1562,6 +1562,36 @@ jobs:
       - 'stable'
       - 'sashal-next'
 
+  kbuild-gcc-14-x86-aws-ec2:
+    <<: *kbuild-gcc-14-x86-job
+    params:
+      <<: *kbuild-gcc-14-x86-params
+      fragments:
+        - 'aws-ec2'
+      extra_targets:
+        - 'binrpm-pkg'
+    rules:
+      tree:
+      - 'mainline'
+      - 'stable'
+      - 'stable-rc'
+      - 'next'
+
+  kbuild-gcc-14-arm64-aws-ec2:
+    <<: *kbuild-gcc-14-arm64-job
+    params:
+      <<: *kbuild-gcc-14-arm64-params
+      fragments:
+        - 'aws-ec2'
+      extra_targets:
+        - 'binrpm-pkg'
+    rules:
+      tree:
+      - 'mainline'
+      - 'stable'
+      - 'stable-rc'
+      - 'next'
+
   blktests-ddp-x86:
     template: blktests-ddp.jinja2
     kind: job

--- a/config/runtime/kbuild.jinja2
+++ b/config/runtime/kbuild.jinja2
@@ -58,6 +58,9 @@ KBUILD_PARAMS = {
 {%- if kselftest %}
     'kselftest': '{{ kselftest }}'
 {%- endif %}
+{%- if extra_targets %}
+    'extra_targets': {{ extra_targets }},
+{%- endif %}
 
 }
 {%- endblock %}

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -608,6 +608,9 @@ scheduler:
   - job: kbuild-gcc-14-arm64
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-14-arm64-aws-ec2
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-arm64-nfsboot
     <<: *build-k8s-all
 
@@ -773,6 +776,9 @@ scheduler:
         - '!efi'
 
   - job: kbuild-gcc-14-x86
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-14-x86-aws-ec2
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-x86-allnoconfig


### PR DESCRIPTION
Add support for building kernel RPM packages targeting AWS EC2 instances:

- New aws-ec2 config fragment with EC2-critical drivers built-in (ENA, NVMe, XFS, virtio) so kernels boot without an initramfs
- New kbuild-gcc-14-x86-aws-ec2 job using the fragment and tuxmake's binrpm-pkg target to produce installable RPMs
- Scheduler entry to trigger builds on new checkouts
- Template update to pass extra_targets through to KBuild

Requires the matching extra_targets support in kernelci-core.