### PR TITLE
logspec: don't emit issue comments without a description

### DIFF
--- a/src/kernelci_pipeline/logspec_api.py
+++ b/src/kernelci_pipeline/logspec_api.py
@@ -199,17 +199,21 @@ def new_issue(logspec_error, test_type):
     Returns the issue as a dict.
     """
     error_copy = deepcopy(logspec_error)
-    signature = error_copy["error"].pop("signature")
-    comment = ""
-    if "error_summary" in error_copy["error"]:
-        comment += f" {error_copy['error']['error_summary']}"
-    if "target" in error_copy["error"]:
-        comment += f" in {error_copy['error']['target']}"
-        if "src_file" in error_copy["error"]:
-            comment += f" ({error_copy['error']['src_file']})"
-        elif "script" in error_copy["error"]:
-            comment += f" ({error_copy['error']['script']})"
-    comment += f" [logspec:{test_types[test_type]['parser']},{error_copy['error']['error_type']}]"
+    error = error_copy["error"]
+    signature = error.pop("signature")
+    # logspec may not be able to extract a description, for instance for
+    # a generic kbuild failure with no diagnostic line preceding the make
+    # error. Fall back to a placeholder so the comment isn't left empty.
+    comment = error.get("error_summary", "").strip() or "Error"
+    if "target" in error:
+        comment += f" in {error['target']}"
+        if "src_file" in error:
+            comment += f" ({error['src_file']})"
+        elif "script" in error:
+            comment += f" ({error['script']})"
+    comment += (
+        f" [logspec:{test_types[test_type]['parser']},{error['error_type']}]"
+    )
     issue = {
         "origin": "maestro",
         "id": f"maestro:{signature}",


### PR DESCRIPTION
Generic kbuild failures can have no diagnostic line for logspec to harvest, so `error_summary` is left unset. `get_logspec_errors()` drops falsy fields, and `new_issue()` then unconditionally prepended a space — the resulting issue comment starts with nothing at all:

```
 in arch/x86/include/generated/asm/cpufeaturemasks.h (/tmp/kci/linux/arch/x86/Makefile:269) [logspec:kbuild,kbuild.other]
```

That is what landed in the report at https://lore.kernel.org/all/178711194407.380.4108589457572337694@kernelci.org/ (dashboard: https://d.kernelci.org/i/maestro:e019eff33641f280144d13719cbbf59eb379327c).

kernelci/logspec#29 (merged as 15d893c) fixes the empty `log_excerpt` for these cases, but not the comment — logspec still has no summary to offer here. This is the pipeline-side half.

`new_issue()` now falls back to `"Error"` when there is no summary and builds the comment from a local alias, dropping the leading space:

```
Error in arch/x86/include/generated/asm/cpufeaturemasks.h (/tmp/kci/linux/arch/x86/Makefile:269) [logspec:kbuild,kbuild.other]
Error in /tmp/kci/artifacts/build/kselftest/arm64/signal/fake_sigreturn_bad_magic (Makefile:21) [logspec:kbuild,kbuild.other]
```

`error_summary` is not in `KbuildGenericError._signature_fields`, so issue signatures and ids are unchanged.

Verified against the two logs added by kernelci/logspec#29 (`kbuild_025.log`, `kbuild_026.log`) with that logspec revision installed. ruff check and ruff format both clean.

Assisted-by: Claude