### PR TITLE
stable-rt: Add v6.6-next stable-rt tree

### DIFF
--- a/config/trees/stable-rt.yaml
+++ b/config/trees/stable-rt.yaml
@@ -40,6 +40,10 @@ build_configs:
     <<: *stable-rt
     branch: 'v6.6-rt'
 
+  stable-rt_v6.6-rt-next:
+    <<: *stable-rt
+    branch: 'v6.6-rt-next'
+
   stable-rt_v6.12-rt:
     <<: *stable-rt
     branch: 'v6.12-rt'


### PR DESCRIPTION
Clark asked for the -next branch for his v6.6 stable-rt tree to be added
to KernelCI.

Signed-off-by: Mark Brown <broonie@kernel.org>
