### PR TITLE
config: add ltp-smoke-aws-ec2 pull-labs job

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -64,3 +64,11 @@ jobs:
     kind: job
     priority: medium
     kcidb_test_suite: boot
+
+  ltp-smoke-aws-ec2:
+    template: ltp-pull-labs.jinja2
+    kind: job
+    params:
+      <<: *ltp-params-pull-labs
+      tst_cmdfiles: "smoketest"
+    kcidb_test_suite: ltp

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -101,7 +101,7 @@ scheduler:
       - qemu-x86_64
 
   - job: baseline-x86-aws-ec2
-    event:
+    event: &kbuild-gcc-14-x86-aws-ec2-node-event
       <<: *node-event-kbuild
       name: kbuild-gcc-14-x86-aws-ec2
     runtime: &pull-labs-aws-ec2-runtime
@@ -111,9 +111,21 @@ scheduler:
       - aws-ec2-x86_64
 
   - job: baseline-arm64-aws-ec2
-    event:
+    event: &kbuild-gcc-14-arm64-aws-ec2-node-event
       <<: *node-event-kbuild
       name: kbuild-gcc-14-arm64-aws-ec2
+    runtime: *pull-labs-aws-ec2-runtime
+    platforms:
+      - aws-ec2-arm64
+
+  - job: ltp-smoke-aws-ec2
+    event: *kbuild-gcc-14-x86-aws-ec2-node-event
+    runtime: *pull-labs-aws-ec2-runtime
+    platforms:
+      - aws-ec2-x86_64
+
+  - job: ltp-smoke-aws-ec2
+    event: *kbuild-gcc-14-arm64-aws-ec2-node-event
     runtime: *pull-labs-aws-ec2-runtime
     platforms:
       - aws-ec2-arm64


### PR DESCRIPTION
Run the LTP smoketest on the pull-labs-aws-ec2 runtime, on aws-ec2-x86_64 and aws-ec2-arm64, triggered by the aws-ec2 kbuild events.