### PR TITLE
config: decommission unreliable Kevin device

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -592,13 +592,6 @@ platforms:
     dtb: dtbs/renesas/r8a779m1-ulcb.dtb
     compatible: ['renesas,h3ulcb', 'renesas,r8a779m1', 'renesas,r8a7795']
 
-  rk3399-gru-kevin:
-    <<: *arm64-device
-    boot_method: depthcharge
-    mach: rockchip
-    dtb: dtbs/rockchip/rk3399-gru-kevin.dtb
-    compatible: ['google,kevin-rev15', 'google,kevin-rev14']
-
   rk3399-khadas-edge-v:
     <<: *arm64-device
     mach: rockchip

--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -160,7 +160,6 @@ scheduler:
       - mt8395-genio-1200-evk
       - qemu-arm64
       - r8a779m1-ulcb
-      - rk3399-gru-kevin
       - rk3399-rock-pi-4b
       - rk3576-rock-4d
       - rk3588-rock-5b
@@ -181,7 +180,6 @@ scheduler:
       - mt8395-genio-1200-evk
       - qemu-arm64
       - r8a779m1-ulcb
-      - rk3399-gru-kevin
       - rk3399-rock-pi-4b
       - rk3576-rock-4d
       - rk3588-rock-5b
@@ -1497,7 +1495,6 @@ scheduler:
 #    runtime: *lava-collabora-runtime
 #    platforms:
 #      - meson-g12b-a311d-khadas-vim3
-#      - rk3399-gru-kevin
 #      - rk3399-rock-pi-4b
 #      - sun50i-h6-pine-h64
 
@@ -2104,12 +2101,6 @@ scheduler:
 
   - job: ltp-fcntl-locktests
     event: *kbuild-gcc-14-arm64-node-event
-    runtime: *lava-collabora-runtime
-    platforms:
-      - rk3399-gru-kevin
-
-  - job: ltp-fcntl-locktests
-    event: *kbuild-gcc-14-arm64-node-event
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2837-rpi-3-b-plus
@@ -2179,12 +2170,6 @@ scheduler:
     runtime: *lava-broonie-runtime
     platforms:
       - bcm2711-rpi-4-b
-
-  - job: ltp-pty
-    event: *kbuild-gcc-14-arm64-node-event
-    runtime: *lava-collabora-runtime
-    platforms:
-      - rk3399-gru-kevin
 
   - job: ltp-sched
     event: *kbuild-gcc-14-arm-node-event
@@ -2252,7 +2237,6 @@ scheduler:
     runtime: *lava-collabora-runtime
     platforms:
       - bcm2711-rpi-4-b
-      - rk3399-gru-kevin
 
   - job: ltp-timers_qemu
     event: *kbuild-gcc-14-x86-node-event
@@ -2578,7 +2562,6 @@ scheduler:
     event: *kbuild-gcc-14-arm64-node-event
     runtime: *lava-collabora-runtime
     platforms:
-      - rk3399-gru-kevin
       - rk3399-rock-pi-4b
 
   # Execute nipa-update on the blktests-ddp-x86 node


### PR DESCRIPTION
The rk3399-gru-kevin device has become increasingly unreliable and frequently crashes in the lab. Remove its platform definition and scheduler entries as the device will be decommissioned.

The affected LTP tests remain covered by other platforms.