### PR TITLE
scheduler: skip jobs for runtimes that are not answering

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -43,6 +43,10 @@ DEDUP_CACHE_MAX = 50000
 # many queued events between backlog warnings.
 EVENT_QUEUE_POLL_TIMEOUT = 1  # seconds
 EVENT_QUEUE_WARN_DEPTH = 100
+# How long a runtime liveness result is trusted.  A lab that has gone away
+# makes every device and queue query block until it times out, once per job
+# and per platform; one cheap probe per interval replaces all of them.
+RUNTIME_LIVENESS_TTL = 60  # seconds
 
 
 class HealthHandler(BaseHTTPRequestHandler):
@@ -161,6 +165,9 @@ class Scheduler(Service):
         # is part of the key so legitimate retries are never suppressed.
         self._recent_jobs = collections.OrderedDict()
         self._dedup_lock = threading.Lock()
+        # Cached runtime liveness: name -> (checked_at, alive, detail)
+        self._runtime_liveness = {}
+        self._liveness_lock = threading.Lock()
         # Backup is disabled by default, enable via BACKUP_FILE_LIFETIME env variable (in seconds)
         self._backup_file_lifetime = int(os.getenv("BACKUP_FILE_LIFETIME", "0"))
         self._last_backup_cleanup = 0
@@ -525,6 +532,69 @@ class Scheduler(Service):
             return 1.0
         fraction = max(0.0, min(1.0, fraction))
         return 1.0 + fraction * (factor_max - 1.0)
+
+    def _is_runtime_alive(self, runtime):
+        """Cached liveness of a runtime, probed at most once per TTL
+
+        Transitions are logged so a lab going away, and coming back, is
+        visible without one message per skipped job.
+        """
+        name = runtime.config.name
+        with self._liveness_lock:
+            checked_at, alive, detail = self._runtime_liveness.get(
+                name, (0.0, True, "")
+            )
+            now = time.time()
+            if now - checked_at < RUNTIME_LIVENESS_TTL:
+                return alive, detail
+            was_alive = alive
+            try:
+                alive, detail = runtime.is_alive()
+            except Exception as exc:
+                # Fail open: a broken probe must not stop scheduling.
+                alive, detail = True, f"liveness probe error: {exc}"
+            self._runtime_liveness[name] = (now, alive, detail)
+
+        if alive != was_alive:
+            if alive:
+                self.log.info(f"Runtime {name} is reachable again: {detail}")
+                kind = "runtime_warning"
+            else:
+                self.log.error(f"Runtime {name} is unreachable: {detail}")
+                kind = "runtime_error"
+            self._telemetry.emit(
+                kind,
+                runtime=name,
+                error_type="liveness",
+                error_msg=detail[:200],
+            )
+        return alive, detail
+
+    def _should_skip_unreachable_runtime(self, runtime, job_config, platform):
+        """Check if job should be skipped because its runtime is down.
+
+        Returns True if job should be skipped, False otherwise.
+        """
+        if self._disable_device_health_check:
+            return False
+        if not hasattr(runtime, "is_alive"):
+            return False
+        alive, detail = self._is_runtime_alive(runtime)
+        if alive:
+            return False
+        self.log.info(
+            f"Skipping job {job_config.name} for {runtime.config.name}: "
+            f"runtime unreachable ({detail})"
+        )
+        self._telemetry.emit(
+            "job_skip",
+            runtime=runtime.config.name,
+            device_type=platform.name,
+            job_name=job_config.name,
+            error_type="runtime_unreachable",
+            error_msg=f"runtime unreachable: {detail}"[:200],
+        )
+        return True
 
     def _should_skip_due_to_queue_depth(
         self, runtime, job_config, platform, input_node=None
@@ -1222,6 +1292,8 @@ class Scheduler(Service):
                 f"runtime={runtime.config.name} platform={platform.name}",
                 thread_name,
             )
+            if self._should_skip_unreachable_runtime(runtime, job, platform):
+                continue
             input_node = self._api.node.get(event["id"])
             jobfilter = event.get("jobfilter")
             # Add to node data the jobfilter if it exists in event
