### PR TITLE
config: use current virt machine for qemu-arm

### DIFF
--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -561,7 +561,7 @@ platforms:
     context:
       arch: arm
       cpu: cortex-a15
-      machine: virt-2.11,gic-version=3
+      machine: virt,gic-version=3
       guestfs_interface: virtio
 
   qemu-arm64:


### PR DESCRIPTION
The qemu-arm platform pins the QEMU 2.11 versioned virt machine while LAVA pulls kernelci/qemu:latest for every job. The image now contains QEMU 11.0.2, which no longer provides virt-2.11. QEMU exits before the kernel starts, and LAVA reports the resulting EOF as "Connection closed". This affects qemu-arm runners in both lava-cip and lava-collabora.

Select the unversioned virt alias while retaining gic-version=3. This matches qemu-arm64 and keeps the machine selection compatible with the floating QEMU image instead of depending on an obsolete compatibility machine.

Link: https://lava.ciplatform.org/scheduler/job/1500711

Link: https://lava.collabora.dev/scheduler/job/22866879