### PR TITLE
config: runtime: ltp-pull-labs: carry the kirk path to tuxrun

### DIFF
--- a/config/runtime/ltp-pull-labs.jinja2
+++ b/config/runtime/ltp-pull-labs.jinja2
@@ -19,6 +19,8 @@
 {%- endif %}
 {%- set ltp_parameters = ltp_params_list | join(' ') %}
 
+{%- do tuxrun_parameters.update({'RUNNER': '/opt/kirk/kirk'}) %}
+
 {#- Calculate timeout in seconds (default 60 minutes) #}
 {%- set test_timeout = (job_timeout | default(60)) * 60 %}
 


### PR DESCRIPTION
The base pull_labs template renders tuxrun_parameters into the job definition's top-level parameters.