### PR TITLE
platforms: use appended DTB for dragonboard fastboot

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -106,6 +106,10 @@ platforms:
     mach: qcom
     dtb: dtbs/qcom/apq8016-sbc.dtb
     compatible: ['qcom,apq8016-sbc', 'qcom,apq8016']
+    params:
+      fastboot_boot_image_format: appended-dtb
+      fastboot_mkbootimg_pagesize: 2048
+      fastboot_mkbootimg_base: "0x80000000"
 
   dragonboard-820c:
     <<: *arm64-device
@@ -113,6 +117,10 @@ platforms:
     mach: qcom
     dtb: dtbs/qcom/apq8096-db820c.dtb
     compatible: ['qcom,apq8096-db820c', 'qcom,apq8096']
+    params:
+      fastboot_boot_image_format: appended-dtb
+      fastboot_mkbootimg_pagesize: 4096
+      fastboot_mkbootimg_base: "0x80000000"
 
   eic7700-hifive-premier-p550:
     <<: *riscv-device


### PR DESCRIPTION
dragonboard-410c and dragonboard-820c use the LK bootloader which requires the DTB appended to the kernel image, same as sm8350-hdk. Their LAVA jobs currently fail with:

  ERROR: Bad magic in device tree table
  DTB offset is incorrect, kernel image does not have appended DTB