### PR TITLE
send_kcidb: catch all request failures when fetching files

### DIFF
--- a/src/send_kcidb.py
+++ b/src/send_kcidb.py
@@ -221,7 +221,7 @@ class KCIDBBridge(Service):
             res = requests.get(log_url, timeout=60)
             if res.status_code != 200:
                 return None
-        except requests.exceptions.ConnectionError as exc:
+        except requests.exceptions.RequestException as exc:
             self.log.error(f"{str(exc)}")
             return None
 
@@ -273,7 +273,7 @@ class KCIDBBridge(Service):
             res = requests.get(url, timeout=60)
             if res.status_code != 200:
                 return None
-        except requests.exceptions.ConnectionError as exc:
+        except requests.exceptions.RequestException as exc:
             self.log.error(f"Retrieving file failed: {str(exc)}")
             return None
         with open(path, "wb") as f:


### PR DESCRIPTION
_get_log_excerpt() and _cached_fetch() only caught requests.exceptions.ConnectionError. ReadTimeout is not a subclass of it -- it derives from Timeout, which derives from RequestException -- so a slow response from files.kernelci.org escaped the handler, propagated up through _process_node() to Service.run(), and terminated the process.

In production this crashed pipeline-kcidb 8 times over 7 days, each time stalling KCIDB submission until Kubernetes restarted the pod:

  requests.exceptions.ReadTimeout: HTTPSConnectionPool(
    host='files.kernelci.org', port=443): Read timed out.
    (read timeout=60)
    File "./src/send_kcidb.py", line 221, in _get_log_excerpt

Both fetches are best-effort enrichment and already return None on failure, so widen them to RequestException to cover every transport error these calls can raise.

Assisted-by: Claude
