### PR TITLE
config: pull-labs: add a UnixBench benchmark job for aws-ec2

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -243,3 +243,11 @@ jobs:
       <<: *ltp-params-pull-labs
       tst_cmdfiles: "smoketest"
     kcidb_test_suite: ltp
+
+  unixbench-aws-ec2:
+    template: unixbench-pull-labs.jinja2
+    kind: job
+    priority: low
+    kcidb_test_suite: unixbench
+    params:
+      job_timeout: 90

--- a/config/runtime/unixbench-pull-labs.jinja2
+++ b/config/runtime/unixbench-pull-labs.jinja2
@@ -1,0 +1,19 @@
+{# UnixBench benchmark template for pull-labs runtime #}
+{# This template builds test_definitions for the UnixBench kernel A/B benchmark #}
+{%- set base_template = 'base/pull_labs.jinja2' %}
+
+{#- Calculate timeout in seconds (default 90 minutes) #}
+{%- set test_timeout = (job_timeout | default(90)) * 60 %}
+
+{%- set test_definitions = [
+  {
+    'id': 'unixbench',
+    'type': 'unixbench',
+    'depends': [],
+    'timeout_s': test_timeout,
+    'pre_commands': [],
+    'post_commands': []
+  }
+] %}
+
+{%- extends base_template %}

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -263,3 +263,16 @@ scheduler:
     runtime: *pull-labs-aws-ec2-runtime
     platforms:
       - aws-ec2-arm64
+
+# UnixBench A/B benchmark, staged but not scheduled yet.
+#
+# The job and template are complete, but the pull-labs runner cannot honour an
+# A/B benchmark yet: a job definition carries a single kernel and the benchmark
+# needs two to compare against each other. Enable this once the runner can
+# accept both, otherwise the job runs and reports against one kernel only.
+#
+#  - job: unixbench-aws-ec2
+#    event: *kbuild-gcc-14-x86-aws-ec2-node-event
+#    runtime: *pull-labs-aws-ec2-runtime
+#    platforms:
+#      - aws-ec2-x86_64


### PR DESCRIPTION
Add the job definition and jinja2 template for running UnixBench on the pull-labs aws-ec2 runtime.

The scheduler entry is included but commented out. The runner cannot honour an A/B benchmark yet: a job definition carries a single kernel and the benchmark needs two to compare against each other. With no scheduler entry the job is never dispatched, so this lands the config shape for review without changing what runs today.