### PR TITLE
scheduler-pull-labs: add first pull lab for pengutronix

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -25,6 +25,7 @@ _anchors:
 
 jobs:
   baseline-arm-pull-labs-demo: *baseline-job-pull-labs
+  baseline-arm-pull-pengutronix: *baseline-job-pull-labs
   baseline-arm64-pull-labs-demo: *baseline-job-pull-labs
   baseline-x86-pull-labs-demo: *baseline-job-pull-labs
 

--- a/config/pipeline-pull-labs.yaml
+++ b/config/pipeline-pull-labs.yaml
@@ -19,3 +19,11 @@ runtimes:
     notify:
       callback:
         token: kernelci-pull-labs-aws-ec2
+
+  pull-pengutronix:
+    lab_type: pull_labs
+    poll_interval: 60
+    timeout: 7200
+    notify:
+      callback:
+        token: kernelci-pull-lab

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -35,6 +35,14 @@ scheduler:
       - fvp-aemva
       - qemu-arm64
 
+  - job: baseline-arm-pull-pengutronix
+    event: *kbuild-gcc-14-arm-node-event
+    runtime: &pull-pengutronix-runtime
+      type: pull_labs
+      name: pull-pengutronix
+    platforms:
+      - imx6dl-riotboard
+
   - job: ltp-smoke-pull-labs
     event: *kbuild-gcc-14-arm64-node-event
     runtime:


### PR DESCRIPTION
This is more of a test, that everything in the pipeline works. More boards will follow, as soon as it is validated.