### PR TITLE
config: add sasha-lab pull lab with Orin Nano, Grace and x86_64

### DIFF
--- a/config/jobs-pull-labs.yaml
+++ b/config/jobs-pull-labs.yaml
@@ -243,3 +243,27 @@ jobs:
       <<: *ltp-params-pull-labs
       tst_cmdfiles: "smoketest"
     kcidb_test_suite: ltp
+
+# These boot the machine's own installed rootfs, so they follow the
+# baseline-*-aws-ec2 entries rather than *baseline-job-pull-labs (which sets a
+# buildroot ramdisk).
+
+  baseline-arm64-sasha-lab:
+    template: baseline.jinja2
+    kind: job
+    priority: medium
+    kcidb_test_suite: boot
+    rules:
+      tree:
+        - mainline
+        - next
+
+  baseline-x86-sasha-lab:
+    template: baseline.jinja2
+    kind: job
+    priority: medium
+    kcidb_test_suite: boot
+    rules:
+      tree:
+        - mainline
+        - next

--- a/config/pipeline-pull-labs.yaml
+++ b/config/pipeline-pull-labs.yaml
@@ -27,3 +27,8 @@ runtimes:
     notify:
       callback:
         token: kernelci-pull-lab
+
+  sasha-lab:
+    lab_type: pull_labs
+    poll_interval: 60
+    timeout: 7200

--- a/config/platforms.yaml
+++ b/config/platforms.yaml
@@ -25,7 +25,6 @@ _anchors:
     boot_method: grub
     mach: x86
 
-
 platforms:
 
   aaeon-UPN-EHLX4RE-A10-0864: *x86_64-device
@@ -773,3 +772,23 @@ platforms:
     arch: arm64
     boot_method: grub
     mach: arm
+
+  # Jetson Orin Nano devkit: P3767 module on P3768 carrier. SD root.
+  jetson-orin-nano-devkit:
+    <<: *arm64-device
+    mach: nvidia
+    dtb: dtbs/nvidia/tegra234-p3768-0000+p3767-0005.dtb
+    compatible:
+      - 'nvidia,p3768-0000+p3767-0005'
+      - 'nvidia,tegra234'
+
+  # NVIDIA GB300 workstation (Grace, Neoverse-V2), board P3809.
+  nvidia-p3809-gb300:
+    <<: *arm64-device
+    mach: nvidia
+    boot_method: grub
+
+  # HPE ProLiant DL345 Gen11, AMD EPYC 9655P.
+  hpe-proliant-dl345-gen11:
+    <<: *x86_64-device
+    boot_method: grub

--- a/config/scheduler-pull-labs.yaml
+++ b/config/scheduler-pull-labs.yaml
@@ -263,3 +263,18 @@ scheduler:
     runtime: *pull-labs-aws-ec2-runtime
     platforms:
       - aws-ec2-arm64
+
+  - job: baseline-arm64-sasha-lab
+    event: *kbuild-gcc-15-arm64-node-event
+    runtime: &sasha-lab-runtime
+      type: pull_labs
+      name: sasha-lab
+    platforms:
+      - jetson-orin-nano-devkit
+      - nvidia-p3809-gb300
+
+  - job: baseline-x86-sasha-lab
+    event: *kbuild-gcc-15-x86-node-event
+    runtime: *sasha-lab-runtime
+    platforms:
+      - hpe-proliant-dl345-gen11


### PR DESCRIPTION
Add a new pull_labs runtime running baseline (boot) tests on three platforms:

  jetson-orin-nano-devkit    Jetson Orin Nano devkit, Tegra234
  nvidia-p3809-gb300         NVIDIA GB300 workstation, Grace Neoverse-V2
  hpe-proliant-dl345-gen11   HPE ProLiant DL345 Gen11, AMD EPYC 9655P