### PR TITLE
(platforms.yaml) Add support for Qualcomm glymur-crd platform

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -458,6 +458,13 @@ platforms:
     dtb: dtbs/qcom/monaco-evk.dtb
     compatible: ['qcom,monaco-evk', 'qcom,qcs8300']
 
+  glymur-crd:
+    <<: *arm64-device
+    boot_method: fastboot
+    mach: qcom
+    dtb: dtbs/qcom/glymur-crd.dtb
+    compatible: ['qcom,glymur-crd', 'qcom,glymur']
+
   qemu-x86_64: &qemu-device
     base_name: qemu
     arch: x86_64

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -304,6 +304,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -876,6 +877,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -908,6 +910,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -937,6 +940,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -966,6 +970,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -995,6 +1000,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1052,6 +1058,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1079,6 +1086,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1131,6 +1139,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1161,6 +1170,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1196,6 +1206,7 @@ scheduler:
       - kaanapali-qrd
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - sm8750-mtp
       - qcs615-ride
       - qcs6490-rb3gen2
@@ -1410,6 +1421,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - x1e80100
 
   - job: kselftest-proc
@@ -1445,6 +1457,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
 
   - job: kselftest-ring-buffer
     event:
@@ -1479,6 +1492,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - x1e80100
 
   - job: kselftest-rlimits
@@ -1590,6 +1604,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - x1e80100
 
   - job: kselftest-tmpfs
@@ -1619,6 +1634,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - x1e80100
 
   - job: kselftest-seccomp
@@ -1756,6 +1772,7 @@ scheduler:
       - kaanapali-mtp
       - lemans-evk
       - monaco-evk
+      - glymur-crd
       - x1e80100
 
   - job: kselftest-cpufreq-suspend


### PR DESCRIPTION
Extend pipeline to support Qualcomm platform glymur-crd.