### PR TITLE
config: disable coverage report scheduling

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -390,29 +390,38 @@ scheduler:
     platforms:
       - supermicro-as-2015hr-tnr
 
-  - job: coverage-report-arm
-    <<: *build-k8s-all
-    event: *node-event-kbuild-done
+  # Disabled 2026-06-13T13:53:39+03:00: coverage reports OOM ordinary builders.
+  # See https://github.com/kernelci/kernelci-pipeline/issues/1360.
+  # Re-enable only with isolated resources; remove feature if not fixed in 3-6 months.
+  # coverage-report-arm after kbuild disabled due to ordinary-builder OOM.
+  # - job: coverage-report-arm
+  #   <<: *build-k8s-all
+  #   event: *node-event-kbuild-done
 
-  - job: coverage-report-arm
-    <<: *build-k8s-all
-    event: *job-event
+  # coverage-report-arm after tests disabled due to ordinary-builder OOM.
+  # - job: coverage-report-arm
+  #   <<: *build-k8s-all
+  #   event: *job-event
 
-  - job: coverage-report-arm64
-    <<: *build-k8s-all
-    event: *node-event-kbuild-done
+  # coverage-report-arm64 after kbuild disabled due to ordinary-builder OOM.
+  # - job: coverage-report-arm64
+  #   <<: *build-k8s-all
+  #   event: *node-event-kbuild-done
 
-  - job: coverage-report-arm64
-    <<: *build-k8s-all
-    event: *job-event
+  # coverage-report-arm64 after tests disabled due to ordinary-builder OOM.
+  # - job: coverage-report-arm64
+  #   <<: *build-k8s-all
+  #   event: *job-event
 
-  - job: coverage-report-x86
-    <<: *build-k8s-all
-    event: *node-event-kbuild-done
+  # coverage-report-x86 after kbuild disabled due to ordinary-builder OOM.
+  # - job: coverage-report-x86
+  #   <<: *build-k8s-all
+  #   event: *node-event-kbuild-done
 
-  - job: coverage-report-x86
-    <<: *build-k8s-all
-    event: *job-event
+  # coverage-report-x86 after tests disabled due to ordinary-builder OOM.
+  # - job: coverage-report-x86
+  #   <<: *build-k8s-all
+  #   event: *job-event
 
   - job: kbuild-clang-21-arm
     <<: *build-k8s-all


### PR DESCRIPTION
Coverage report jobs are OOM-killing ordinary k8s builders and blocking normal compile capacity. Keep the scheduler entries commented for now so the feature can be re-enabled only after isolated resources or throttling are available.

Leave a dated note that the feature should be removed if dedicated resources are not found within 3-6 months.

Fixes: 668165d ("config: create and enable coverage data post-processing job")

Fixes: 5496fa9 ("config: also trigger coverage-report for test jobs")

Closes: https://github.com/kernelci/kernelci-pipeline/issues/1360