### PR TITLE
Qcom kernelci lab update boot method , add new platform and kselftests pipeline

### DIFF
--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -182,6 +182,7 @@ jobs:
   baseline-arm64-pengutronix: *baseline-job
   baseline-arm64-foundriesio: *baseline-job
   baseline-arm64-qualcomm: *baseline-job
+  baseline-arm64-preempt_rt-qualcomm: *baseline-job
   baseline-riscv-broonie: *baseline-job
   baseline-riscv-clabbe: *baseline-job
   baseline-riscv-collabora: *baseline-job
@@ -1908,12 +1909,26 @@ jobs:
         - collabora-next:for-kernelci
     kcidb_test_suite: kselftest.devices-exist
 
+  kselftest-devices-exist-ramdisk:
+    <<: *kselftest-job-ramdisk
+    params:
+      <<: *kselftest-params-ramdisk
+      collections: devices-exist
+    kcidb_test_suite: kselftest.devices-exist
+
   kselftest-device-error-logs-main:
     <<: *kselftest-job
     params:
       <<: *kselftest-params
       collections: devices/error_logs
     kcidb_test_suite: kselftest.device_error_logs
+
+  kselftest-device-error-logs-ramdisk:
+    <<: *kselftest-job-ramdisk
+    params:
+      <<: *kselftest-params-ramdisk
+      collections: device-error-logs
+    kcidb_test_suite: kselftest.device-error-logs
 
   kselftest-devices-probe:
     <<: *kselftest-job
@@ -1926,6 +1941,13 @@ jobs:
       min_version:
         version: 6
         patchlevel: 11
+    kcidb_test_suite: kselftest.devices-probe
+
+  kselftest-devices-probe-ramdisk:
+    <<: *kselftest-job-ramdisk
+    params:
+      <<: *kselftest-params-ramdisk
+      collections: devices-probe
     kcidb_test_suite: kselftest.devices-probe
 
   kselftest-dmabuf-heaps:

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -390,14 +390,18 @@ platforms:
     compatible: ['mediatek,mt8395-evk', 'mediatek,mt8395', 'mediatek,mt8195']
 
   # Qualcomm Platform list
+  # flash_image hosted on Qualcomm's kernelci-lab is generated from https://github.com/qualcomm-linux/meta-qcom
   qcs615-ride:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/qcs615-ride/qcs615-ride.qcomflash.kernelci.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/qcs615-ride.dtb
     compatible: ['qcom,qcs615-ride', 'qcom,qcs615', 'qcom,sm6150']
 
-  # flash_image hosted on Qualcomm's kernelci-lab is generated from https://github.com/qualcomm-linux/meta-qcom
   qcs6490-rb3gen2:
     <<: *arm64-device
     boot_method: efi
@@ -411,21 +415,33 @@ platforms:
 
   qcs8300-ride:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/qcs8300-ride-sx/qcom-multimedia-image-qcs8300-ride-sx.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/qcs8300-ride.dtb
     compatible: ['qcom,qcs8300-ride', 'qcom,qcs8300']
 
   qcs9100-ride:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/qcs9100-ride/qcom-multimedia-image-qcs9100-ride-sx.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/qcs9100-ride.dtb
     compatible: ['qcom,qcs9100-ride', 'qcom,qcs9100']
 
   sm8750-mtp:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/sm8750-mtp/qcom-multimedia-image-sm8750-mtp.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/sm8750-mtp.dtb
     compatible: ['qcom,sm8750-mtp', 'qcom,sm8750']
@@ -439,7 +455,11 @@ platforms:
 
   kaanapali-mtp:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/kaanapali-mtp/qcom-multimedia-image-kaanapali-mtp.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/kaanapali-mtp.dtb
     compatible: ['qcom,kaanapali-mtp', 'qcom,kaanapali']
@@ -451,21 +471,33 @@ platforms:
 
   lemans-evk:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/iq-9075-evk/qcom-multimedia-image-iq-9075-evk.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/lemans-evk.dtb
     compatible: ['qcom,lemans-evk', 'qcom,qcs9100', 'qcom,sa8775p']
 
   monaco-evk:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/iq-8275-evk/21656922932-1/qcom-multimedia-proprietary-image-iq-8275-evk.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/monaco-evk.dtb
     compatible: ['qcom,monaco-evk', 'qcom,qcs8300']
 
   glymur-crd:
     <<: *arm64-device
-    boot_method: fastboot
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/glymur-crd/qcom-multimedia-image-glymur-crd.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
     mach: qcom
     dtb: dtbs/qcom/glymur-crd.dtb
     compatible: ['qcom,glymur-crd', 'qcom,glymur']

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -502,6 +502,28 @@ platforms:
     dtb: dtbs/qcom/glymur-crd.dtb
     compatible: ['qcom,glymur-crd', 'qcom,glymur']
 
