### PR TITLE
config: add gcc-15 kbuild jobs for x86 and arm64

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -668,6 +668,16 @@ jobs:
       cross_compile: 'arm-linux-gnueabihf-'
       defconfig: multi_v7_defconfig
 
+  kbuild-gcc-15-arm: &kbuild-gcc-15-arm-job
+    <<: *kbuild-job
+    image: ghcr.io/kernelci/{image_prefix}gcc-15:arm-kselftest-kernelci
+    params: &kbuild-gcc-15-arm-params
+      backend: tuxmake
+      arch: arm
+      compiler: gcc-15
+      cross_compile: 'arm-linux-gnueabihf-'
+      defconfig: multi_v7_defconfig
+
   kbuild-gcc-14-arm-allnoconfig: &kbuild-gcc-14-arm-allnoconfig-job
     <<: *kbuild-gcc-14-arm-job
     params:
@@ -919,6 +929,19 @@ jobs:
   kbuild-gcc-14-arm64: *kbuild-gcc-14-arm64-job
 
   kbuild-gcc-15-arm64: *kbuild-gcc-15-arm64-job
+
+  kbuild-gcc-15-arm64-nfsboot: &kbuild-gcc-15-arm64-nfsboot-job
+    <<: *kbuild-job
+    image: ghcr.io/kernelci/{image_prefix}gcc-15:arm64-kselftest-kernelci
+    params:
+      arch: arm64
+      compiler: gcc-15
+      cross_compile: 'aarch64-linux-gnu-'
+      defconfig: defconfig
+      fragments:
+        - 'netdev'
+        - 'nfs-root-boot'
+        - 'kselftest'
 
   kbuild-gcc-14-arm64-nfsboot: *kbuild-gcc-14-arm64-nfsboot-job
 
@@ -1741,6 +1764,43 @@ jobs:
     <<: *kbuild-gcc-14-arm64-job
     params:
       <<: *kbuild-gcc-14-arm64-params
+      fragments:
+        - 'aws-ec2'
+      extra_targets:
+        - 'binrpm-pkg'
+    rules:
+      min_version:
+        version: 6
+        patchlevel: 6
+      tree:
+      - 'mainline'
+      - 'stable'
+      - 'stable-rc'
+      - 'next'
+      - 'kernelci'
+
+  kbuild-gcc-15-x86-aws-ec2:
+    <<: *kbuild-gcc-15-x86-job
+    params:
+      <<: *kbuild-gcc-15-x86-params
+      fragments:
+        - 'aws-ec2'
+      extra_targets:
+        - 'binrpm-pkg'
+    rules:
+      min_version:
+        version: 6
+        patchlevel: 6
+      tree:
+      - 'mainline'
+      - 'stable'
+      - 'stable-rc'
+      - 'next'
+
+  kbuild-gcc-15-arm64-aws-ec2:
+    <<: *kbuild-gcc-15-arm64-job
+    params:
+      <<: *kbuild-gcc-15-arm64-params
       fragments:
         - 'aws-ec2'
       extra_targets:

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -91,6 +91,31 @@ _anchors:
       fragments:
         - 'kselftest'
 
+  # gcc-15 (forky-based image) rollout, limited to x86 and arm64 for now
+  kbuild-gcc-15-arm64-job: &kbuild-gcc-15-arm64-job
+    <<: *kbuild-job
+    image: ghcr.io/kernelci/{image_prefix}gcc-15:arm64-kselftest-kernelci
+    params: &kbuild-gcc-15-arm64-params
+      backend: tuxmake
+      arch: arm64
+      compiler: gcc-15
+      cross_compile: 'aarch64-linux-gnu-'
+      defconfig: defconfig
+      fragments:
+        - 'lab-setup'
+        - 'kselftest'
+
+  kbuild-gcc-15-x86-job: &kbuild-gcc-15-x86-job
+    <<: *kbuild-job
+    image: ghcr.io/kernelci/{image_prefix}gcc-15:x86-kselftest-kernelci
+    params: &kbuild-gcc-15-x86-params
+      backend: tuxmake
+      arch: x86_64
+      compiler: gcc-15
+      defconfig: x86_64_defconfig
+      fragments:
+        - 'kselftest'
+
   kvm-unit-tests-job: &kvm-unit-tests-job
     template: kvm-unit-tests.jinja2
     kind: job
@@ -893,6 +918,8 @@ jobs:
 
   kbuild-gcc-14-arm64: *kbuild-gcc-14-arm64-job
 
+  kbuild-gcc-15-arm64: *kbuild-gcc-15-arm64-job
+
   kbuild-gcc-14-arm64-nfsboot: *kbuild-gcc-14-arm64-nfsboot-job
 
   kbuild-gcc-14-arm64-chromebook-main:
@@ -1507,6 +1534,20 @@ jobs:
     <<: *kbuild-gcc-14-x86-job
     params:
       <<: *kbuild-gcc-14-x86-params