@@ -1300,7 +1372,10 @@ class cmd_loop(Command):
         {
             "name": "--disable-device-health-check",
             "action": "store_true",
-            "help": "Do not skip jobs when no online devices are reported by LAVA",
+            "help": (
+                "Do not skip jobs when the runtime is unreachable or "
+                "reports no online devices"
+            ),
         },
         {
             "name": "--disable-watchdog",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,7 +8,7 @@ import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-from src.scheduler import Scheduler
+from src.scheduler import RUNTIME_LIVENESS_TTL, Scheduler
 
 
 class TestSchedulerWatchdog(unittest.TestCase):
@@ -538,6 +538,161 @@ class TestSchedulerEventDecoupling(unittest.TestCase):
 
         self.assertFalse(processor.is_alive())
         self.assertEqual(processed, ["bad", "good"])
+
+
+class TestSchedulerRuntimeLiveness(unittest.TestCase):
+    """Test the cached runtime liveness probe and the skip it drives."""
+
+    def _make_scheduler(self):
+        scheduler = MagicMock(spec=Scheduler)
+        scheduler.log = MagicMock()
+        scheduler._telemetry = MagicMock()
+        scheduler._runtime_liveness = {}
+        scheduler._liveness_lock = threading.Lock()
+        scheduler._disable_device_health_check = False
+        # Exercise the real probe through the skip helper.
+        scheduler._is_runtime_alive.side_effect = (
+            lambda runtime: Scheduler._is_runtime_alive(scheduler, runtime)
+        )
+        return scheduler
+
+    @staticmethod
+    def _make_runtime(name="lava-broonie"):
+        runtime = MagicMock()
+        runtime.config.name = name
+        runtime.is_alive.return_value = (True, "version 2026.07")
+        return runtime
+
+    def test_probe_result_is_cached_for_the_ttl(self):
+        """A live runtime is probed once, not once per job."""
+        scheduler = self._make_scheduler()
+        runtime = self._make_runtime()
+        for _ in range(5):
+            alive, _ = Scheduler._is_runtime_alive(scheduler, runtime)
+            self.assertTrue(alive)
+        runtime.is_alive.assert_called_once()
+
+    def test_probe_is_repeated_after_the_ttl(self):
+        """Once the cached result has expired the runtime is probed again."""
+        scheduler = self._make_scheduler()
+        runtime = self._make_runtime()
+        Scheduler._is_runtime_alive(scheduler, runtime)
+        # Age the cached entry past the TTL.
+        checked_at, alive, detail = scheduler._runtime_liveness["lava-broonie"]
+        scheduler._runtime_liveness["lava-broonie"] = (
+            checked_at - RUNTIME_LIVENESS_TTL - 1,
+            alive,
+            detail,
+        )
+        Scheduler._is_runtime_alive(scheduler, runtime)
+        self.assertEqual(runtime.is_alive.call_count, 2)
+
+    def test_unreachable_runtime_skips_the_job(self):
+        """An unreachable lab skips its jobs instead of blocking on them."""
+        scheduler = self._make_scheduler()
+        runtime = self._make_runtime()
+        runtime.is_alive.return_value = (False, "Network is unreachable")
+        job_config = types.SimpleNamespace(name="baseline-arm64")
+        platform = types.SimpleNamespace(name="qemu-arm64")
+
+        self.assertTrue(
+            Scheduler._should_skip_unreachable_runtime(
+                scheduler, runtime, job_config, platform
+            )
+        )
+        kinds = [c.args[0] for c in scheduler._telemetry.emit.call_args_list]
+        self.assertIn("job_skip", kinds)
+
+    def test_reachable_runtime_does_not_skip(self):
+        """A lab that answers must not have its jobs skipped."""
+        scheduler = self._make_scheduler()
+        runtime = self._make_runtime()
+        job_config = types.SimpleNamespace(name="baseline-arm64")
+        platform = types.SimpleNamespace(name="qemu-arm64")
+
+        self.assertFalse(
+            Scheduler._should_skip_unreachable_runtime(
+                scheduler, runtime, job_config, platform
+            )
+        )
+
+    def test_event_processing_skips_unreachable_runtime_and_continues(self):
+        """A down runtime must not prevent other jobs in an event running."""
+        scheduler = self._make_scheduler()
+        scheduler._sched = MagicMock()
+        scheduler._api = MagicMock()
+        scheduler._api_helper = MagicMock()
+        scheduler._should_skip_unreachable_runtime.side_effect = (
+            lambda *args: Scheduler._should_skip_unreachable_runtime(
+                scheduler, *args
+            )
+        )
+        scheduler._api_helper_lock = threading.Lock()
+        scheduler._should_skip_due_to_queue_depth.return_value = False
+        scheduler._job_recently_scheduled.return_value = False
+        down = self._make_runtime("lava-down")
+        down.is_alive.return_value = (False, "Network is unreachable")
+        alive = self._make_runtime("lava-alive")
+        job = types.SimpleNamespace(name="baseline-arm64", params={})
+        platform = types.SimpleNamespace(name="qemu-arm64")
+        scheduler._sched.get_schedule.return_value = [
+            (job, down, platform, []),
+            (job, alive, platform, []),
+        ]
+        input_node = {"id": "node-1"}
+        scheduler._api.node.get.return_value = input_node
+
+        Scheduler._process_event(scheduler, "node", input_node, "processor")
+
+        scheduler._api.node.get.assert_called_once_with("node-1")
+        scheduler._run_job.assert_called_once_with(
+            job, alive, platform, input_node, 0
+        )
+
+    def test_probe_error_fails_open(self):
+        """A probe that raises must not stop jobs being scheduled."""
+        scheduler = self._make_scheduler()
+        runtime = self._make_runtime()
+        runtime.is_alive.side_effect = RuntimeError("boom")
+        job_config = types.SimpleNamespace(name="baseline-arm64")
+        platform = types.SimpleNamespace(name="qemu-arm64")
+
+        self.assertFalse(
+            Scheduler._should_skip_unreachable_runtime(
+                scheduler, runtime, job_config, platform
+            )
+        )
+
+    def test_health_check_flag_disables_the_skip(self):
+        """--disable-device-health-check bypasses the liveness skip."""
+        scheduler = self._make_scheduler()
+        scheduler._disable_device_health_check = True
+        runtime = self._make_runtime()
+        runtime.is_alive.return_value = (False, "Network is unreachable")
+        job_config = types.SimpleNamespace(name="baseline-arm64")
+        platform = types.SimpleNamespace(name="qemu-arm64")
+
+        self.assertFalse(
+            Scheduler._should_skip_unreachable_runtime(
+                scheduler, runtime, job_config, platform
+            )
+        )
+        runtime.is_alive.assert_not_called()
+
+    def test_runtime_without_probe_is_not_skipped(self):
+        """A runtime from an older kernelci-core has no is_alive()."""
+        scheduler = self._make_scheduler()
+        runtime = types.SimpleNamespace(
+            config=types.SimpleNamespace(name="k8s-all")
+        )
+        job_config = types.SimpleNamespace(name="kbuild-gcc-14-arm64")
+        platform = types.SimpleNamespace(name="kubernetes")
+
+        self.assertFalse(
+            Scheduler._should_skip_unreachable_runtime(
+                scheduler, runtime, job_config, platform
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a lab goes away the scheduler still queries it for online devices and queue depth before every single job, on every platform, and each of those calls blocks until it times out.  That is what took job creation down to one per 90s while lava.sirena.org.uk was unreachable, which in turn starved every other lab sharing the scheduler process.

Probe the runtime once per RUNTIME_LIVENESS_TTL instead, and skip its jobs while it is down.  The probe is kernelci-core's Runtime.is_alive(); for LAVA that is a ~20 byte /system/version/ request that touches no table in the lab, so it costs a lab far less than the queries it saves.

The result is cached per runtime and transitions are logged once rather than once per skipped job, with a job_skip telemetry event per skipped job to match the existing no_online_devices path.

Both failure modes fail open: a runtime with no is_alive() (an older kernelci-core) and a probe that raises are both treated as reachable, and --disable-device-health-check bypasses the skip entirely.