### PR TITLE
rootfs: bump trixie-kselftest to 20260606.0

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -20,7 +20,7 @@ _anchors:
 
   kselftest-params-pull-labs: &kselftest-params-pull-labs
     boot_commands: nfs
-    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260219.0/{debarch}'
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260606.0/{debarch}'
     job_timeout: 30
 
 jobs:

--- a/config/rootfs.yaml
+++ b/config/rootfs.yaml
@@ -40,11 +40,11 @@ rootfs:
     nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-gst-h26forge/20260219.0/{debarch}/'
 
   trixie-kselftest:
-    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260219.0/{debarch}'
-    ramdiskroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260219.0/{debarch}'
+    nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260606.0/{debarch}'
+    ramdiskroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260606.0/{debarch}'
 
   trixie-kselftest-boot:
-    nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260219.0/{debarch}'
+    nfsroot: 'http://storage.kernelci.org/images/rootfs/debian/trixie-kselftest/20260606.0/{debarch}'
 
   trixie-kvm-unit-tests:
     nfsroot: 'https://storage.kernelci.org/images/rootfs/debian/trixie-kvm-unit-tests/20260219.0/{debarch}'

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
Includes the e2fsprogs add from kernelci-core PR 3112.