+  hamoa-evk:
+    <<: *arm64-device
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/hamoa-evk/qcom-multimedia-image-iq-x7181-evk.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
+    mach: qcom
+    dtb: dtbs/qcom/hamoa-iot-evk.dtb
+    compatible: ['qcom,hamoa-iot-evk', 'qcom,x1e80100']
+
+  purwa-evk:
+    <<: *arm64-device
+    boot_method: efi
+    flash_image: "https://storage-lava-hyd.qualcomm.com/purwa-evk/qcom-multimedia-image-iq-x5121-evk.rootfs.qcomflash.tar.gz"
+    params:
+      flash_image_headers:
+        Authorization: LAVA_BASIC_AUTH
+    mach: qcom
+    dtb: dtbs/qcom/purwa-iot-evk.dtb
+    compatible: ['qcom,purwa-iot-evk', 'qcom,x1e001x0']
+
   qemu-x86_64: &qemu-device
     base_name: qemu
     arch: x86_64

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -316,6 +316,28 @@ scheduler:
       - purwa-evk
       - x1e80100
 
+  - job: baseline-arm64-preempt_rt-qualcomm
+    event:
+      <<: *node-event-kbuild
+      name: kbuild-gcc-14-arm64-preempt_rt
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-qrd
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
+      - kaanapali-mtp
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - x1e80100
+
   - job: baseline-riscv-broonie
     event: &kbuild-gcc-14-riscv-node-event
       <<: *node-event-kbuild
@@ -1080,6 +1102,26 @@ scheduler:
     platforms:
       - mt8390-genio-700-evk
       - mt8395-genio-1200-evk
+
+  - job: kselftest-device-error-logs-ramdisk
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-mtp
+      - kaanapali-qrd
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
+      - x1e80100
 
   - job: kselftest-dt
     event: *kbuild-gcc-14-arm-node-event
@@ -1851,6 +1893,86 @@ scheduler:
       - glymur-crd
       - hamoa-evk
       - purwa-evk
+      - x1e80100
+
+  - job: kselftest-devices-exist-ramdisk
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-mtp
+      - kaanapali-qrd
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
+      - x1e80100
+
+  - job: kselftest-devices-probe-ramdisk
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-mtp
+      - kaanapali-qrd
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
+      - x1e80100
+
+  - job: kselftest-dmabuf-heaps-ramdisk
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-mtp
+      - kaanapali-qrd
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
+      - x1e80100
+
+  - job: kselftest-exec-ramdisk
+    event: *kbuild-gcc-14-arm64-node-event
+    runtime:
+      type: lava
+      name: lava-kci-qualcomm
+    platforms:
+      - glymur-crd
+      - hamoa-evk
+      - kaanapali-mtp
+      - kaanapali-qrd
+      - lemans-evk
+      - monaco-evk
+      - purwa-evk
+      - qcs615-ride
+      - qcs6490-rb3gen2
+      - qcs8300-ride
+      - qcs9100-ride
+      - sm8750-mtp
       - x1e80100
 
   - job: kselftest-cpufreq-suspend

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -312,6 +312,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: baseline-riscv-broonie
@@ -927,6 +929,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-breakpoints
@@ -960,6 +964,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-capabilities
@@ -990,6 +996,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-clone3
@@ -1020,6 +1028,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-coredump
@@ -1050,6 +1060,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-device-error-logs-main
@@ -1108,6 +1120,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-efivars
@@ -1136,6 +1150,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-fchmodat2
@@ -1189,6 +1205,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-futex
@@ -1220,6 +1238,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-gpio
@@ -1256,6 +1276,8 @@ scheduler:
       - qcs6490-rb3gen2
       - qcs8300-ride
       - qcs9100-ride
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-ipc
@@ -1466,6 +1488,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-proc
@@ -1502,6 +1526,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
 
   - job: kselftest-ring-buffer
     event:
@@ -1537,6 +1563,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-rlimits
@@ -1649,6 +1677,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-tmpfs
@@ -1679,6 +1709,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-seccomp
@@ -1817,6 +1849,8 @@ scheduler:
       - lemans-evk
       - monaco-evk
       - glymur-crd
+      - hamoa-evk
+      - purwa-evk
       - x1e80100
 
   - job: kselftest-cpufreq-suspend


### PR DESCRIPTION
migrate eight boards from fastboot to EFI
add hamoa-evk (x1e80100) and purwa-evk (x1e001x0) EFI platforms
Enable new test pipelines