### PR TITLE
config: add gs101-oriole platform for pull labs ltp-smoke

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -141,6 +141,17 @@ platforms:
         - mainline
         - next
 
+  gs101-oriole:
+    <<: *arm64-device
+    mach: samsung
+    boot_method: fastboot
+    dtb: dtbs/exynos/google/gs101-oriole.dtb
+    compatible: ['google,gs101-oriole', 'google,gs101']
+    rules:
+      tree:
+        - mainline
+        - next
+
   imx23-olinuxino:
     <<: *arm-device
     boot_method: barebox

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -51,6 +51,7 @@ scheduler:
     platforms:
       - bcm2711-rpi-4-b
       - exynos850-e850-96
+      - gs101-oriole
 
   - job: ltp-smoke-pull-labs
     event:


### PR DESCRIPTION
Add the Google Pixel 6 (gs101-oriole) as an arm64 fastboot platform and add it to the ltp-smoke-pull-labs job on the pull-labs-demo runtime.