### PR TITLE
config: restrict AWS/RPM builds to kernels >= 6.6

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1571,6 +1571,9 @@ jobs:
       extra_targets:
         - 'binrpm-pkg'
     rules:
+      min_version:
+        version: 6
+        patchlevel: 6
       tree:
       - 'mainline'
       - 'stable'
@@ -1586,6 +1589,9 @@ jobs:
       extra_targets:
         - 'binrpm-pkg'
     rules:
+      min_version:
+        version: 6
+        patchlevel: 6
       tree:
       - 'mainline'
       - 'stable'


### PR DESCRIPTION
Add min_version 6.6 to both kbuild-gcc-14-{x86,arm64}-aws-ec2 so the jobs are skipped on stable/stable-rc branches since current it'll error out.