### PR TITLE
pull-labs: add AWS EC2 platform and scheduler config

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -30,3 +30,15 @@ jobs:
       <<: *ltp-params-pull-labs
       tst_cmdfiles: "smoketest"
     kcidb_test_suite: ltp
+
+  baseline-x86-aws-ec2:
+    template: baseline.jinja2
+    kind: job
+    priority: medium
+    kcidb_test_suite: boot
+
+  baseline-arm64-aws-ec2:
+    template: baseline.jinja2
+    kind: job
+    priority: medium
+    kcidb_test_suite: boot

--- a/config/pipeline-pull-labs.yaml
+++ b/config/pipeline-pull-labs.yaml
@@ -11,3 +11,11 @@ runtimes:
     notify:
       callback:
         token: kernelci-pull-labs-demo
+
+  pull-labs-aws-ec2:
+    lab_type: pull_labs
+    poll_interval: 60
+    timeout: 7200
+    notify:
+      callback:
+        token: kernelci-pull-labs-aws-ec2

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -669,3 +669,13 @@ platforms:
     dtb: dtbs/allwinner/sun50i-h6-orangepi-3.dtb
     compatible: ['xunlong,orangepi-3', 'allwinner,sun50i-h6']
 
+  aws-ec2-x86_64:
+    arch: x86_64
+    boot_method: grub
+    mach: x86
+
+  aws-ec2-arm64:
+    arch: arm64
+    boot_method: grub
+    mach: arm
+

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -62,3 +62,21 @@ scheduler:
       name: pull-labs-demo
     platforms:
       - qemu-x86_64
+
+  - job: baseline-x86-aws-ec2
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-x86-aws-ec2
+    runtime: &pull-labs-aws-ec2-runtime
+      type: pull_labs
+      name: pull-labs-aws-ec2
+    platforms:
+      - aws-ec2-x86_64
+
+  - job: baseline-arm64-aws-ec2
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64-aws-ec2
+    runtime: *pull-labs-aws-ec2-runtime
+    platforms:
+      - aws-ec2-arm64


### PR DESCRIPTION
Add pull_labs configuration for AWS EC2 kernel testing:

- Platform definitions for aws-ec2-x86_64 and aws-ec2-arm64
- pull-labs-aws-ec2 runtime with dedicated callback token
- Baseline boot jobs for both architectures
- Scheduler entries watching kbuild-gcc-14-x86-aws-ec2 and kbuild-gcc-14-arm64-aws-ec2 build completions