### PR TITLE
config: Enable rseq selftests

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -2053,6 +2053,14 @@ jobs:
       collections: rlimits
     kcidb_test_suite: kselftest.rlimits
 
+  kselftest-rseq:
+    <<: *kselftest-job
+    params:
+      <<: *kselftest-params
+      collections: rseq
+      job_timeout: 30
+    kcidb_test_suite: kselftest.rseq
+
   kselftest-seccomp:
     <<: *kselftest-job
     params:

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -1491,6 +1491,22 @@ scheduler:
     platforms:
       - bcm2837-rpi-3-b-plus
 
+  - job: kselftest-rseq
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - beaglebone-black
+
+  - job: kselftest-rseq
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64-kselftest
+    runtime: *lava-broonie-runtime
+    platforms:
+      - bcm2711-rpi-4-b
+
   - job: kselftest-splice
     event:
       <<: *node-event-kbuild


### PR DESCRIPTION
Add a job for the rseq selftests and run it on BeagleBone Black and
Raspberry Pi 4 in my lab, it'd be good to get some other architecture
coverage as well.  The job timeout is set high mainly for the benefit of
32 bit arm, the tests are quite CPU intensive and it turns out that the
BeagleBone Black is not very fast.

Currently these do not actually need the kselftest defconfig but there
is some discussion upstream of adding a fragment to enable some
debugging options and it shouldn't hurt anything to have it.

Signed-off-by: Mark Brown <broonie@kernel.org>
