### PR TITLE
config: refine kcidebug builds

### DIFF
--- a/config/fragments.yaml
+++ b/config/fragments.yaml
@@ -342,62 +342,47 @@ fragments:
   kcidebug:
     path: "kernel/configs/kcidebug.config"
     configs:
-      - 'CONFIG_CONSTRUCTORS=y'
-      - 'CONFIG_GENERIC_CSUM=y'
-      - 'CONFIG_KASAN_SHADOW_OFFSET=0xdffffc0000000000'
-      - 'CONFIG_STACKDEPOT_ALWAYS_INIT=y'
-      - 'CONFIG_REF_TRACKER=y'
+      - 'CONFIG_DEBUG_KERNEL=y'
       - 'CONFIG_DEBUG_SECTION_MISMATCH=y'
       - 'CONFIG_UBSAN=y'
-      - 'CONFIG_CC_HAS_UBSAN_BOUNDS_STRICT=y'
       - 'CONFIG_UBSAN_BOUNDS=y'
-      - 'CONFIG_UBSAN_BOUNDS_STRICT=y'
       - 'CONFIG_UBSAN_SHIFT=y'
       - 'CONFIG_UBSAN_BOOL=y'
       - 'CONFIG_UBSAN_ENUM=y'
+      # Needed on older kernels to apply UBSAN instrumentation globally.
       - 'CONFIG_UBSAN_SANITIZE_ALL=y'
       - 'CONFIG_NET_DEV_REFCNT_TRACKER=y'
       - 'CONFIG_NET_NS_REFCNT_TRACKER=y'
-      - 'CONFIG_PAGE_POISONING=y'
-      - 'CONFIG_DEBUG_KMEMLEAK=y'
-      - 'CONFIG_DEBUG_KMEMLEAK_MEM_POOL_SIZE=16000'
-      - 'CONFIG_DEBUG_KMEMLEAK_AUTO_SCAN=y'
       - 'CONFIG_SCHED_STACK_END_CHECK=y'
-      - 'CONFIG_KASAN=y'
-      - 'CONFIG_KASAN_GENERIC=y'
-      - 'CONFIG_KASAN_INLINE=y'
-      - 'CONFIG_KASAN_STACK=y'
-      - 'CONFIG_KASAN_VMALLOC=y'
-      - 'CONFIG_KFENCE=y'
-      - 'CONFIG_KFENCE_SAMPLE_INTERVAL=100'
-      - 'CONFIG_KFENCE_NUM_OBJECTS=255'
-      - 'CONFIG_KFENCE_STRESS_TEST_FAULTS=0'
-      - 'CONFIG_LOCKUP_DETECTOR=y'
       - 'CONFIG_SOFTLOCKUP_DETECTOR=y'
       - 'CONFIG_HARDLOCKUP_DETECTOR=y'
-      - 'CONFIG_HARDLOCKUP_DETECTOR_PERF=y'
-      - 'CONFIG_HARDLOCKUP_DETECTOR_COUNTS_HRTIMER=y'
       - 'CONFIG_DETECT_HUNG_TASK=y'
       - 'CONFIG_DEFAULT_HUNG_TASK_TIMEOUT=120'
       - 'CONFIG_WQ_WATCHDOG=y'
       - 'CONFIG_PROVE_LOCKING=y'
-      - 'CONFIG_DEBUG_RT_MUTEXES=y'
-      - 'CONFIG_DEBUG_SPINLOCK=y'
-      - 'CONFIG_DEBUG_MUTEXES=y'
-      - 'CONFIG_DEBUG_WW_MUTEX_SLOWPATH=y'
-      - 'CONFIG_DEBUG_RWSEMS=y'
-      - 'CONFIG_DEBUG_LOCK_ALLOC=y'
-      - 'CONFIG_LOCKDEP=y'
-      - 'CONFIG_LOCKDEP_BITS=15'
-      - 'CONFIG_LOCKDEP_CHAINS_BITS=16'
-      - 'CONFIG_LOCKDEP_STACK_TRACE_BITS=19'
-      - 'CONFIG_LOCKDEP_STACK_TRACE_HASH_BITS=14'
-      - 'CONFIG_LOCKDEP_CIRCULAR_QUEUE_BITS=12'
       - 'CONFIG_DEBUG_ATOMIC_SLEEP=y'
-      - 'CONFIG_TRACE_IRQFLAGS=y'
-      - 'CONFIG_TRACE_IRQFLAGS_NMI=y'
-      - 'CONFIG_PROVE_RCU=y'
-      - 'CONFIG_PREEMPTIRQ_TRACEPOINTS=y'
+
+  kcidebug-arm64:
+    path: "kernel/configs/kcidebug-arm64.config"
+    configs:
+      # SW_TAGS has substantially lower memory and runtime overhead than
+      # generic KASAN and is suitable for running real arm64 workloads.
+      - 'CONFIG_KASAN=y'
+      - 'CONFIG_KASAN_SW_TAGS=y'
+      - 'CONFIG_KASAN_INLINE=y'
+      - 'CONFIG_KASAN_STACK=y'
+      - 'CONFIG_KASAN_VMALLOC=y'
+
+  kcidebug-x86_64:
+    path: "kernel/configs/kcidebug-x86_64.config"
+    configs:
+      - 'CONFIG_KASAN=y'
+      - 'CONFIG_KASAN_GENERIC=y'
+      # Inline instrumentation makes the image larger, but is considerably
+      # faster than outline instrumentation for CI workloads.
+      - 'CONFIG_KASAN_INLINE=y'
+      - 'CONFIG_KASAN_STACK=y'
+      - 'CONFIG_KASAN_VMALLOC=y'
 
   kselftest:
     path: "kernel/configs/kselftest.config"

--- a/config/jobs.yaml
+++ b/config/jobs.yaml
@@ -1072,9 +1072,10 @@ jobs:
         - 'kselftest'
     rules:
       tree:
-      - '!chromiumos'
-      - '!cip'
-      - '!omap'
+      - 'kernelci'
+      - 'mainline'
+      - 'next'
+      - 'stable'
 
   # Default config and build only job
   kbuild-gcc-14-arm64-build-only:
@@ -1101,6 +1102,7 @@ jobs:
       fragments:
         - arm64-chromebook
         - kcidebug
+        - kcidebug-arm64
         - lab-setup
     rules:
       tree:
@@ -1637,18 +1639,19 @@ jobs:
     rules: *build-only-trees-rules
 
   kbuild-gcc-14-x86-kcidebug:
-    <<: *kbuild-gcc-14-i386-job
+    <<: *kbuild-gcc-14-x86-job
     params:
-      <<: *kbuild-gcc-14-i386-params
-      defconfig: defconfig
+      <<: *kbuild-gcc-14-x86-params
       fragments:
         - kcidebug
+        - kcidebug-x86_64
         - x86-board
     rules:
       tree:
-      - '!android'
-      - '!chromiumos'
-      - '!cip'
+      - 'kernelci'
+      - 'mainline'
+      - 'next'
+      - 'stable'
 
   kbuild-gcc-14-x86-kselftest:
     <<: *kbuild-gcc-14-x86-job


### PR DESCRIPTION
This is an initial step toward providing boot coverage with extended kernel debugging enabled.

Split common diagnostics from architecture-specific KASAN settings, use lower-overhead software tag-based KASAN on arm64, and correct the x86 job to build x86_64. Limit these debug builds to kernelci, stable, mainline, and next trees.