### PR TITLE
monitor: Adapt to kernelci-core events as plain dicts

### DIFF
--- a/src/monitor.py
+++ b/src/monitor.py
@@ -82,7 +82,7 @@ class Monitor(Service):
                     return False
                 continue
             subscribe_retries = 0
-            obj = event.data
+            obj = event["data"]
             dt = datetime.datetime.fromisoformat(event["time"])
             try:
                 commit = obj["data"]["kernel_revision"]["commit"][:12]

--- a/tools/example_api_pubsub.py
+++ b/tools/example_api_pubsub.py
@@ -3,7 +3,7 @@
 This is simplified example how to subscribe to kernelci.org pubsub
 It uses long polling to get events from the server
 It is not recommended to use this in production, as it is not efficient,
-and in production it is preferable to use cloudevents library
+and in production it is preferable to use the kernelci API bindings
 """
 
 import argparse
@@ -66,8 +66,7 @@ def main():
     print("Subscribing to node")
     response = subscribe_node(token)
     print(f"Subscribed with id {response['id']}")
-    # Here i skip cloudevents and parse "manually"
-    # which is not recommended
+    # Parse the CloudEvents JSON envelope manually
     while True:
         r = pollsub(response["id"], token)
         # print(json.dumps(r, indent=2))


### PR DESCRIPTION
kernelci-core receive_event() now returns the parsed CloudEvents JSON envelope as a plain dict instead of a CloudEvent instance, as part of removing the cloudevents dependency. Access the event payload with event["data"]; the event["time"] access is unchanged.

Also refresh stale comments in the pub/sub example that recommended the cloudevents library.