### PR TITLE
config: scheduler: pengutronix: move v5 out of v7

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -169,6 +169,7 @@ jobs:
   baseline-arm-kontron: *baseline-job
   baseline-arm-mfd: *baseline-job
   baseline-arm-pengutronix: *baseline-job
+  baseline-arm-v5-pengutronix: *baseline-job
   baseline-arm64: *baseline-job
   baseline-arm64-android: *baseline-job
   baseline-arm64-baylibre: *baseline-job

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -119,9 +119,6 @@ scheduler:
       type: lava
       name: lava-pengutronix
     platforms:
-      - imx23-olinuxino
-      - imx27-phytec-phycard-s-rdk
-      - imx28-duckbill
       - imx53-qsrb
       - imx6dl-riotboard
       - imx6qp-wandboard-revd1
@@ -135,6 +132,12 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms: &lava-broonie-armv5
       - at91sam9g20ek
+
+  - job: baseline-arm-v5-pengutronix
+    event: *kbuild-gcc-14-armv5-node-event
+    runtime: *lava-pengutronix-runtime
+    platforms:
+      - imx27-phytec-phycard-s-rdk
 
   - job: baseline-arm64
     event: &kbuild-gcc-14-arm64-node-event


### PR DESCRIPTION
The phytec-phycard-s-rdk is only build by the multi_v5_defconfig and not the multi_v7_defconfig. Move it out of the v7 block and create a new v5 block to test after a config has been build.

Remove the imx23 and imx28 boards, as they are build by neither.