### PR TITLE
config: disable rb3gen2 jobs in foundriesio LAB

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -295,7 +295,6 @@ scheduler:
       name: lava-foundriesio
     platforms:
       - bcm2711-rpi-4-b
-      - qcs6490-rb3gen2
 
   - job: baseline-arm64-qualcomm
     event: *kbuild-gcc-14-arm64-node-event


### PR DESCRIPTION
Foundries.io LAB is going through reorganization. For this reason qcs6490-rb3gen2 device type will become unavailable for kernelci job. The device type will be aligned with upstream LAVA and move to be based on base-qdl.jinja2 device type. After the migration kernelci jobs need to change to run properly on this board.