### PR TITLE
config: update de0-nano-soc rootfs

### DIFF
--- a/config/platforms-cip.yaml
+++ b/config/platforms-cip.yaml
@@ -54,7 +54,7 @@ platforms:
       bootz_ramdisk_addr: "0x04000000"
     params:
       boot_commands: nfs
-      nfsroot: http://storage.kernelci.org/images/rootfs/debian/trixie/20240313.0/{debarch}
+      nfsroot: https://storage.kernelci.org/images/rootfs/debian/trixie/20260901.0/{debarch}
 
   r8a7743-iwg20d-q7:
     <<: *arm-device


### PR DESCRIPTION
The trixie/20240313.0 armhf artifacts are no longer available, causing every de0-nano-soc LAVA job to be rejected with HTTP 404 errors.

Point the CIP platform override at the newly published trixie/20260901.0 image and use HTTPS for artifact downloads.

Link: https://github.com/kernelci/kernelci-core/actions/runs/33523155353