+      fragments:
+        - 'lab-setup'
+        - 'x86-board'
+        - 'kselftest'
+    rules:
+      tree:
+      - '!chromiumos'
+      - '!cip'
+      - '!omap'
+
+  kbuild-gcc-15-x86:
+    <<: *kbuild-gcc-15-x86-job
+    params:
+      <<: *kbuild-gcc-15-x86-params
       fragments:
         - 'lab-setup'
         - 'x86-board'

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -11,9 +11,9 @@ _anchors:
 scheduler:
 
   - job: baseline-arm-pull-labs-demo
-    event: &kbuild-gcc-14-arm-node-event
+    event: &kbuild-gcc-15-arm-node-event
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm
+      name: kbuild-gcc-15-arm
     runtime: &pull-labs-demo-runtime
       type: pull_labs
       name: pull-labs-demo
@@ -22,9 +22,9 @@ scheduler:
       - imx6dl-udoo
 
   - job: baseline-arm64-pull-labs-demo
-    event: &kbuild-gcc-14-arm64-node-event
+    event: &kbuild-gcc-15-arm64-node-event
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm64
+      name: kbuild-gcc-15-arm64
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -36,7 +36,7 @@ scheduler:
       - qemu-arm64
 
   - job: baseline-arm-pull-pengutronix
-    event: *kbuild-gcc-14-arm-node-event
+    event: *kbuild-gcc-15-arm-node-event
     runtime: &pull-pengutronix-runtime
       type: pull_labs
       name: pull-pengutronix
@@ -44,7 +44,7 @@ scheduler:
       - imx6dl-riotboard
 
   - job: ltp-smoke-pull-labs
-    event: *kbuild-gcc-14-arm64-node-event
+    event: *kbuild-gcc-15-arm64-node-event
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -55,7 +55,7 @@ scheduler:
   - job: ltp-smoke-pull-labs
     event:
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm64-nfsboot
+      name: kbuild-gcc-15-arm64-nfsboot
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -64,7 +64,7 @@ scheduler:
       - qemu-arm64
 
   - job: kselftest-arm64-pull-labs
-    event: *kbuild-gcc-14-arm64-node-event
+    event: *kbuild-gcc-15-arm64-node-event
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -74,7 +74,7 @@ scheduler:
   - job: kselftest-arm64-pull-labs
     event:
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm64-nfsboot
+      name: kbuild-gcc-15-arm64-nfsboot
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -83,7 +83,7 @@ scheduler:
       - cd8180-orion-o6
 
   - job: kselftest-breakpoints-pull-labs
-    event: *kbuild-gcc-14-arm64-node-event
+    event: *kbuild-gcc-15-arm64-node-event
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -91,9 +91,9 @@ scheduler:
       - exynos850-e850-96
 
   - job: baseline-x86-pull-labs-demo
-    event: &kbuild-gcc-14-x86-node-event
+    event: &kbuild-gcc-15-x86-node-event
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-x86
+      name: kbuild-gcc-15-x86
     runtime:
       type: pull_labs
       name: pull-labs-demo
@@ -103,7 +103,7 @@ scheduler:
   - job: baseline-x86-aws-ec2
     event:
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-x86-aws-ec2
+      name: kbuild-gcc-15-x86-aws-ec2
     runtime: &pull-labs-aws-ec2-runtime
       type: pull_labs
       name: pull-labs-aws-ec2
@@ -113,7 +113,7 @@ scheduler:
   - job: baseline-arm64-aws-ec2
     event:
       <<: *node-event-kbuild
-      name: kbuild-gcc-14-arm64-aws-ec2
+      name: kbuild-gcc-15-arm64-aws-ec2
     runtime: *pull-labs-aws-ec2-runtime
     platforms:
       - aws-ec2-arm64

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -620,6 +620,9 @@ scheduler:
   - job: kbuild-gcc-14-arm64
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-15-arm64
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-arm64-aws-ec2
     <<: *build-k8s-all
 
@@ -821,6 +824,9 @@ scheduler:
         - '!efi'
 
   - job: kbuild-gcc-14-x86
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-15-x86
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-x86-aws-ec2

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -539,6 +539,9 @@ scheduler:
   - job: kbuild-gcc-14-arm
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-15-arm
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-arm-allnoconfig
     <<: *build-k8s-all
 
@@ -626,7 +629,13 @@ scheduler:
   - job: kbuild-gcc-14-arm64-aws-ec2
     <<: *build-k8s-all
 
+  - job: kbuild-gcc-15-arm64-aws-ec2
+    <<: *build-k8s-all
+
   - job: kbuild-gcc-14-arm64-nfsboot
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-15-arm64-nfsboot
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-arm64-allnoconfig
@@ -830,6 +839,9 @@ scheduler:
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-x86-aws-ec2
+    <<: *build-k8s-all
+
+  - job: kbuild-gcc-15-x86-aws-ec2
     <<: *build-k8s-all
 
   - job: kbuild-gcc-14-x86-allnoconfig


### PR DESCRIPTION
Add kbuild-gcc-15-x86 and kbuild-gcc-15-arm64 alongside the gcc-14 jobs, using the new gcc-15 toolchain images, and schedule them on the k8s-all builders.