### PR TITLE
nfs-root-boot: enable EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER

### DIFF
--- a/config/fragments.yaml
+++ b/config/fragments.yaml
@@ -444,6 +444,7 @@ fragments:
       - 'CONFIG_IP_PNP=y'
       - 'CONFIG_IP_PNP_DHCP=y'
       - 'CONFIG_IP_PNP_BOOTP=y'
+      - 'CONFIG_EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER=y'
 
   preempt_rt:
     path: "kernel/configs/preempt_rt.config"


### PR DESCRIPTION
FVP cpio boot fails on linux-5.15.y and linux-6.1.y because the EFI stub's cmdline initrd loader is compiled out. Enable it via the fragment.